### PR TITLE
Feature/font family 

### DIFF
--- a/packages/mapsindoors-map-react/src/components/MapsIndoorsMap/MapsIndoorsMap.scss
+++ b/packages/mapsindoors-map-react/src/components/MapsIndoorsMap/MapsIndoorsMap.scss
@@ -1,9 +1,5 @@
 @import '~@mapsindoors/midt/variables';
 
-* {
-   font-family: var(--font-family-system);
-}
-
 .mapsindoors-map {
     position: relative;
     width: 100%;
@@ -12,6 +8,7 @@
 
     * {
         box-sizing: border-box;
+        font-family: var(--font-family-system);
     }
 }
 


### PR DESCRIPTION
# What 

- Add the `System` font family to the Map Template project.

# How

- Import the CSS variables that are generated in the `midt` project in the top level file which in our case is `MapsIndoorsMap.scss` and make the CSS custom properties available in the :root folder
- Use the `System` font family custom property to set the font globally 