### PR TITLE
Bugfix/venue selector visibility

### DIFF
--- a/packages/map-template/src/components/BottomSheet/BottomSheet.jsx
+++ b/packages/map-template/src/components/BottomSheet/BottomSheet.jsx
@@ -21,14 +21,12 @@ const BOTTOM_SHEETS = {
  * @param {Object} props.setCurrentLocation - The setter for the currently selected MapsIndoors Location.
  * @param {Object} props.currentCategories - The unique categories displayed based on the existing locations.
  * @param {function} props.onLocationsFiltered - The list of locations after filtering through the categories.
- * @param {function} props.onHideFloorSelector - Trigger the visibility of the floor selector to be hidden.
- * @param {function} props.onShowFloorSelector - Trigger the visibility of the floor selector to be shown.
  * @param {function} props.onDisableLocations - Restrict the user from interacting with the locations when in directions mode.
  * @param {function} props.onEnableLocations - Allow the user to interact with the locations when outside of directions mode.
- * @param {function} props.onHideVenueSelector - Trigger the visibility of the venue selector to be hidden.
- * @param {function} props.onShowVenueSelector - Trigger the visibility of the venue selector to be shown.
+ * @param {function} props.onDirectionsOpened - Check if the directions page state is open.
+ * @param {function} props.onDirectionsClosed - Check if the directions page state is closed.
  */
-function BottomSheet({ currentLocation, setCurrentLocation, currentCategories, onLocationsFiltered, onHideFloorSelector, onShowFloorSelector, onDisableLocations, onEnableLocations, onHideVenueSelector, onShowVenueSelector}) {
+function BottomSheet({ currentLocation, setCurrentLocation, currentCategories, onLocationsFiltered, onDisableLocations, onEnableLocations, onDirectionsOpened, onDirectionsClosed}) {
 
     const bottomSheetRef = useRef();
     const [activeBottomSheet, setActiveBottomSheet] = useState(null);
@@ -55,9 +53,8 @@ function BottomSheet({ currentLocation, setCurrentLocation, currentCategories, o
      */
     function setBottomSheet(bottomSheet) {
         setActiveBottomSheet(bottomSheet);
-        onShowFloorSelector();
         onEnableLocations();
-        onShowVenueSelector()
+        onDirectionsClosed();
     }
 
     /**
@@ -65,9 +62,8 @@ function BottomSheet({ currentLocation, setCurrentLocation, currentCategories, o
      */
     function setDirectionsBottomSheet() {
         setActiveBottomSheet(BOTTOM_SHEETS.DIRECTIONS);
-        onHideFloorSelector();
         onDisableLocations();
-        onHideVenueSelector();
+        onDirectionsOpened();
     }
 
     const bottomSheets = [

--- a/packages/map-template/src/components/BottomSheet/BottomSheet.jsx
+++ b/packages/map-template/src/components/BottomSheet/BottomSheet.jsx
@@ -21,12 +21,10 @@ const BOTTOM_SHEETS = {
  * @param {Object} props.setCurrentLocation - The setter for the currently selected MapsIndoors Location.
  * @param {Object} props.currentCategories - The unique categories displayed based on the existing locations.
  * @param {function} props.onLocationsFiltered - The list of locations after filtering through the categories.
- * @param {function} props.onDisableLocations - Restrict the user from interacting with the locations when in directions mode.
- * @param {function} props.onEnableLocations - Allow the user to interact with the locations when outside of directions mode.
  * @param {function} props.onDirectionsOpened - Check if the directions page state is open.
  * @param {function} props.onDirectionsClosed - Check if the directions page state is closed.
  */
-function BottomSheet({ currentLocation, setCurrentLocation, currentCategories, onLocationsFiltered, onDisableLocations, onEnableLocations, onDirectionsOpened, onDirectionsClosed}) {
+function BottomSheet({ currentLocation, setCurrentLocation, currentCategories, onLocationsFiltered, onDirectionsOpened, onDirectionsClosed}) {
 
     const bottomSheetRef = useRef();
     const [activeBottomSheet, setActiveBottomSheet] = useState(null);
@@ -53,7 +51,6 @@ function BottomSheet({ currentLocation, setCurrentLocation, currentCategories, o
      */
     function setBottomSheet(bottomSheet) {
         setActiveBottomSheet(bottomSheet);
-        onEnableLocations();
         onDirectionsClosed();
     }
 
@@ -62,7 +59,6 @@ function BottomSheet({ currentLocation, setCurrentLocation, currentCategories, o
      */
     function setDirectionsBottomSheet() {
         setActiveBottomSheet(BOTTOM_SHEETS.DIRECTIONS);
-        onDisableLocations();
         onDirectionsOpened();
     }
 

--- a/packages/map-template/src/components/BottomSheet/BottomSheet.jsx
+++ b/packages/map-template/src/components/BottomSheet/BottomSheet.jsx
@@ -25,8 +25,10 @@ const BOTTOM_SHEETS = {
  * @param {function} props.onShowFloorSelector - Trigger the visibility of the floor selector to be shown.
  * @param {function} props.onDisableLocations - Restrict the user from interacting with the locations when in directions mode.
  * @param {function} props.onEnableLocations - Allow the user to interact with the locations when outside of directions mode.
+ * @param {function} props.onHideVenueSelector - Trigger the visibility of the venue selector to be hidden.
+ * @param {function} props.onShowVenueSelector - Trigger the visibility of the venue selector to be shown.
  */
-function BottomSheet({ currentLocation, setCurrentLocation, currentCategories, onLocationsFiltered, onHideFloorSelector, onShowFloorSelector, onDisableLocations, onEnableLocations}) {
+function BottomSheet({ currentLocation, setCurrentLocation, currentCategories, onLocationsFiltered, onHideFloorSelector, onShowFloorSelector, onDisableLocations, onEnableLocations, onHideVenueSelector, onShowVenueSelector}) {
 
     const bottomSheetRef = useRef();
     const [activeBottomSheet, setActiveBottomSheet] = useState(null);
@@ -55,6 +57,7 @@ function BottomSheet({ currentLocation, setCurrentLocation, currentCategories, o
         setActiveBottomSheet(bottomSheet);
         onShowFloorSelector();
         onEnableLocations();
+        onShowVenueSelector()
     }
 
     /**
@@ -64,6 +67,7 @@ function BottomSheet({ currentLocation, setCurrentLocation, currentCategories, o
         setActiveBottomSheet(BOTTOM_SHEETS.DIRECTIONS);
         onHideFloorSelector();
         onDisableLocations();
+        onHideVenueSelector();
     }
 
     const bottomSheets = [

--- a/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
+++ b/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
@@ -41,6 +41,7 @@ function MapsIndoorsMap({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId
     const [mapsIndoorsInstance, setMapsIndoorsInstance] = useState();
     const [directionsService, setDirectionsService] = useState();
     const [hasFloorSelector, setHasFloorSelector] = useState(true);
+    const [hasVenueSelector, setHasVenueSelector] = useState(true);
 
     const isDesktop = useMediaQuery('(min-width: 992px)');
 
@@ -54,7 +55,7 @@ function MapsIndoorsMap({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId
     }
 
     /**
-     * Show the floor selector.
+     * Show the floor selector when not having the directions open.
      */
     function showFloorSelector() {
         if (hasFloorSelector === false) {
@@ -86,6 +87,24 @@ function MapsIndoorsMap({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId
     }
 
     /**
+    * Show the venue selector when not having the directions open.
+    */
+    function showVenueSelector() {
+        if (hasVenueSelector === false) {
+            setHasVenueSelector(true);
+        }
+    }
+
+    /**
+     * Hide the venue selector when the directions are open.
+     */
+    function hideVenueSelector() {
+        if (hasVenueSelector === true) {
+            setHasVenueSelector(false);
+        }
+    }
+
+    /**
     * Handle the clicked location on the map.
     * Set the current location if not in directions mode.
     *
@@ -102,7 +121,7 @@ function MapsIndoorsMap({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId
      *
      * @param {array} locationsResult
      */
-     function getCategories(locationsResult) {
+    function getCategories(locationsResult) {
         // Initialise the unique categories map
         let uniqueCategories = new Map();
 
@@ -177,7 +196,7 @@ function MapsIndoorsMap({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId
     return (<MapsIndoorsContext.Provider value={mapsIndoorsInstance}>
         <MapReadyContext.Provider value={isMapReady}>
             <DirectionsServiceContext.Provider value={directionsService}>
-                <div className={`mapsindoors-map ${!hasFloorSelector ? 'mapsindoors-map__floor-selector--hide' : 'mapsindoors-map__floor-selector--show'}`}>
+                <div className={`mapsindoors-map ${!hasFloorSelector ? 'mapsindoors-map__floor-selector--hide' : 'mapsindoors-map__floor-selector--show'} ${!hasVenueSelector ? 'mapsindoors-map__venue-selector--hide' : 'mapsindoors-map__venue-selector--show'}`}>
                     {!isMapReady && <SplashScreen logo={logo} primaryColor={primaryColor} />}
                     {venues.length > 1 && <VenueSelector onVenueSelected={selectedVenue => setCurrentVenueName(selectedVenue.name)} venues={venues} currentVenueName={currentVenueName} />}
                     {isMapReady && isDesktop
@@ -192,6 +211,8 @@ function MapsIndoorsMap({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId
                             onShowFloorSelector={() => showFloorSelector()}
                             onDisableLocations={() => disableLocations()}
                             onEnableLocations={() => enableLocations()}
+                            onHideVenueSelector={() => hideVenueSelector()}
+                            onShowVenueSelector={() => showVenueSelector()}
                         />
                         :
                         <BottomSheet
@@ -203,6 +224,8 @@ function MapsIndoorsMap({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId
                             onShowFloorSelector={() => showFloorSelector()}
                             onDisableLocations={() => disableLocations()}
                             onEnableLocations={() => enableLocations()}
+                            onHideVenueSelector={() => hideVenueSelector()}
+                            onShowVenueSelector={() => showVenueSelector()}
                         />
                     }
                     <MIMap

--- a/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
+++ b/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
@@ -40,8 +40,7 @@ function MapsIndoorsMap({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId
     const [filteredLocations, setFilteredLocations] = useState();
     const [mapsIndoorsInstance, setMapsIndoorsInstance] = useState();
     const [directionsService, setDirectionsService] = useState();
-    const [hasFloorSelector, setHasFloorSelector] = useState(true);
-    const [hasVenueSelector, setHasVenueSelector] = useState(true);
+    const [hasDirectionsOpen, setHasDirectionsOpen] = useState(false);
 
     const isDesktop = useMediaQuery('(min-width: 992px)');
 
@@ -55,20 +54,20 @@ function MapsIndoorsMap({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId
     }
 
     /**
-     * Show the floor selector when not having the directions open.
+     * Handle the state where directions are closed.
      */
-    function showFloorSelector() {
-        if (hasFloorSelector === false) {
-            setHasFloorSelector(true);
+    function directionsClosed() {
+        if (hasDirectionsOpen === true) {
+            setHasDirectionsOpen(false);
         }
     }
 
     /**
-     * Hide the floor selector when the directions are open.
+     * Handle the state where directions are open.
      */
-    function hideFloorSelector() {
-        if (hasFloorSelector === true) {
-            setHasFloorSelector(false);
+    function directionsOpened() {
+        if (hasDirectionsOpen === false) {
+            setHasDirectionsOpen(true);
         }
     }
 
@@ -84,24 +83,6 @@ function MapsIndoorsMap({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId
      */
     function enableLocations() {
         _locationsDisabled = false;
-    }
-
-    /**
-    * Show the venue selector when not having the directions open.
-    */
-    function showVenueSelector() {
-        if (hasVenueSelector === false) {
-            setHasVenueSelector(true);
-        }
-    }
-
-    /**
-     * Hide the venue selector when the directions are open.
-     */
-    function hideVenueSelector() {
-        if (hasVenueSelector === true) {
-            setHasVenueSelector(false);
-        }
     }
 
     /**
@@ -196,7 +177,7 @@ function MapsIndoorsMap({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId
     return (<MapsIndoorsContext.Provider value={mapsIndoorsInstance}>
         <MapReadyContext.Provider value={isMapReady}>
             <DirectionsServiceContext.Provider value={directionsService}>
-                <div className={`mapsindoors-map ${!hasFloorSelector ? 'mapsindoors-map__floor-selector--hide' : 'mapsindoors-map__floor-selector--show'} ${!hasVenueSelector ? 'mapsindoors-map__venue-selector--hide' : 'mapsindoors-map__venue-selector--show'}`}>
+                <div className={`mapsindoors-map ${hasDirectionsOpen ? 'mapsindoors-map--hide-elements' : 'mapsindoors-map--show-elements'}`}>
                     {!isMapReady && <SplashScreen logo={logo} primaryColor={primaryColor} />}
                     {venues.length > 1 && <VenueSelector onVenueSelected={selectedVenue => setCurrentVenueName(selectedVenue.name)} venues={venues} currentVenueName={currentVenueName} />}
                     {isMapReady && isDesktop
@@ -207,12 +188,10 @@ function MapsIndoorsMap({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId
                             currentCategories={currentCategories}
                             onClose={() => setCurrentLocation(null)}
                             onLocationsFiltered={(locations) => setFilteredLocations(locations)}
-                            onHideFloorSelector={() => hideFloorSelector()}
-                            onShowFloorSelector={() => showFloorSelector()}
                             onDisableLocations={() => disableLocations()}
                             onEnableLocations={() => enableLocations()}
-                            onHideVenueSelector={() => hideVenueSelector()}
-                            onShowVenueSelector={() => showVenueSelector()}
+                            onDirectionsOpened={() => directionsOpened()}
+                            onDirectionsClosed={() => directionsClosed()}
                         />
                         :
                         <BottomSheet
@@ -220,12 +199,10 @@ function MapsIndoorsMap({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId
                             setCurrentLocation={setCurrentLocation}
                             currentCategories={currentCategories}
                             onLocationsFiltered={(locations) => setFilteredLocations(locations)}
-                            onHideFloorSelector={() => hideFloorSelector()}
-                            onShowFloorSelector={() => showFloorSelector()}
                             onDisableLocations={() => disableLocations()}
                             onEnableLocations={() => enableLocations()}
-                            onHideVenueSelector={() => hideVenueSelector()}
-                            onShowVenueSelector={() => showVenueSelector()}
+                            onDirectionsOpened={() => directionsOpened()}
+                            onDirectionsClosed={() => directionsClosed()}
                         />
                     }
                     <MIMap

--- a/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
+++ b/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
@@ -59,6 +59,7 @@ function MapsIndoorsMap({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId
     function directionsClosed() {
         if (hasDirectionsOpen === true) {
             setHasDirectionsOpen(false);
+            _locationsDisabled = false;
         }
     }
 
@@ -68,21 +69,8 @@ function MapsIndoorsMap({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId
     function directionsOpened() {
         if (hasDirectionsOpen === false) {
             setHasDirectionsOpen(true);
+            _locationsDisabled = true;
         }
-    }
-
-    /**
-     * Disable the locations when in directions mode.
-     */
-    function disableLocations() {
-        _locationsDisabled = true;
-    }
-
-    /**
-     * Enable the locations when not in directions mode.
-     */
-    function enableLocations() {
-        _locationsDisabled = false;
     }
 
     /**
@@ -173,7 +161,6 @@ function MapsIndoorsMap({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId
         });
     }, [apiKey]);
 
-
     return (<MapsIndoorsContext.Provider value={mapsIndoorsInstance}>
         <MapReadyContext.Provider value={isMapReady}>
             <DirectionsServiceContext.Provider value={directionsService}>
@@ -188,8 +175,6 @@ function MapsIndoorsMap({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId
                             currentCategories={currentCategories}
                             onClose={() => setCurrentLocation(null)}
                             onLocationsFiltered={(locations) => setFilteredLocations(locations)}
-                            onDisableLocations={() => disableLocations()}
-                            onEnableLocations={() => enableLocations()}
                             onDirectionsOpened={() => directionsOpened()}
                             onDirectionsClosed={() => directionsClosed()}
                         />
@@ -199,8 +184,6 @@ function MapsIndoorsMap({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId
                             setCurrentLocation={setCurrentLocation}
                             currentCategories={currentCategories}
                             onLocationsFiltered={(locations) => setFilteredLocations(locations)}
-                            onDisableLocations={() => disableLocations()}
-                            onEnableLocations={() => enableLocations()}
                             onDirectionsOpened={() => directionsOpened()}
                             onDirectionsClosed={() => directionsClosed()}
                         />

--- a/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.scss
+++ b/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.scss
@@ -12,25 +12,21 @@
         font-family: var(--font-family-system);
     }
 
-    &__floor-selector--show {
+    &--show-elements {
         .mapsindoors.floor-selector {
             display: block;
         }
-    }
 
-    &__floor-selector--hide {
-        .mapsindoors.floor-selector {
-            display: none;
-        }
-    }
-
-    &__venue-selector--show {
         .venue-selector__button {
             display: block;
         }
     }
 
-    &__venue-selector--hide {
+    &--hide-elements {
+        .mapsindoors.floor-selector {
+            display: none;
+        }
+
         .venue-selector__button {
             display: none;
         }

--- a/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.scss
+++ b/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.scss
@@ -23,6 +23,18 @@
             display: none;
         }
     }
+
+    &__venue-selector--show {
+        .venue-selector__button {
+            display: block;
+        }
+    }
+
+    &__venue-selector--hide {
+        .venue-selector__button {
+            display: none;
+        }
+    }
 }
 
 .map-container {

--- a/packages/map-template/src/components/Sidebar/Sidebar.jsx
+++ b/packages/map-template/src/components/Sidebar/Sidebar.jsx
@@ -19,15 +19,13 @@ const VIEWS = {
  * @param {Object} props.currentCategories - The unique categories displayed based on the existing locations.
  * @param {function} props.onLocationsFiltered - The list of locations after filtering through the categories.
  * @param {function} props.onLocationsFiltered - The list of locations after filtering through the categories.
- * @param {function} props.onHideFloorSelector - Trigger the visibility of the floor selector to be hidden.
- * @param {function} props.onShowFloorSelector- Trigger the visibility of the floor selector to be shown.
  * @param {function} props.onDisableLocations - Restrict the user from interacting with the locations when in wayfinding mode.
  * @param {function} props.onEnableLocations - Allow the user to interact with the locations when outside of directions mode.
- * @param {function} props.onHideVenueSelector - Trigger the visibility of the venue selector to be hidden.
- * @param {function} props.onShowVenueSelector - Trigger the visibility of the venue selector to be shown.
+ * @param {function} props.onDirectionsOpened - Check if the directions page state is open.
+ * @param {function} props.onDirectionsClosed - Check if the directions page state is closed.
  *
 */
-function Sidebar({ currentLocation, setCurrentLocation, currentCategories, onLocationsFiltered, onHideFloorSelector, onShowFloorSelector, onDisableLocations, onEnableLocations, onHideVenueSelector, onShowVenueSelector }) {
+function Sidebar({ currentLocation, setCurrentLocation, currentCategories, onLocationsFiltered, onDisableLocations, onEnableLocations, onDirectionsOpened, onDirectionsClosed }) {
     const [activePage, setActivePage] = useState(null);
 
     const [directions, setDirections] = useState();
@@ -46,9 +44,8 @@ function Sidebar({ currentLocation, setCurrentLocation, currentCategories, onLoc
      */
     function setPage(page) {
         setActivePage(page);
-        onShowFloorSelector();
         onEnableLocations();
-        onShowVenueSelector();
+        onDirectionsClosed();
     }
 
     /**
@@ -56,9 +53,9 @@ function Sidebar({ currentLocation, setCurrentLocation, currentCategories, onLoc
      */
     function setDirectionsPage() {
         setActivePage(VIEWS.DIRECTIONS);
-        onHideFloorSelector();
         onDisableLocations();
-        onHideVenueSelector();
+        onDirectionsOpened();
+
     }
 
     const pages = [

--- a/packages/map-template/src/components/Sidebar/Sidebar.jsx
+++ b/packages/map-template/src/components/Sidebar/Sidebar.jsx
@@ -19,13 +19,11 @@ const VIEWS = {
  * @param {Object} props.currentCategories - The unique categories displayed based on the existing locations.
  * @param {function} props.onLocationsFiltered - The list of locations after filtering through the categories.
  * @param {function} props.onLocationsFiltered - The list of locations after filtering through the categories.
- * @param {function} props.onDisableLocations - Restrict the user from interacting with the locations when in wayfinding mode.
- * @param {function} props.onEnableLocations - Allow the user to interact with the locations when outside of directions mode.
  * @param {function} props.onDirectionsOpened - Check if the directions page state is open.
  * @param {function} props.onDirectionsClosed - Check if the directions page state is closed.
  *
 */
-function Sidebar({ currentLocation, setCurrentLocation, currentCategories, onLocationsFiltered, onDisableLocations, onEnableLocations, onDirectionsOpened, onDirectionsClosed }) {
+function Sidebar({ currentLocation, setCurrentLocation, currentCategories, onLocationsFiltered, onDirectionsOpened, onDirectionsClosed }) {
     const [activePage, setActivePage] = useState(null);
 
     const [directions, setDirections] = useState();
@@ -44,7 +42,6 @@ function Sidebar({ currentLocation, setCurrentLocation, currentCategories, onLoc
      */
     function setPage(page) {
         setActivePage(page);
-        onEnableLocations();
         onDirectionsClosed();
     }
 
@@ -53,7 +50,6 @@ function Sidebar({ currentLocation, setCurrentLocation, currentCategories, onLoc
      */
     function setDirectionsPage() {
         setActivePage(VIEWS.DIRECTIONS);
-        onDisableLocations();
         onDirectionsOpened();
 
     }

--- a/packages/map-template/src/components/Sidebar/Sidebar.jsx
+++ b/packages/map-template/src/components/Sidebar/Sidebar.jsx
@@ -23,9 +23,11 @@ const VIEWS = {
  * @param {function} props.onShowFloorSelector- Trigger the visibility of the floor selector to be shown.
  * @param {function} props.onDisableLocations - Restrict the user from interacting with the locations when in wayfinding mode.
  * @param {function} props.onEnableLocations - Allow the user to interact with the locations when outside of directions mode.
+ * @param {function} props.onHideVenueSelector - Trigger the visibility of the venue selector to be hidden.
+ * @param {function} props.onShowVenueSelector - Trigger the visibility of the venue selector to be shown.
  *
 */
-function Sidebar({ currentLocation, setCurrentLocation, currentCategories, onLocationsFiltered, onHideFloorSelector, onShowFloorSelector, onDisableLocations, onEnableLocations }) {
+function Sidebar({ currentLocation, setCurrentLocation, currentCategories, onLocationsFiltered, onHideFloorSelector, onShowFloorSelector, onDisableLocations, onEnableLocations, onHideVenueSelector, onShowVenueSelector }) {
     const [activePage, setActivePage] = useState(null);
 
     const [directions, setDirections] = useState();
@@ -46,6 +48,7 @@ function Sidebar({ currentLocation, setCurrentLocation, currentCategories, onLoc
         setActivePage(page);
         onShowFloorSelector();
         onEnableLocations();
+        onShowVenueSelector();
     }
 
     /**
@@ -55,6 +58,7 @@ function Sidebar({ currentLocation, setCurrentLocation, currentCategories, onLoc
         setActivePage(VIEWS.DIRECTIONS);
         onHideFloorSelector();
         onDisableLocations();
+        onHideVenueSelector();
     }
 
     const pages = [


### PR DESCRIPTION
# What 
- Hide the venue selector when having directions open 

# How 
- Refactor the `BottomSheet` and `Sidebar` components to keep track of the state of the directions page 
- Call the `onDirectionsOpened` and `onDirectionsClosed` when navigating to and from the directions page
- Refactor the implementation of toggling the visibility of the floor selector to be more generic, as we need to show/hide more than one element on the map
- Refactor the `MapsIndoorsMap` component to keep track of directions and hide or show the floor selector and the venue selector 