### PR TITLE
fix/make-wayfinding-work-on-desktop

### DIFF
--- a/packages/mapsindoors-map-react/src/components/Modal/Modal.jsx
+++ b/packages/mapsindoors-map-react/src/components/Modal/Modal.jsx
@@ -35,20 +35,20 @@ function Modal({ currentLocation, onClose }) {
     }, [currentLocation]);
 
     const pages = [
-        <div className="modal">
+        <div className={`modal ${activePage === VIEWS.LOCATION_DETAILS ? 'modal--open' : ''}`} key="A">
             <LocationDetails onStartWayfinding={() => setActivePage(VIEWS.WAYFINDING)} location={currentLocation} onClose={() => close()} />
         </div>,
-        <div className="modal">
+         <div className={`modal ${activePage === VIEWS.WAYFINDING ? 'modal--open' : ''}`} key="B">
             <Wayfinding onStartDirections={() => setActivePage(VIEWS.DIRECTIONS)} location={currentLocation} onBack={() => setActivePage(VIEWS.LOCATION_DETAILS)} />
         </div>,
-        <div className="modal">
+         <div className={`modal ${activePage === VIEWS.DIRECTIONS ? 'modal--open' : ''}`} key="C">
             <Directions onBack={() => setActivePage(VIEWS.WAYFINDING)} />
         </div>
     ]
 
     return (
         <div className="modals">
-            {pages[activePage]}
+            {pages}
         </div>
     )
 }

--- a/packages/mapsindoors-map-react/src/components/Modal/Modal.scss
+++ b/packages/mapsindoors-map-react/src/components/Modal/Modal.scss
@@ -1,4 +1,5 @@
 .modal {
+    display: none;
     position: absolute;
     z-index: var(--z-index-modal);
     width: 568px;
@@ -7,4 +8,8 @@
     border-radius: var(--spacing-x-small);
     border: 1px solid var(--color-gray-30);
     background: var(--color-white-white);
+
+    &--open {
+        display: initial;
+    }
 }


### PR DESCRIPTION
# What

- Make sure the "to" field for wayfinding is prefilled with the current location on desktop viewports.

# How

- Make all modal views be available in the app at all times, making the wayfinding component able to react to changes to the currentLocation prop.