### PR TITLE
Bugfix/display rule icon

### DIFF
--- a/packages/mapsindoors-map-react/src/components/Search/Search.jsx
+++ b/packages/mapsindoors-map-react/src/components/Search/Search.jsx
@@ -67,7 +67,7 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize })
      */
     function addSearchResults(result) {
         const listItem = document.createElement('mi-list-item-location');
-        result.properties.imageURL = mapsIndoorsInstance.getDisplayRule(result).icon;
+        result.properties.imageURL = mapsIndoorsInstance?.getDisplayRule(result).icon;
         listItem.location = result;
         searchResultsRef.current.appendChild(listItem);
         listItem.addEventListener('locationClicked', resultClickedHandler);


### PR DESCRIPTION
# What 
- Make sure that the MapsIndoors instance exists when rendering the icon from the display rule in the `mi-list-item-location` component

# How
- Check if the MapsIndoors instance exists, and only then assign the icon from the display rule