### PR TITLE
chore: Fix vertical scrolling on the mobile and desktop devices.

### DIFF
--- a/packages/mapsindoors-map-react/src/components/BottomSheet/BottomSheet.jsx
+++ b/packages/mapsindoors-map-react/src/components/BottomSheet/BottomSheet.jsx
@@ -70,7 +70,6 @@ function BottomSheet({ currentLocation, setCurrentLocation, currentCategories, o
         </Sheet>,
         <Sheet
             minHeight="220"
-            preferredSizeSnapPoint={3}
             isOpen={activeBottomSheet === BOTTOM_SHEETS.WAYFINDING}
             preferredSizeSnapPoint={wayfindingSheetSize}
             key="C">

--- a/packages/mapsindoors-map-react/src/components/Search/Search.jsx
+++ b/packages/mapsindoors-map-react/src/components/Search/Search.jsx
@@ -106,6 +106,7 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize })
 
         /** Perform a search when a category is clicked and filter the results through the category. */
         searchFieldRef.current.setAttribute('mi-categories', category);
+        setSize(snapPoints.MAX);
 
         /**
          * Check if the clicked category is the same as the active one.

--- a/packages/mapsindoors-map-react/src/components/Search/Search.scss
+++ b/packages/mapsindoors-map-react/src/components/Search/Search.scss
@@ -6,6 +6,7 @@
     gap: var(--spacing-x-small);
     height: 100%;
     grid-auto-rows: min-content;
+    overflow: auto;
 
     &__scrollable {
         overflow: auto;


### PR DESCRIPTION
# What 
- Fix the vertical scroll not working on mobile and desktop devices

# How 
- Add the `overflow` property to the search sheet 
- Set the bottom sheet to full height when clicking on the categories