### PR TITLE
Use web component wrapper components for search & categories

### DIFF
--- a/packages/map-template/src/components/Search/Search.jsx
+++ b/packages/map-template/src/components/Search/Search.jsx
@@ -28,11 +28,10 @@ let _selectedCategory;
  */
 function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize }) {
 
-    /** Referencing the search DOM element */
+    /** Referencing the search field */
     const searchFieldRef = useRef();
 
     const [searchResults, setSearchResults] = useState([]);
-    const [searchFieldValue, setSearchFieldValue] = useState();
 
     /** Referencing the search results container DOM element */
     const searchResultsRef = useRef();
@@ -172,13 +171,13 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize })
     return (
         <div className="search">
             <SearchField
+                ref={searchFieldRef}
                 mapsindoors={true}
                 placeholder="Search by name, category, building..."
                 results={locations => onResults(locations)}
                 clicked={() => setSize(snapPoints.MAX)}
                 cleared={() => cleared()}
                 category={selectedCategory}
-                valueChanged={value => setSearchFieldValue(value)}
             />
             <div className="search__scrollable prevent-scroll" {...scrollableContentSwipePrevent}>
                 <div ref={categoriesListRef} className="search__categories">

--- a/packages/map-template/src/components/Search/Search.jsx
+++ b/packages/map-template/src/components/Search/Search.jsx
@@ -55,41 +55,31 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize })
 
     /**
      * Handles the click events on the categories list.
-     * Set a selected category and only allow one category to be selected at once.
      *
      * @param {string} category
      */
     function categoryClicked(category) {
-        /** Perform a search when a category is clicked and filter the results through the category. */
         setSelectedCategory(category);
         setSize(snapPoints.MAX);
 
-        /**
-         * Check if the clicked category is the same as the active one.
-         * Clear out the results list and set the selected category to null.
-         */
         if (selectedCategory === category) {
+            // If the clicked category is the same as currently selected, "deselect" it.
+
             setSearchResults([]);
             setSelectedCategory(null);
 
             // Pass an empty array to the filtered locations in order to reset the locations.
             onLocationsFiltered([]);
 
-            /** Check if the search field has a value and trigger the search again. */
+            // Check if the search field has a value and trigger the search again.
             if (searchFieldRef.current.getValue()) {
                 searchFieldRef.current.triggerSearch();
             }
-
-            /**
-             * Check if the search field has a value while a category is selected.
-             * Trigger the search again and set the current selected category.
-             */
-        } else if (searchFieldRef.current.value) {
-            /**
-             * Check if a category is selected and filter through the locations within that category.
-             * Clear out the search results after each category is selected.
-             */
+        } else if (searchFieldRef.current.getValue()) {
+            // If the search field has a value, trigger a research based on the new category.
+            searchFieldRef.current.triggerSearch();
         } else {
+            // If the search field is empty, show all locations with that category.
             getFilteredLocations(category);
         }
     }

--- a/packages/map-template/src/components/Search/Search.jsx
+++ b/packages/map-template/src/components/Search/Search.jsx
@@ -1,20 +1,13 @@
 import React from "react";
 import './Search.scss';
-import { useRef, useState, useContext } from 'react';
+import { useRef, useState } from 'react';
 import { snapPoints } from '../../constants/snapPoints';
 import { usePreventSwipe } from '../../hooks/usePreventSwipe';
-import { MapsIndoorsContext } from '../../MapsIndoorsContext';
 import ListItemLocation from '../WebComponentWrappers/ListItemLocation/ListItemLocation';
 import SearchField from '../WebComponentWrappers/Search/Search';
 
 /** Initialize the MapsIndoors instance. */
 const mapsindoors = window.mapsindoors;
-
-/**
- * Private variable used inside an event listener for a custom event from a web componenent.
- * Implemented due to the impossibility to use the React useState hook.
- */
-let _selectedCategory;
 
 /**
  * Show the search results.
@@ -47,8 +40,6 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize })
 
     const scrollableContentSwipePrevent = usePreventSwipe();
 
-    const mapsIndoorsInstance = useContext(MapsIndoorsContext);
-
     function locationClickHandler(location) {
         onLocationClick(location);
     }
@@ -69,15 +60,10 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize })
         mapsindoors.services.LocationsService.getLocations({
             categories: category,
         }).then(locations => {
-
-            /** Function that takes the locations and passes them to the parent component. */
+            // Pass the locations to the parent component.
             onLocationsFiltered(locations);
 
-            /** Loop through the filtered locations and add them to the search results list. */
-            for (const location of locations) {
-                // FIXME: Make work with search field wrapper
-                //addSearchResults(location);
-            }
+            setSearchResults(locations);
         });
     }
 
