### PR TITLE
Bugfix/search results scroll

### DIFF
--- a/packages/map-template/src/components/BottomSheet/Sheet/Sheet.jsx
+++ b/packages/map-template/src/components/BottomSheet/Sheet/Sheet.jsx
@@ -65,6 +65,7 @@ function Sheet({ children, isOpen, minHeight, preferredSizeSnapPoint, onSwipedTo
             switch (targetSize) {
                 case snapPoints.MAX:
                     setStyle({ height: `${container.current.clientHeight}px`});
+                    console.log(container.current);
                     break;
                 case snapPoints.FIT:
                     setStyle({ height: `${contentHeight}px`});
@@ -165,7 +166,7 @@ function Sheet({ children, isOpen, minHeight, preferredSizeSnapPoint, onSwipedTo
     };
 
     return <div {...swipeHandler} ref={refPassthrough} style={style} className={`sheet ${isOpen ? 'sheet--active' : ''} ${isDragging ? 'sheet--dragging': ''}`}>
-        <div ref={contentRef} className="sheet__content">
+        <div ref={contentRef} className="sheet__content" style={style}>
             {children}
         </div>
     </div>

--- a/packages/map-template/src/components/BottomSheet/Sheet/Sheet.jsx
+++ b/packages/map-template/src/components/BottomSheet/Sheet/Sheet.jsx
@@ -65,7 +65,6 @@ function Sheet({ children, isOpen, minHeight, preferredSizeSnapPoint, onSwipedTo
             switch (targetSize) {
                 case snapPoints.MAX:
                     setStyle({ height: `${container.current.clientHeight}px`});
-                    console.log(container.current);
                     break;
                 case snapPoints.FIT:
                     setStyle({ height: `${contentHeight}px`});


### PR DESCRIPTION
# What 
- Fix the search results not being scrollable when navigating back to the Search page from the Location Details page

# How 
- Set the style of the `sheet__content` element to follow the same style of the `sheet` element