### PR TITLE
Add NPM publish workflow

### DIFF
--- a/packages/components/.github/workflows/npm-publish.yml
+++ b/packages/components/.github/workflows/npm-publish.yml
@@ -1,0 +1,24 @@
+# This workflow will publish the release as an NPM package
+
+name: Publish NPM package
+
+on:
+    release:
+        types: [released]
+
+jobs:
+    publish-npm:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-node@v2
+              with:
+                  node-version: 14
+                  registry-url: https://registry.npmjs.org/
+                  scope: "@mapsindoors"
+            - run: echo "TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+            - run: npm ci
+            - run: npm version --no-git-tag-version --allow-same-version ${{ env.TAG }}
+            - run: npm publish --access public
+              env:
+                  NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}

--- a/packages/components/.github/workflows/publish-release.yml
+++ b/packages/components/.github/workflows/publish-release.yml
@@ -1,0 +1,21 @@
+name: Publish Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          draft: false
+          prerelease: false
+          generate_release_notes: false
+          token: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
This is copied from https://github.com/mapspeople/css. I already made sure there are secrets for each of the two new tokens; one for NPM, one for GitHub.

The workflow is as follows:

1. Do your work on a branch, and commit it
2. When you're ready to merge to `main`, bump the version number in `package.json` and commit it (bonus points if you use the version number as the commit text, e.g. write `v1.2.3`)
3. Tag the last commit with the version number in `package.json`, e.g. `git tag v1.2.3`
4. Run `git push && git push --tags`
5. Merge to `main`
6. `publish-release.yml` will run and create a new GitHub Release, using the version tag
7. `npm-publish.yml` will run after the version is created, and publish an updated package of that version to NPM
8. Champagne 🍾 

