### PR TITLE
Feature/blue route wayfinding

### DIFF
--- a/packages/mapsindoors-map-react/src/components/Directions/Directions.jsx
+++ b/packages/mapsindoors-map-react/src/components/Directions/Directions.jsx
@@ -34,7 +34,7 @@ function Directions({ isOpen, onBack, directions }) {
      * Close the directions and set the visibility of the blue route to false.
      */
     function onDirectionsClosed() {
-        directionsRenderer.setOptions({ mapsIndoors: null, visible: false });
+        directionsRenderer.setRoute(null);
         onBack();
     }
 


### PR DESCRIPTION
# What 
- Set the visibility of the blue route to false when closing the directions page 

# How 
- Create a function that takes the sets the options of the `directionsRenderer`
- Set the visibility of the blue route to false
- Call the `onBack` function 