@@ -88,50 +74,38 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize })
      * @param {string} category
      */
     function categoryClicked(category) {
-        // FIXME: Make work with search field wrapper
-
         /** Perform a search when a category is clicked and filter the results through the category. */
-        // searchFieldRef.current.setAttribute('mi-categories', category);
-        // setSize(snapPoints.MAX);
+        setSelectedCategory(category);
+        setSize(snapPoints.MAX);
 
-        // /**
-        //  * Check if the clicked category is the same as the active one.
-        //  * Clear out the results list and set the selected category to null.
-        //  */
-        // if (selectedCategory === category) {
-        //     searchResultsRef.current.innerHTML = '';
-        //     setSelectedCategory(null);
-        //     _selectedCategory = null;
-        //     searchFieldRef.current.removeAttribute('mi-categories');
+        /**
+         * Check if the clicked category is the same as the active one.
+         * Clear out the results list and set the selected category to null.
+         */
+        if (selectedCategory === category) {
+            setSearchResults([]);
+            setSelectedCategory(null);
 
-        //     // Pass an empty array to the filtered locations in order to reset the locations.
-        //     onLocationsFiltered([]);
+            // Pass an empty array to the filtered locations in order to reset the locations.
+            onLocationsFiltered([]);
 
-        //     /** Check if the search field has a value and trigger the search again. */
-        //     if (searchFieldRef.current.value) {
-        //         searchFieldRef.current.removeAttribute('mi-categories');
-        //         searchFieldRef.current.triggerSearch();
-        //     }
+            /** Check if the search field has a value and trigger the search again. */
+            if (searchFieldRef.current.getValue()) {
+                searchFieldRef.current.triggerSearch();
+            }
 
-        //     /**
-        //      * Check if the search field has a value while a category is selected.
-        //      * Trigger the search again and set the current selected category.
-        //      */
-        // } else if (searchFieldRef.current.value) {
-        //     searchFieldRef.current.triggerSearch();
-        //     setSelectedCategory(category);
-        //     _selectedCategory = category;
-
-        //     /**
-        //      * Check if a category is selected and filter through the locations within that category.
-        //      * Clear out the search results after each category is selected.
-        //      */
-        // } else {
-        //     searchResultsRef.current.innerHTML = '';
-        //     setSelectedCategory(category);
-        //     _selectedCategory = category;
-        //     getFilteredLocations(category);
-        // }
+            /**
+             * Check if the search field has a value while a category is selected.
+             * Trigger the search again and set the current selected category.
+             */
+        } else if (searchFieldRef.current.value) {
+            /**
+             * Check if a category is selected and filter through the locations within that category.
+             * Clear out the search results after each category is selected.
+             */
+        } else {
+            getFilteredLocations(category);
+        }
     }
 
     /**
@@ -160,9 +134,9 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize })
 
     function cleared() {
         setSearchResults([]);
-        if (_selectedCategory) {
+        if (selectedCategory) {
             // TODO: Test
-            getFilteredLocations(_selectedCategory);
+            getFilteredLocations(selectedCategory);
         }
 
         onLocationsFiltered([]);

--- a/packages/map-template/src/components/Search/Search.jsx
+++ b/packages/map-template/src/components/Search/Search.jsx
@@ -29,17 +29,11 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize })
     /** Indicate if search results have been found */
     const [showNotFoundMessage, setShowNotFoundMessage] = useState(false);
 
-    /** Referencing the search results container DOM element */
-    const searchResultsRef = useRef();
-
     /** Referencing the categories results container DOM element */
     const categoriesListRef = useRef();
 
     /** Determines which category has been selected */
     const [selectedCategory, setSelectedCategory] = useState();
-
-    /** Instruct the search field to search for Locations near the map center. */
-    // const searchNear = useNear();
 
     const scrollableContentSwipePrevent = usePreventSwipe();
 
@@ -157,7 +151,6 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize })
                         </mi-chip>)
                     }
                 </div>
-                <div ref={searchResultsRef} className="search__results"></div>
                 <div className="search__results">
                     {showNotFoundMessage && <p>Nothing was found</p>}
                     {searchResults.map(location => <ListItemLocation key={location.id} location={location} locationClicked={e => locationClickHandler(e)} />)}

--- a/packages/map-template/src/components/Search/Search.jsx
+++ b/packages/map-template/src/components/Search/Search.jsx
@@ -1,10 +1,11 @@
 import React from "react";
 import './Search.scss';
-import { useRef, useEffect, useState, useContext } from 'react';
+import { useRef, useState, useContext } from 'react';
 import { snapPoints } from '../../constants/snapPoints';
 import { usePreventSwipe } from '../../hooks/usePreventSwipe';
 import { MapsIndoorsContext } from '../../MapsIndoorsContext';
-import useNear from '../../hooks/useNear';
+import ListItemLocation from '../WebComponentWrappers/ListItemLocation/ListItemLocation';
+import SearchField from '../WebComponentWrappers/Search/Search';
 
 /** Initialize the MapsIndoors instance. */
 const mapsindoors = window.mapsindoors;
@@ -30,6 +31,9 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize })
     /** Referencing the search DOM element */
     const searchFieldRef = useRef();
 
+    const [searchResults, setSearchResults] = useState([]);
+    const [searchFieldValue, setSearchFieldValue] = useState();
+
     /** Referencing the search results container DOM element */
     const searchResultsRef = useRef();
 
@@ -40,41 +44,14 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize })
     const [selectedCategory, setSelectedCategory] = useState();
 
     /** Instruct the search field to search for Locations near the map center. */
