### PR TITLE
Bug/logo google map

### DIFF
--- a/packages/mapsindoors-map-react/src/components/MapsIndoorsMap/MapsIndoorsMap.scss
+++ b/packages/mapsindoors-map-react/src/components/MapsIndoorsMap/MapsIndoorsMap.scss
@@ -19,7 +19,7 @@
     position: relative;
 
     #mi_map_logo {
-        z-index: 100 !important;
+        z-index: var(--z-index-dropdown) !important;
     }
 }
 


### PR DESCRIPTION
# What 
- Fix the overlapping logo on the google maps

# How 
- Adjust the z-index of the logo on the map to 600, as the bottom sheet has 700.