### PR TITLE
Bug/categories list width

### DIFF
--- a/packages/mapsindoors-map-react/src/components/Search/Search.scss
+++ b/packages/mapsindoors-map-react/src/components/Search/Search.scss
@@ -12,7 +12,7 @@
         grid-auto-flow: column;
         gap: var(--spacing-x-small);
         overflow: auto hidden;
-        width: fit-content;
+        grid-auto-columns: min-content;
     }
 
     &__results {


### PR DESCRIPTION
# What 
- Fix the width of the categories list

# How
- Instead of having the width of the list to fit the content, set the grid columns to always take as much space as the content.