-    const searchNear = useNear();
+    // const searchNear = useNear();
 
     const scrollableContentSwipePrevent = usePreventSwipe();
 
     const mapsIndoorsInstance = useContext(MapsIndoorsContext);
 
-    /**
-     * Click event handler that takes the selected location as an argument.
-     *
-     * @param {string} category
-     */
-    function resultClickedHandler(location) {
-        onLocationClick(location.detail);
-    }
-
-    /** Remove click event listeners on all mi-list-item-location components. */
-    function clearEventListeners() {
-        const listItemLocations = document.querySelectorAll('mi-list-item-location');
-        listItemLocations.forEach(element => {
-            element.removeEventListener('click', resultClickedHandler);
-        });
-    }
-
-    /**
-     * Add search results by creating a 'mi-list-item-location' component for displaying the content of each result.
-     * Append all the results to the results container and listen to the events when a result item is clicked.
-     *
-     * @param {string} result
-     */
-    function addSearchResults(result) {
-        const listItem = document.createElement('mi-list-item-location');
-        result.properties.imageURL = mapsIndoorsInstance.getDisplayRule(result).icon;
-        listItem.location = result;
-        searchResultsRef.current.appendChild(listItem);
-        listItem.addEventListener('locationClicked', resultClickedHandler);
+    function locationClickHandler(location) {
+        onLocationClick(location);
     }
 
     /** Display message when no results have been found. */
@@ -99,7 +76,8 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize })
 
             /** Loop through the filtered locations and add them to the search results list. */
             for (const location of locations) {
-                addSearchResults(location);
+                // FIXME: Make work with search field wrapper
+                //addSearchResults(location);
             }
         });
     }
@@ -111,49 +89,50 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize })
      * @param {string} category
      */
     function categoryClicked(category) {
+        // FIXME: Make work with search field wrapper
 
         /** Perform a search when a category is clicked and filter the results through the category. */
-        searchFieldRef.current.setAttribute('mi-categories', category);
-        setSize(snapPoints.MAX);
+        // searchFieldRef.current.setAttribute('mi-categories', category);
+        // setSize(snapPoints.MAX);
 
-        /**
-         * Check if the clicked category is the same as the active one.
-         * Clear out the results list and set the selected category to null.
-         */
-        if (selectedCategory === category) {
-            searchResultsRef.current.innerHTML = '';
-            setSelectedCategory(null);
-            _selectedCategory = null;
-            searchFieldRef.current.removeAttribute('mi-categories');
+        // /**
+        //  * Check if the clicked category is the same as the active one.
+        //  * Clear out the results list and set the selected category to null.
+        //  */
+        // if (selectedCategory === category) {
+        //     searchResultsRef.current.innerHTML = '';
+        //     setSelectedCategory(null);
+        //     _selectedCategory = null;
+        //     searchFieldRef.current.removeAttribute('mi-categories');
 
-            // Pass an empty array to the filtered locations in order to reset the locations.
-            onLocationsFiltered([]);
+        //     // Pass an empty array to the filtered locations in order to reset the locations.
+        //     onLocationsFiltered([]);
 
-            /** Check if the search field has a value and trigger the search again. */
-            if (searchFieldRef.current.value) {
-                searchFieldRef.current.removeAttribute('mi-categories');
-                searchFieldRef.current.triggerSearch();
-            }
+        //     /** Check if the search field has a value and trigger the search again. */
+        //     if (searchFieldRef.current.value) {
+        //         searchFieldRef.current.removeAttribute('mi-categories');
+        //         searchFieldRef.current.triggerSearch();
+        //     }
 
-            /**
-             * Check if the search field has a value while a category is selected.
-             * Trigger the search again and set the current selected category.
-             */
-        } else if (searchFieldRef.current.value) {
-            searchFieldRef.current.triggerSearch();
-            setSelectedCategory(category);
-            _selectedCategory = category;
+        //     /**
+        //      * Check if the search field has a value while a category is selected.
+        //      * Trigger the search again and set the current selected category.
+        //      */
+        // } else if (searchFieldRef.current.value) {
+        //     searchFieldRef.current.triggerSearch();
+        //     setSelectedCategory(category);
+        //     _selectedCategory = category;
 
-            /**
-             * Check if a category is selected and filter through the locations within that category.
-             * Clear out the search results after each category is selected.
-             */
-        } else {
-            searchResultsRef.current.innerHTML = '';
-            setSelectedCategory(category);
-            _selectedCategory = category;
-            getFilteredLocations(category);
-        }
+        //     /**
+        //      * Check if a category is selected and filter through the locations within that category.
+        //      * Clear out the search results after each category is selected.
+        //      */
+        // } else {
+        //     searchResultsRef.current.innerHTML = '';
+        //     setSelectedCategory(category);
+        //     _selectedCategory = category;
+        //     getFilteredLocations(category);
+        // }
     }
 
     /**
@@ -166,52 +145,41 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize })
         }
     }
 
-    useEffect(() => {
-        /**
-         * Search location and add results list implementation.
-         * Listen to the 'results' event provided by the 'mi-search' component.
-         */
-        searchFieldRef.current.addEventListener('results', e => {
-            clearEventListeners();
-            searchResultsRef.current.innerHTML = '';
+    /**
+     * Handle search results from the search field.
+     *
+     * @param {array} locations
+     */
+    function onResults(locations) {
+        setSearchResults(locations);
+        onLocationsFiltered(locations);
 
-            onLocationsFiltered(e.detail);
+        if (locations.length === 0) {
+            showNotFoundMessage();
+        }
+    }
 
-            if (e.detail.length === 0) {
-                showNotFoundMessage();
-            } else {
-                for (const result of e.detail) {
-                    addSearchResults(result);
-                }
-            }
-        });
+    function cleared() {
+        setSearchResults([]);
+        if (_selectedCategory) {
+            // TODO: Test
+            getFilteredLocations(_selectedCategory);
+        }
 
-        clearEventListeners();
-
-        /**
-         * Listen to the 'cleared' event provided by the 'mi-search' component.
-         * Clear the results list.
-         */
-        searchFieldRef.current.addEventListener('cleared', () => {
-            clearEventListeners();
-            searchResultsRef.current.innerHTML = '';
-            if (_selectedCategory) {
-                getFilteredLocations(_selectedCategory);
-            }
-
-            // Pass an empty array to the filtered locations in order to reset the locations.
-            onLocationsFiltered([]);
-        });
-
-        /** Listen to click events on the input and set the input focus to true. */
-        searchFieldRef.current.addEventListener('click', () => {
-            setSize(snapPoints.MAX);
-        });
-    }, []);
+        onLocationsFiltered([]);
+    }
 
     return (
         <div className="search">
-            <mi-search mi-near={searchNear} ref={searchFieldRef} placeholder="Search by name, category, building..." mapsindoors="true"></mi-search>
+            <SearchField
+                mapsindoors={true}
+                placeholder="Search by name, category, building..."
+                results={locations => onResults(locations)}
+                clicked={() => setSize(snapPoints.MAX)}
+                cleared={() => cleared()}
+                category={selectedCategory}
+                valueChanged={value => setSearchFieldValue(value)}
+            />
             <div className="search__scrollable prevent-scroll" {...scrollableContentSwipePrevent}>
                 <div ref={categoriesListRef} className="search__categories">
                     {categories?.map(([category, categoryInfo]) =>
@@ -224,6 +192,9 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize })
                     }
                 </div>
                 <div ref={searchResultsRef} className="search__results"></div>
