### PR TITLE
chore: Add missing property on bottom sheet for directions.

### DIFF
--- a/packages/mapsindoors-map-react/src/components/BottomSheet/BottomSheet.jsx
+++ b/packages/mapsindoors-map-react/src/components/BottomSheet/BottomSheet.jsx
@@ -31,7 +31,7 @@ function BottomSheet({ currentLocation, setCurrentLocation, currentCategories, o
     const [locationDetailsSheetSwiped, setLocationDetailsSheetSwiped] = useState();
 
     const [directions, setDirections] = useState();
-const [wayfindingSheetSize, setWayfindingSheetSize] = useState();
+    const [wayfindingSheetSize, setWayfindingSheetSize] = useState();
     const [searchSheetSize, setSearchSheetSize] = useState();
 
     /*
@@ -78,6 +78,7 @@ const [wayfindingSheetSize, setWayfindingSheetSize] = useState();
                 onSetSize={size => setWayfindingSheetSize(size)}
                 onStartDirections={() => setActiveBottomSheet(BOTTOM_SHEETS.DIRECTIONS)}
                 location={currentLocation}
+                onDirections={result => setDirections(result)}
                 onBack={() => setActiveBottomSheet(BOTTOM_SHEETS.LOCATION_DETAILS)}
                 isActive={activeBottomSheet === BOTTOM_SHEETS.WAYFINDING}
             />
@@ -91,7 +92,6 @@ const [wayfindingSheetSize, setWayfindingSheetSize] = useState();
                 directions={directions}
                 onBack={() => setActiveBottomSheet(BOTTOM_SHEETS.WAYFINDING)}
             />
-
         </Sheet>
     ]
 


### PR DESCRIPTION
# What 
- Add missing prop on the wayfinding component in the bottom sheet which throws an error when trying to get directions.

# How 
- Add the `onDirections` prop to the wayfinding component.