### PR TITLE
fix/mitigate-eslint-warnings

### DIFF
--- a/packages/mapsindoors-map-react/src/components/Map/GoogleMapsMap/GoogleMapsMap.jsx
+++ b/packages/mapsindoors-map-react/src/components/Map/GoogleMapsMap/GoogleMapsMap.jsx
@@ -30,7 +30,8 @@ function GoogleMapsMap({ gmApiKey, onMapView}) {
             const mapViewInstance = new mapsindoors.mapView.GoogleMapsView(mapViewOptions);
             onMapView(mapViewInstance)
         });
-    }, []);
+    }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    // We ignore eslint warnings about missing dependencies because onMapView should never change runtime and changing Google Maps API key runtime will give other problems.
 
     return <div className="map-container" id="map"></div>
 }

--- a/packages/mapsindoors-map-react/src/components/Map/Map.jsx
+++ b/packages/mapsindoors-map-react/src/components/Map/Map.jsx
@@ -47,7 +47,8 @@ function Map({ gmApiKey, mapboxAccessToken, venues, venueName, onLocationClick, 
                 setVenue(venueToShow, mapsIndoorsInstance);
             };
         }
-    }, [venueName, venues]);
+    }, [venueName, venues]); // eslint-disable-line react-hooks/exhaustive-deps
+    // We ignore eslint warnings about missing dependencies because mapsIndoorsInstance should never change runtime anyway.
 
     /**
      * Set the venue to show on the map.

--- a/packages/mapsindoors-map-react/src/components/Map/MapboxMap/MapboxMap.jsx
+++ b/packages/mapsindoors-map-react/src/components/Map/MapboxMap/MapboxMap.jsx
@@ -24,7 +24,8 @@ function MapboxMap({ mapboxAccessToken, onMapView }) {
 
         const mapViewInstance = new mapsindoors.mapView.MapboxView(mapViewOptions);
         onMapView(mapViewInstance);
-    }, []);
+    }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    // We ignore eslint warnings about missing dependencies because onMapView should never change runtime and changing Mapbox Access Token runtime will give other problems.
 
     return <div className="map-container" id="map"></div>
 }


### PR DESCRIPTION
# What

Ignore eslint warnings about dependencies in useEffect hooks

# Why

The dependencies in question should never change anyway, and we should strive towards no warnings.