### PR TITLE
Feature/media query hook

### DIFF
--- a/packages/mapsindoors-map-react/src/hooks/useMediaQuery.jsx
+++ b/packages/mapsindoors-map-react/src/hooks/useMediaQuery.jsx
@@ -1,5 +1,12 @@
 import { useState, useEffect } from "react";
 
+
+/**
+ * Media query hook for determining the device's viewport size. 
+ *
+ * @param {string} query
+ */
+
 const useMediaQuery = (query) => {
   const [matches, setMatches] = useState(false);
 


### PR DESCRIPTION
# What 
- Implement media query hook for rendering different components based on the viewport size

# How
- Create a `utils` folder where the `useMediaQuery` hook has been created. The hook listens to `resize` events and determines which viewport is being used. 
- The hook takes a `query` argument which needs to be passed when using the media query hook. 
- Example:  `const isDesktop = useMediaQuery('(min-width: 1200px)');`