### PR TITLE
Bugfix/wayfinding details height

### DIFF
--- a/packages/map-template/src/components/Search/Search.scss
+++ b/packages/map-template/src/components/Search/Search.scss
@@ -32,8 +32,4 @@
             text-align: center;
         }
     }
-
-    @media (min-width: $desktop-breakpoint) {
-        max-height: 50vh;
-    }
 }

--- a/packages/map-template/src/components/Sidebar/Modal/Modal.scss
+++ b/packages/map-template/src/components/Sidebar/Modal/Modal.scss
@@ -8,7 +8,9 @@
     border: 1px solid var(--color-gray-30);
     background: var(--color-white-white);
     transform: translateY(calc(100% + var(--spacing-large)));
-    max-height: calc(100% - var(--spacing-xx-large));
+    max-height: 50vh; // UX spec
+    min-height: fit-content;
+    overflow: auto;
 
     &--open {
         transform: translateY(0);

--- a/packages/map-template/src/components/Wayfinding/Wayfinding.scss
+++ b/packages/map-template/src/components/Wayfinding/Wayfinding.scss
@@ -124,9 +124,4 @@
     &__error {
         text-align: center;
     }
-
-    @media (min-width: $desktop-breakpoint) {
-        max-height: 50vh;
-        min-height: 400px;
-    }
 }


### PR DESCRIPTION
# What 
- Fix wayfinding content going out of the sidebar component.

# How 
- Remove specific `max-height` values from the pages and added a `max-height` to the `modal` component, as it should never go over `50vh` according to the UX spec.