### PR TITLE
Feature/directions close button

### DIFF
--- a/packages/mapsindoors-map-react/src/components/Directions/Directions.scss
+++ b/packages/mapsindoors-map-react/src/components/Directions/Directions.scss
@@ -21,6 +21,7 @@
         display: grid;
         gap: var(--spacing-medium);
         position: relative;
+        width: fit-content;
     }
 
     &__container {


### PR DESCRIPTION
# What 
- Fix close button on directions being difficult to click.

# How 
- Add fit content property to the width of the content, which was overlapping the close button, making it difficult to trigger.