+                <div className="search__results">
+                    {searchResults.map(location => <ListItemLocation key={location.id} location={location} locationClicked={e => locationClickHandler(e)} />)}
+                </div>
             </div>
         </div>
     )

--- a/packages/map-template/src/components/Search/Search.jsx
+++ b/packages/map-template/src/components/Search/Search.jsx
@@ -37,10 +37,6 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize })
 
     const scrollableContentSwipePrevent = usePreventSwipe();
 
-    function locationClickHandler(location) {
-        onLocationClick(location);
-    }
-
     /**
      * Get the locations and filter through them based on categories selected.
      *
@@ -119,6 +115,9 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize })
         setShowNotFoundMessage(locations.length === 0);
     }
 
+    /**
+     * Clear results list when search field is cleared.
+     */
     function cleared() {
         setSearchResults([]);
         setShowNotFoundMessage(false);
@@ -153,7 +152,7 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize })
                 </div>
                 <div className="search__results">
                     {showNotFoundMessage && <p>Nothing was found</p>}
-                    {searchResults.map(location => <ListItemLocation key={location.id} location={location} locationClicked={e => locationClickHandler(e)} />)}
+                    {searchResults.map(location => <ListItemLocation key={location.id} location={location} locationClicked={e => onLocationClick(e)} />)}
                 </div>
             </div>
         </div>

--- a/packages/map-template/src/components/Search/Search.jsx
+++ b/packages/map-template/src/components/Search/Search.jsx
@@ -26,6 +26,9 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize })
 
     const [searchResults, setSearchResults] = useState([]);
 
+    /** Indicate if search results have been found */
+    const [showNotFoundMessage, setShowNotFoundMessage] = useState(false);
+
     /** Referencing the search results container DOM element */
     const searchResultsRef = useRef();
 
