### PR TITLE
Bugfix/category display name

### DIFF
--- a/packages/mapsindoors-map-react/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
+++ b/packages/mapsindoors-map-react/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
@@ -66,7 +66,7 @@ function MapsIndoorsMap({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId
 
         // Loop through the locations which have categories and create a set of unique categories.
         locationCategories.forEach(item => {
-            Object.keys(item).forEach(value => uniqueCategories.add(value));
+            Object.values(item).forEach(value => uniqueCategories.add(value));
         });
 
         setCurrentCategories(uniqueCategories);


### PR DESCRIPTION
# What 
- Show display name instead of key for the category list 

# How 
- Change the Object `keys` to `values` when looping through the locations which have categories 