### PR TITLE
fix/wrong app size

### DIFF
--- a/packages/map-template/src/App.css
+++ b/packages/map-template/src/App.css
@@ -1,4 +1,4 @@
 .app {
-    width: 100vw;
-    height: 100vh;
+    width: 100%;
+    height: 100%;
 }

--- a/packages/map-template/src/index.css
+++ b/packages/map-template/src/index.css
@@ -8,7 +8,8 @@ body {
 }
 
 html, body {
-  height: 100vh;
+  height: 100%;
+  width: 100%;
   position: fixed;
   overflow: hidden;
 }
@@ -16,4 +17,9 @@ html, body {
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
+}
+
+#root {
+  width: 100%;
+  height: 100%;
 }


### PR DESCRIPTION
# What, how

- Avoid using 100vh for app size.

# Why

- 100vh is more than visually visible in some mobile browsers.