@@ -42,13 +45,6 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize })
 
     function locationClickHandler(location) {
         onLocationClick(location);
-    }
-
-    /** Display message when no results have been found. */
-    function showNotFoundMessage() {
-        const notFoundMessage = document.createElement('p');
-        notFoundMessage.innerHTML = "Nothing was found";
-        searchResultsRef.current.appendChild(notFoundMessage);
     }
 
     /**
@@ -126,16 +122,13 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize })
     function onResults(locations) {
         setSearchResults(locations);
         onLocationsFiltered(locations);
-
-        if (locations.length === 0) {
-            showNotFoundMessage();
-        }
+        setShowNotFoundMessage(locations.length === 0);
     }
 
     function cleared() {
         setSearchResults([]);
+        setShowNotFoundMessage(false);
         if (selectedCategory) {
-            // TODO: Test
             getFilteredLocations(selectedCategory);
         }
 
@@ -166,6 +159,7 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize })
                 </div>
                 <div ref={searchResultsRef} className="search__results"></div>
                 <div className="search__results">
+                    {showNotFoundMessage && <p>Nothing was found</p>}
                     {searchResults.map(location => <ListItemLocation key={location.id} location={location} locationClicked={e => locationClickHandler(e)} />)}
                 </div>
             </div>

--- a/packages/map-template/src/components/Search/Search.jsx
+++ b/packages/map-template/src/components/Search/Search.jsx
@@ -1,8 +1,9 @@
 import React from "react";
 import './Search.scss';
-import { useRef, useState } from 'react';
+import { useContext, useRef, useState } from 'react';
 import { snapPoints } from '../../constants/snapPoints';
 import { usePreventSwipe } from '../../hooks/usePreventSwipe';
+import { MapsIndoorsContext } from '../../MapsIndoorsContext';
 import ListItemLocation from '../WebComponentWrappers/ListItemLocation/ListItemLocation';
 import SearchField from '../WebComponentWrappers/Search/Search';
 
@@ -37,6 +38,8 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize })
 
     const scrollableContentSwipePrevent = usePreventSwipe();
 
+    const mapsIndoorsInstance = useContext(MapsIndoorsContext);
+
     /**
      * Get the locations and filter through them based on categories selected.
      *
@@ -45,12 +48,7 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize })
     function getFilteredLocations(category) {
         mapsindoors.services.LocationsService.getLocations({
             categories: category,
-        }).then(locations => {
-            // Pass the locations to the parent component.
-            onLocationsFiltered(locations);
-
-            setSearchResults(locations);
-        });
+        }).then(onResults);
     }
 
     /**
@@ -100,6 +98,10 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize })
      * @param {array} locations
      */
     function onResults(locations) {
+        for (const location of locations) {
+            location.properties.imageURL = mapsIndoorsInstance.getDisplayRule(location).icon; // FIXME: Don't set icon as imageURL on referenced locations data.
+        }
+
         setSearchResults(locations);
         onLocationsFiltered(locations);
         setShowNotFoundMessage(locations.length === 0);

--- a/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
+++ b/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
@@ -38,6 +38,9 @@ function Wayfinding({ onStartDirections, onBack, location, onSetSize, isActive, 
     /** Referencing the accessibility details DOM element */
     const detailsRef = useRef();
 
+    const toFieldRef = useRef();
+    const fromFieldRef = useRef();
+
     const directionsService = useContext(DirectionsServiceContext);
 
     /** Indicate if a route has been found */
@@ -51,10 +54,6 @@ function Wayfinding({ onStartDirections, onBack, location, onSetSize, isActive, 
 
     /** Holds search results given from a search field */
     const [searchResults, setSearchResults] = useState([]);
-
-    const [toFieldDisplayText, setToFieldDisplayText] = useState();
-
-    const [fromFieldDisplayText, setFromFieldDisplayText] = useState();
 
     const [destinationLocation, setDestinationLocation] = useState();
     const [originLocation, setOriginLocation] = useState();
@@ -72,10 +71,10 @@ function Wayfinding({ onStartDirections, onBack, location, onSetSize, isActive, 
      */
     function locationClickHandler(location) {
         if (_activeSearchField === searchFieldItentifiers.TO) {
-            setToFieldDisplayText(location.properties.name);
+            toFieldRef.current.setDisplayText(location.properties.name);
             setDestinationLocation(location);
         } else if (_activeSearchField === searchFieldItentifiers.FROM) {
-            setFromFieldDisplayText(location.properties.name);
+            fromFieldRef.current.setDisplayText(location.properties.name);
             setOriginLocation(location);
         }
 
@@ -150,10 +149,10 @@ function Wayfinding({ onStartDirections, onBack, location, onSetSize, isActive, 
     */
     function resetSearchField() {
         if (_activeSearchField === searchFieldItentifiers.TO) {
-            setToFieldDisplayText('');
+            toFieldRef.current.setDisplayText('');
             setDestinationLocation();
         } else if (_activeSearchField === searchFieldItentifiers.FROM) {
-            setFromFieldDisplayText('');
+            fromFieldRef.current.setDisplayText('');
             setOriginLocation();
         }
     }
@@ -163,7 +162,7 @@ function Wayfinding({ onStartDirections, onBack, location, onSetSize, isActive, 
         setSize(snapPoints.MAX);
         // If there is a location selected, pre-fill the value of the `to` field with the location name.
         if (location) {
-            setToFieldDisplayText(location.properties.name);
+            toFieldRef.current.setDisplayText(location.properties.name);
             setDestinationLocation(location);
         }
 
@@ -216,10 +215,10 @@ function Wayfinding({ onStartDirections, onBack, location, onSetSize, isActive, 
                     <label className="wayfinding__label">
                         TO
                         <SearchField
+                            ref={toFieldRef}
                             mapsindoors={true}
                             placeholder="Search by name, category, building..."
                             results={locations => searchResultsReceived(locations, searchFieldItentifiers.TO)}
-                            displayText={toFieldDisplayText}
                             clicked={() => onSearchClicked(searchFieldItentifiers.TO)}
                             cleared={() => onSearchCleared(searchFieldItentifiers.TO)}
                         />
@@ -227,11 +226,11 @@ function Wayfinding({ onStartDirections, onBack, location, onSetSize, isActive, 
                     <label className="wayfinding__label">
                         FROM
                         <SearchField
+                            ref={fromFieldRef}
                             hasInputFocus={isActive}
                             mapsindoors={true}
                             placeholder="Search by name, category, buildings..."
                             results={locations => searchResultsReceived(locations, searchFieldItentifiers.FROM)}
-                            displayText={fromFieldDisplayText}
                             clicked={() => onSearchClicked(searchFieldItentifiers.FROM)}
                             cleared={() => onSearchCleared(searchFieldItentifiers.FROM)}
                         />

--- a/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
+++ b/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
@@ -18,12 +18,6 @@ const searchFieldItentifiers = {
 };
 
 /**
- * Private variable used to assign the active search field.
- * Implemented due to the impossibility to use the React useState hook.
- */
-let _activeSearchField;
-
-/**
  * Show the wayfinding view.
  *
  * @param {Object} props
@@ -42,6 +36,8 @@ function Wayfinding({ onStartDirections, onBack, location, onSetSize, isActive, 
     const fromFieldRef = useRef();
 
     const directionsService = useContext(DirectionsServiceContext);
+
+    const [activeSearchField, setActiveSearchField] = useState();
 
     /** Indicate if a route has been found */
     const [hasFoundRoute, setHasFoundRoute] = useState(true);
@@ -70,10 +66,10 @@ function Wayfinding({ onStartDirections, onBack, location, onSetSize, isActive, 
      * and clears out the results list.
      */
     function locationClickHandler(location) {
-        if (_activeSearchField === searchFieldItentifiers.TO) {
+        if (activeSearchField === searchFieldItentifiers.TO) {
             toFieldRef.current.setDisplayText(location.properties.name);
             setDestinationLocation(location);
-        } else if (_activeSearchField === searchFieldItentifiers.FROM) {
+        } else if (activeSearchField === searchFieldItentifiers.FROM) {
             fromFieldRef.current.setDisplayText(location.properties.name);
             setOriginLocation(location);
         }
@@ -88,7 +84,7 @@ function Wayfinding({ onStartDirections, onBack, location, onSetSize, isActive, 
      * @param {string} searchFieldIdentifier
      */
     function searchResultsReceived(results, searchFieldIdentifier) {
-        _activeSearchField = searchFieldIdentifier;
+        setActiveSearchField(searchFieldIdentifier);
 
         if (results.length === 0) {
             setHasSearchResults(false);
@@ -125,7 +121,7 @@ function Wayfinding({ onStartDirections, onBack, location, onSetSize, isActive, 
      * @param {string} searchFieldIdentifier
      */
     function onSearchClicked(searchFieldIdentifier) {
-        _activeSearchField = searchFieldIdentifier;
+        setActiveSearchField(searchFieldIdentifier);
         resetSearchField();
         setHasError(false);
         setHasFoundRoute(true);
@@ -137,7 +133,7 @@ function Wayfinding({ onStartDirections, onBack, location, onSetSize, isActive, 
      * @param {string} searchFieldIdentifier
      */
     function onSearchCleared(searchFieldIdentifier) {
-        _activeSearchField = searchFieldIdentifier;
+        setActiveSearchField(searchFieldIdentifier);
         resetSearchField();
         setSearchResults([]);
         setHasError(false);
@@ -148,10 +144,10 @@ function Wayfinding({ onStartDirections, onBack, location, onSetSize, isActive, 
     * Reset the active field's display text and location.
     */
     function resetSearchField() {
-        if (_activeSearchField === searchFieldItentifiers.TO) {
+        if (activeSearchField === searchFieldItentifiers.TO) {
             toFieldRef.current.setDisplayText('');
             setDestinationLocation();
-        } else if (_activeSearchField === searchFieldItentifiers.FROM) {
+        } else if (activeSearchField === searchFieldItentifiers.FROM) {
             fromFieldRef.current.setDisplayText('');
             setOriginLocation();
         }
@@ -166,7 +162,7 @@ function Wayfinding({ onStartDirections, onBack, location, onSetSize, isActive, 
             setDestinationLocation(location);
         }
 
-        _activeSearchField = searchFieldItentifiers.FROM;
+        setActiveSearchField(searchFieldItentifiers.FROM);
     }, [location]);
 
     useEffect(() => {

--- a/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
+++ b/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
@@ -169,6 +169,12 @@ function Wayfinding({ onStartDirections, onBack, location, onSetSize, isActive, 
         _activeSearchField = searchFieldItentifiers.FROM;
     }, [location]);
 
+    useEffect(() => {
+        if (isActive && !fromFieldRef.current?.getValue()) {
+            fromFieldRef.current.focusInput();
+        }
+    }, [isActive]);
+
     /**
      * When both origin location and destination location are selected, call the MapsIndoors SDK
      * to get information about the route.
@@ -227,7 +233,6 @@ function Wayfinding({ onStartDirections, onBack, location, onSetSize, isActive, 
                         FROM
                         <SearchField
                             ref={fromFieldRef}
-                            hasInputFocus={isActive}
                             mapsindoors={true}
                             placeholder="Search by name, category, buildings..."
                             results={locations => searchResultsReceived(locations, searchFieldItentifiers.FROM)}

--- a/packages/map-template/src/components/WebComponentWrappers/Search/Search.jsx
+++ b/packages/map-template/src/components/WebComponentWrappers/Search/Search.jsx
@@ -14,9 +14,10 @@ import useNear from '../../../hooks/useNear';
  * @param {string} props.displayText - Display text in the search field when the user selects a result.
  * @param {boolean} props.hasInputFocus - If set to true, it will set focus to the input field.
  * @param {string} props.category - If set, search will be performed for Locations having this category.
+ * @param {function} props.valueChanged - Function that is called when the search field value changes. Passes the value as payload.
  *
  */
-function SearchField({ placeholder, mapsindoors, results, clicked, cleared, clear, displayText, hasInputFocus, category }) {
+function SearchField({ placeholder, mapsindoors, results, clicked, cleared, clear, displayText, hasInputFocus, category, valueChanged }) {
     const elementRef = useRef();
 
     /** Instruct the search field to search for Locations near the map center. */
@@ -47,7 +48,21 @@ function SearchField({ placeholder, mapsindoors, results, clicked, cleared, clea
         current.addEventListener('click', clicked);
         current.addEventListener('cleared', cleared);
 
+        // Observer for the value attribute.
+        // TODO: Figure out if we should implement a proper way to do this: expose an event from the component.
+        const observer = new MutationObserver(mutationList => {
+            mutationList.forEach(mutation => {
+                if (mutation.attributeName === 'value') {
+                    if (typeof valueChanged === 'function') {
+                        valueChanged(current.getAttribute('value'));
+                    }
+                }
+            });
+        });
+        observer.observe(current, { attributes: true });
+
         return () => {
+            observer.disconnect();
             current.removeEventListener('results', searchResultsHandler);
             current.removeEventListener('click', clicked);
             current.removeEventListener('cleared', cleared);

--- a/packages/map-template/src/components/WebComponentWrappers/Search/Search.jsx
+++ b/packages/map-template/src/components/WebComponentWrappers/Search/Search.jsx
@@ -11,11 +11,10 @@ import useNear from '../../../hooks/useNear';
  * @param {function} props.clicked - Function that is called when search field is clicked.
  * @param {function} props.cleared - Function that is called when search field is cleared.
  * @param {boolean} props.clear - Programatically clear the search field.
- * @param {string} props.displayText - Display text in the search field when the user selects a result.
  * @param {boolean} props.hasInputFocus - If set to true, it will set focus to the input field.
  * @param {string} props.category - If set, search will be performed for Locations having this category.
  */
-const SearchField = forwardRef(({ placeholder, mapsindoors, results, clicked, cleared, displayText, hasInputFocus, category }, ref) => {
+const SearchField = forwardRef(({ placeholder, mapsindoors, results, clicked, cleared, hasInputFocus, category }, ref) => {
     const elementRef = useRef();
 
     /** Instruct the search field to search for Locations near the map center. */
@@ -30,6 +29,9 @@ const SearchField = forwardRef(({ placeholder, mapsindoors, results, clicked, cl
         },
         getValue() {
             return elementRef.current.value;
+        },
+        setDisplayText(displayText) {
+            elementRef.current.setDisplayText(displayText);
         }
     }));
 
@@ -40,10 +42,6 @@ const SearchField = forwardRef(({ placeholder, mapsindoors, results, clicked, cl
 
         if (mapsindoors === true) {
             current.mapsindoors = 'true';
-        }
-
-        if (displayText) {
-            current.setDisplayText(displayText);
         }
 
         if (hasInputFocus && !current.value) {
@@ -60,7 +58,7 @@ const SearchField = forwardRef(({ placeholder, mapsindoors, results, clicked, cl
             current.removeEventListener('cleared', cleared);
         }
 
-    }, [placeholder, mapsindoors, results, clicked, cleared, displayText, hasInputFocus]);
+    }, [placeholder, mapsindoors, results, clicked, cleared, hasInputFocus]);
 
     return <mi-search ref={elementRef} placeholder={placeholder} mi-near={searchNear} mi-categories={category}  />
 });

--- a/packages/map-template/src/components/WebComponentWrappers/Search/Search.jsx
+++ b/packages/map-template/src/components/WebComponentWrappers/Search/Search.jsx
@@ -10,11 +10,9 @@ import useNear from '../../../hooks/useNear';
  * @param {function} props.results - Function that is called when search results are received.
  * @param {function} props.clicked - Function that is called when search field is clicked.
  * @param {function} props.cleared - Function that is called when search field is cleared.
- * @param {boolean} props.clear - Programatically clear the search field.
- * @param {boolean} props.hasInputFocus - If set to true, it will set focus to the input field.
  * @param {string} props.category - If set, search will be performed for Locations having this category.
  */
-const SearchField = forwardRef(({ placeholder, mapsindoors, results, clicked, cleared, hasInputFocus, category }, ref) => {
+const SearchField = forwardRef(({ placeholder, mapsindoors, results, clicked, cleared, category }, ref) => {
     const elementRef = useRef();
 
     /** Instruct the search field to search for Locations near the map center. */
@@ -32,6 +30,9 @@ const SearchField = forwardRef(({ placeholder, mapsindoors, results, clicked, cl
         },
         setDisplayText(displayText) {
             elementRef.current.setDisplayText(displayText);
+        },
+        focusInput() {
+            elementRef.current.focusInput();
         }
     }));
 
@@ -44,10 +45,6 @@ const SearchField = forwardRef(({ placeholder, mapsindoors, results, clicked, cl
             current.mapsindoors = 'true';
         }
 
-        if (hasInputFocus && !current.value) {
-            current.focusInput();
-        }
-
         current.addEventListener('results', searchResultsHandler);
         current.addEventListener('click', clicked);
         current.addEventListener('cleared', cleared);
@@ -58,7 +55,7 @@ const SearchField = forwardRef(({ placeholder, mapsindoors, results, clicked, cl
             current.removeEventListener('cleared', cleared);
         }
 
-    }, [placeholder, mapsindoors, results, clicked, cleared, hasInputFocus]);
+    }, [placeholder, mapsindoors, results, clicked, cleared]);
 
     return <mi-search ref={elementRef} placeholder={placeholder} mi-near={searchNear} mi-categories={category}  />
 });

--- a/packages/map-template/src/components/WebComponentWrappers/Search/Search.jsx
+++ b/packages/map-template/src/components/WebComponentWrappers/Search/Search.jsx
@@ -45,14 +45,21 @@ const SearchField = forwardRef(({ placeholder, mapsindoors, results, clicked, cl
             current.mapsindoors = 'true';
         }
 
+        function onCleared() {
+            if (!current.getValue) {
+                current.focusInput();
+            }
+            cleared();
+        }
+
         current.addEventListener('results', searchResultsHandler);
         current.addEventListener('click', clicked);
-        current.addEventListener('cleared', cleared);
+        current.addEventListener('cleared', onCleared);
 
         return () => {
             current.removeEventListener('results', searchResultsHandler);
             current.removeEventListener('click', clicked);
-            current.removeEventListener('cleared', cleared);
+            current.removeEventListener('cleared', onCleared);
         }
 
     }, [placeholder, mapsindoors, results, clicked, cleared]);

--- a/packages/map-template/src/components/WebComponentWrappers/Search/Search.jsx
+++ b/packages/map-template/src/components/WebComponentWrappers/Search/Search.jsx
@@ -14,10 +14,8 @@ import useNear from '../../../hooks/useNear';
  * @param {string} props.displayText - Display text in the search field when the user selects a result.
  * @param {boolean} props.hasInputFocus - If set to true, it will set focus to the input field.
  * @param {string} props.category - If set, search will be performed for Locations having this category.
- * @param {function} props.valueChanged - Function that is called when the search field value changes. Passes the value as payload.
- *
  */
-const SearchField = forwardRef(({ placeholder, mapsindoors, results, clicked, cleared, displayText, hasInputFocus, category, valueChanged }, ref) => {
+const SearchField = forwardRef(({ placeholder, mapsindoors, results, clicked, cleared, displayText, hasInputFocus, category }, ref) => {
     const elementRef = useRef();
 
     /** Instruct the search field to search for Locations near the map center. */

--- a/packages/map-template/src/components/WebComponentWrappers/Search/Search.jsx
+++ b/packages/map-template/src/components/WebComponentWrappers/Search/Search.jsx
@@ -13,9 +13,10 @@ import useNear from '../../../hooks/useNear';
  * @param {boolean} props.clear - Programatically clear the search field.
  * @param {string} props.displayText - Display text in the search field when the user selects a result.
  * @param {boolean} props.hasInputFocus - If set to true, it will set focus to the input field.
+ * @param {string} props.category - If set, search will be performed for Locations having this category.
  *
  */
-function SearchField({ placeholder, mapsindoors, results, clicked, cleared, clear, displayText, hasInputFocus }) {
+function SearchField({ placeholder, mapsindoors, results, clicked, cleared, clear, displayText, hasInputFocus, category }) {
     const elementRef = useRef();
 
     /** Instruct the search field to search for Locations near the map center. */
@@ -54,7 +55,7 @@ function SearchField({ placeholder, mapsindoors, results, clicked, cleared, clea
 
     }, [placeholder, mapsindoors, results, clicked, cleared, displayText, hasInputFocus]);
 
-    return <mi-search ref={elementRef} placeholder={placeholder} mi-near={searchNear}  />
+    return <mi-search ref={elementRef} placeholder={placeholder} mi-near={searchNear} mi-categories={category}  />
 }
 
 export default SearchField;


### PR DESCRIPTION
# What

- Use web component wrappers for searching and category handling.

# How

- Refactored `WebComponentWrappers/Search` to utilize `useImperativeHandle` in order to programmatically trigger methods on the `<mi-search>` component without relying on props.
- Introduced category prop on `WebComponentWrappers/Search` so we can filter by a category.
- Refactored the `Search` component to use the `WebComponentWrappers/Search` instead of `<mi-search>` directly.
  - This had the benefits of
    - removing some usages of `document.createElement` and native DOM event listeners
    - getting rid of "double" variable for holding the selected category.
- Refactored the `Wayfinding` component to make use of the imperative ways to trigger method on the `WebComponentWrappers/Search` component.