### PR TITLE
Bugfix/wayfinding error message

### DIFF
--- a/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
+++ b/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
@@ -46,6 +46,7 @@ function Wayfinding({ onStartDirections, onBack, location, onSetSize, isActive, 
     /** Check if search results have been found */
     const [hasSearchResults, setHasSearchResults] = useState(true);
 
+    /** Check if the searched route throws errors */
     const [hasError, setHasError] = useState(false);
 
     /** Holds search results given from a search field */
@@ -127,6 +128,8 @@ function Wayfinding({ onStartDirections, onBack, location, onSetSize, isActive, 
     function onSearchClicked(searchFieldIdentifier) {
         _activeSearchField = searchFieldIdentifier;
         resetSearchField();
+        setHasError(false);
+        setHasFoundRoute(true);
     }
 
     /**
@@ -138,6 +141,8 @@ function Wayfinding({ onStartDirections, onBack, location, onSetSize, isActive, 
         _activeSearchField = searchFieldIdentifier;
         resetSearchField();
         setSearchResults([]);
+        setHasError(false);
+        setHasFoundRoute(true);
     }
 
     /**


### PR DESCRIPTION
# What 
- Reset the state of the error messages when clearing or searching again.

# How
- Change the state of the error messages shown when `onSearchCleared` and `onSearchClicked` are called.