### PR TITLE
Feature/upgrade midt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3909,7 +3909,8 @@
     "node_modules/@mapsindoors/midt": {
       "version": "17.0.0",
       "resolved": "https://registry.npmjs.org/@mapsindoors/midt/-/midt-17.0.0.tgz",
-      "integrity": "sha512-wlHYr7XC2QbaTibLvMYtK5/c3tx0ZhFsu8P5NL3nVSA3xcLVRHISzVFOAArO8PKnloXozMBlN0Z7fsqHJXORTw=="
+      "integrity": "sha512-wlHYr7XC2QbaTibLvMYtK5/c3tx0ZhFsu8P5NL3nVSA3xcLVRHISzVFOAArO8PKnloXozMBlN0Z7fsqHJXORTw==",
+      "dev": true
     },
     "node_modules/@mapsindoors/typescript-interfaces": {
       "version": "2.1.2",
@@ -25171,7 +25172,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@googlemaps/js-api-loader": "^1.15.1",
-        "@mapsindoors/midt": "^17.0.0",
+        "@mapsindoors/midt": "^18.1.1",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -25184,6 +25185,11 @@
         "sass": "^1.57.1",
         "web-vitals": "^2.1.4"
       }
+    },
+    "packages/mapsindoors-map-react/node_modules/@mapsindoors/midt": {
+      "version": "18.1.1",
+      "resolved": "https://registry.npmjs.org/@mapsindoors/midt/-/midt-18.1.1.tgz",
+      "integrity": "sha512-LqUD3q55kBOS8oRQGtG+yzUsZhsr77HBBYQ1OX63n8NygME7swsaXhqaS6y7w17FJOQbPiGZBmQUrPC9D4QtqQ=="
     },
     "packages/mi-components": {
       "version": "12.0.0",
@@ -28035,7 +28041,8 @@
     "@mapsindoors/midt": {
       "version": "17.0.0",
       "resolved": "https://registry.npmjs.org/@mapsindoors/midt/-/midt-17.0.0.tgz",
-      "integrity": "sha512-wlHYr7XC2QbaTibLvMYtK5/c3tx0ZhFsu8P5NL3nVSA3xcLVRHISzVFOAArO8PKnloXozMBlN0Z7fsqHJXORTw=="
+      "integrity": "sha512-wlHYr7XC2QbaTibLvMYtK5/c3tx0ZhFsu8P5NL3nVSA3xcLVRHISzVFOAArO8PKnloXozMBlN0Z7fsqHJXORTw==",
+      "dev": true
     },
     "@mapsindoors/typescript-interfaces": {
       "version": "2.1.2",
@@ -36952,7 +36959,7 @@
       "version": "file:packages/mapsindoors-map-react",
       "requires": {
         "@googlemaps/js-api-loader": "^1.15.1",
-        "@mapsindoors/midt": "^17.0.0",
+        "@mapsindoors/midt": "^18.1.1",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -36964,6 +36971,13 @@
         "react-transition-group": "^4.4.5",
         "sass": "^1.57.1",
         "web-vitals": "^2.1.4"
+      },
+      "dependencies": {
+        "@mapsindoors/midt": {
+          "version": "18.1.1",
+          "resolved": "https://registry.npmjs.org/@mapsindoors/midt/-/midt-18.1.1.tgz",
+          "integrity": "sha512-LqUD3q55kBOS8oRQGtG+yzUsZhsr77HBBYQ1OX63n8NygME7swsaXhqaS6y7w17FJOQbPiGZBmQUrPC9D4QtqQ=="
+        }
       }
     },
     "markdown-it": {

--- a/packages/mapsindoors-map-react/package.json
+++ b/packages/mapsindoors-map-react/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@googlemaps/js-api-loader": "^1.15.1",
-    "@mapsindoors/midt": "^17.0.0",
+    "@mapsindoors/midt": "^18.1.1",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
@@ -13,8 +13,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",
-    "sass": "^1.57.1",
     "react-transition-group": "^4.4.5",
+    "sass": "^1.57.1",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/packages/mapsindoors-map-react/src/components/MapsIndoorsMap/MapsIndoorsMap.scss
+++ b/packages/mapsindoors-map-react/src/components/MapsIndoorsMap/MapsIndoorsMap.scss
@@ -1,4 +1,4 @@
-@import '~@mapsindoors/midt/variables';
+@import '~@mapsindoors/midt/build/css/mapsindoors-map-variables';
 
 .mapsindoors-map {
     position: relative;


### PR DESCRIPTION
# What 
- Upgrade the `midt` to the latest version.

# How
- Install the latest version of the `midt` npm package and change the `MapsIndoorsMap.css` file to use the scoped CSS variables. 