### PR TITLE
Fix/avoid replacing imageurl on location.details

### DIFF
--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -275,6 +275,11 @@ export namespace Components {
     }
     interface MiListItemLocation {
         /**
+          * @description Optional URL to icon to render for the Location. If not set, imageURL on the Location data will be used.
+          * @type {string}
+         */
+        "icon": string;
+        /**
           * @description Add a badge to the location icon of the type given as value.
           * @type {string}
          */
@@ -1515,6 +1520,11 @@ declare namespace LocalJSX {
         "orientation"?: string;
     }
     interface MiListItemLocation {
+        /**
+          * @description Optional URL to icon to render for the Location. If not set, imageURL on the Location data will be used.
+          * @type {string}
+         */
+        "icon"?: string;
         /**
           * @description Add a badge to the location icon of the type given as value.
           * @type {string}

--- a/packages/components/src/components/list-item-location/list-item-location.tsx
+++ b/packages/components/src/components/list-item-location/list-item-location.tsx
@@ -1,5 +1,5 @@
 import midtIcon from '@mapsindoors/midt/tokens/icon.json';
-import { Component, Event, EventEmitter, h, Host, JSX, Prop, Watch } from '@stencil/core';
+import { Component, Event, EventEmitter, h, Host, JSX, Prop, State, Watch } from '@stencil/core';
 import { appendMapsIndoorsImageQueryParameters } from '../../utils/utils';
 import { UnitSystem } from './../../enums/unit-system.enum';
 
@@ -22,6 +22,12 @@ export class ListItemLocation {
      * @type {UnitSystem}
      */
     @Prop() unit: UnitSystem;
+
+    /**
+     * @description Optional URL to icon to render for the Location. If not set, imageURL on the Location data will be used.
+     * @type {string}
+     */
+    @Prop() icon: string;
 
     /**
      * @description Add a badge to the location icon of the type given as value.
@@ -57,6 +63,8 @@ export class ListItemLocation {
      */
     @Event() listItemDidRender: EventEmitter;
 
+    @State() iconURLToRender; string;
+
     private imageElement: HTMLImageElement;
     private infoElement: HTMLMiLocationInfoElement;
     private iconAttributes: {};
@@ -72,6 +80,7 @@ export class ListItemLocation {
     }
 
     componentWillLoad(): void {
+        this.iconURLToRender = this.icon ? this.icon : this.location.properties.imageURL;
         this.updateBadge();
     }
 
@@ -93,7 +102,7 @@ export class ListItemLocation {
      * Apply badge to location icon
      */
     updateBadge(): void {
-        if (this.iconBadge && this.iconBadgeValue && this.location.properties.imageURL) {
+        if (this.iconBadge && this.iconBadgeValue && this.iconURLToRender) {
             this.applyBadgeToIcon();
         }
     }
@@ -103,7 +112,7 @@ export class ListItemLocation {
      * @param {HTMLImageElement} image
      */
     objectFitImage(image: HTMLImageElement): void {
-        image.setAttribute('style', `background: no-repeat center center url("${this.location.properties.imageURL}"); background-size: cover;`);
+        image.setAttribute('style', `background: no-repeat center center url("${this.iconURLToRender}"); background-size: cover;`);
         image.src = `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='${image.width}' height='${image.height}'%3E%3C/svg%3E`;
     }
 
@@ -114,7 +123,9 @@ export class ListItemLocation {
     applyBadgeToIcon(): void {
         let originalIconScale;
 
-        const iconURL = appendMapsIndoorsImageQueryParameters(this.location.properties.imageURL, this.iconDisplaySize);
+        this.iconURLToRender = this.icon ? this.icon : this.location.properties.imageURL;
+
+        const iconURL = appendMapsIndoorsImageQueryParameters(this.iconURLToRender, this.iconDisplaySize);
         this.getImageFromUrl(iconURL).then(image => {
             originalIconScale = image.width / 24;
             switch (this.iconBadge.toLowerCase()) {
@@ -133,9 +144,7 @@ export class ListItemLocation {
             }
         }).then(badgedImage => {
             if (badgedImage) {
-                const newLocation = {...this.location};
-                newLocation.properties.imageURL = badgedImage.src;
-                this.location = newLocation;
+                this.iconURLToRender = badgedImage.src;
 
                 // Badged image must be moved so the original image aligns with other.
                 const translateIcon = (badgedImage.width - 24) / -2;
@@ -178,7 +187,7 @@ export class ListItemLocation {
     render(): JSX.Element {
         return this.location && (
             <Host role="listitem" onClick={() => this.locationClickedHandler(this.location)}>
-                {this.location.properties.imageURL ? this.renderIcon() : null}
+                {this.iconURLToRender ? this.renderIcon() : null}
 
                 <div class="details">
                     <p class="details-title">{this.location.properties.name}</p>
@@ -195,8 +204,7 @@ export class ListItemLocation {
      * @returns {JSX.Element}
      */
     renderIcon(): JSX.Element {
-        const iconURL = appendMapsIndoorsImageQueryParameters(this.location.properties.imageURL, this.iconDisplaySize);
-
+        const iconURL = appendMapsIndoorsImageQueryParameters(this.iconURLToRender, this.iconDisplaySize);
         return (
             <div class="img-container">
                 <img {...this.iconAttributes} ref={(el) => this.imageElement = el as HTMLImageElement} src={iconURL} />

--- a/packages/components/src/components/list-item-location/readme.md
+++ b/packages/components/src/components/list-item-location/readme.md
@@ -77,6 +77,7 @@ A `listItemDidRender` event is emitted from the `<mi-list-item-location>` elemen
 
 | Property         | Attribute          | Description | Type                                       | Default     |
 | ---------------- | ------------------ | ----------- | ------------------------------------------ | ----------- |
+| `icon`           | `icon`             |             | `string`                                   | `undefined` |
 | `iconBadge`      | `icon-badge`       |             | `string`                                   | `undefined` |
 | `iconBadgeValue` | `icon-badge-value` |             | `string`                                   | `undefined` |
 | `location`       | `location`         |             | `any`                                      | `undefined` |

--- a/packages/components/src/components/list-item-location/test.html
+++ b/packages/components/src/components/list-item-location/test.html
@@ -36,6 +36,12 @@ You can change the MapsIndoors apiKey in start of the script below
             </label>
         </p>
         <p>
+            <label>
+                Icon
+                <input name="icon" placeholder="URL to icon" />
+            </label>
+        </p>
+        <p>
 
             Availability Badge
             <label>
@@ -60,7 +66,7 @@ You can change the MapsIndoors apiKey in start of the script below
 
         mapsindoors.MapsIndoors.setMapsIndoorsApiKey(apiKey);
 
-        async function render(locationId, unit, badge) {
+        async function render(locationId, unit, icon, badge) {
             const location = await mapsindoors.services.LocationsService.getLocation(locationId);
 
             const listItemLocationComponent = document.createElement('mi-list-item-location');
@@ -68,6 +74,10 @@ You can change the MapsIndoors apiKey in start of the script below
 
             if (unit) {
                 listItemLocationComponent.setAttribute('unit', unit);
+            }
+
+            if (icon) {
+                listItemLocationComponent.setAttribute('icon', icon);
             }
 
             if (badge !== 'none') {
@@ -85,8 +95,9 @@ You can change the MapsIndoors apiKey in start of the script below
             e.preventDefault();
             const locationId = document.querySelector('input[name="locationId"]').value;
             const unit = document.querySelector('input[name="unit"]').value;
+            const icon = document.querySelector('input[name="icon"]').value;
             const badge = document.querySelector('input[name="badge"]:checked') ? document.querySelector('input[name="badge"]:checked').value : 'none';
-            render(locationId, unit, badge);
+            render(locationId, unit, icon, badge);
         }
     </script>
 

--- a/packages/map-template/src/components/Search/Search.jsx
+++ b/packages/map-template/src/components/Search/Search.jsx
@@ -98,10 +98,6 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize })
      * @param {array} locations
      */
     function onResults(locations) {
-        for (const location of locations) {
-            location.properties.imageURL = mapsIndoorsInstance.getDisplayRule(location).icon; // FIXME: Don't set icon as imageURL on referenced locations data.
-        }
-
         setSearchResults(locations);
         onLocationsFiltered(locations);
         setShowNotFoundMessage(locations.length === 0);

--- a/packages/map-template/src/components/Search/Search.jsx
+++ b/packages/map-template/src/components/Search/Search.jsx
@@ -1,9 +1,8 @@
 import React from "react";
 import './Search.scss';
-import { useContext, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { snapPoints } from '../../constants/snapPoints';
 import { usePreventSwipe } from '../../hooks/usePreventSwipe';
-import { MapsIndoorsContext } from '../../MapsIndoorsContext';
 import ListItemLocation from '../WebComponentWrappers/ListItemLocation/ListItemLocation';
 import SearchField from '../WebComponentWrappers/Search/Search';
 
@@ -37,8 +36,6 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize })
     const [selectedCategory, setSelectedCategory] = useState();
 
     const scrollableContentSwipePrevent = usePreventSwipe();
-
-    const mapsIndoorsInstance = useContext(MapsIndoorsContext);
 
     /**
      * Get the locations and filter through them based on categories selected.

--- a/packages/map-template/src/components/WebComponentWrappers/ListItemLocation/ListItemLocation.jsx
+++ b/packages/map-template/src/components/WebComponentWrappers/ListItemLocation/ListItemLocation.jsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef } from 'react';
+import { useContext, useEffect, useRef, useState } from 'react';
+import { MapsIndoorsContext } from '../../../MapsIndoorsContext';
 
 /**
  * React wrapper around the custom element <mi-list-item-location>.
@@ -10,12 +11,15 @@ import { useEffect, useRef } from 'react';
 function ListItemLocation({ location, locationClicked }) {
     const elementRef = useRef();
 
+    const mapsIndoorsInstance = useContext(MapsIndoorsContext);
+
     useEffect(() => {
         const clickHandler = customEvent => locationClicked(customEvent.detail);
 
         const { current } = elementRef;
 
         current.location = location;
+        current.icon = mapsIndoorsInstance.getDisplayRule(location).icon;
         current.addEventListener('locationClicked', clickHandler);
 
         return () => current.removeEventListener('locationClicked', clickHandler);


### PR DESCRIPTION
# What

- Fix bug where imageURL on a Locations was wrongly populated with icon from Display Rule when having a Location displayed as part of a search result.

# How

- Implement new (optional) icon prop on the Stencil component `<mi-list-item-location>`
  - The component will fallback to current behavior if not set, thus ensuring backwards comparability.
  - This required some refactoring of the Live Data badge handling
- Set the icon prop within the wrapper component `ListItemLocation` instead of overwriting the Location data in the `Search` component.