### PR TITLE
Bugfix/reset categories

### DIFF
--- a/packages/map-template/src/components/BottomSheet/BottomSheet.jsx
+++ b/packages/map-template/src/components/BottomSheet/BottomSheet.jsx
@@ -23,8 +23,9 @@ const BOTTOM_SHEETS = {
  * @param {function} props.onLocationsFiltered - The list of locations after filtering through the categories.
  * @param {function} props.onDirectionsOpened - Check if the directions page state is open.
  * @param {function} props.onDirectionsClosed - Check if the directions page state is closed.
+ * @param {string} props.currentVenueName - The currently selected venue.
  */
-function BottomSheet({ currentLocation, setCurrentLocation, currentCategories, onLocationsFiltered, onDirectionsOpened, onDirectionsClosed}) {
+function BottomSheet({ currentLocation, setCurrentLocation, currentCategories, onLocationsFiltered, onDirectionsOpened, onDirectionsClosed, currentVenueName}) {
 
     const bottomSheetRef = useRef();
     const [activeBottomSheet, setActiveBottomSheet] = useState(null);
@@ -73,6 +74,7 @@ function BottomSheet({ currentLocation, setCurrentLocation, currentCategories, o
                 onLocationClick={(location) => setCurrentLocation(location)}
                 categories={currentCategories}
                 onLocationsFiltered={(locations) => onLocationsFiltered(locations)}
+                currentVenueName={currentVenueName}
             />
         </Sheet>,
         <Sheet

--- a/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
+++ b/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
@@ -215,6 +215,7 @@ function MapsIndoorsMap({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId
                         ?
                         <Sidebar
                             currentLocation={currentLocation}
+                            currentVenueName={currentVenueName}
                             setCurrentLocation={setCurrentLocation}
                             currentCategories={currentCategories}
                             onClose={() => setCurrentLocation(null)}
@@ -225,6 +226,7 @@ function MapsIndoorsMap({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId
                         :
                         <BottomSheet
                             currentLocation={currentLocation}
+                            currentVenueName={currentVenueName}
                             setCurrentLocation={setCurrentLocation}
                             currentCategories={currentCategories}
                             onLocationsFiltered={(locations) => setFilteredLocations(locations)}

--- a/packages/map-template/src/components/Search/Search.jsx
+++ b/packages/map-template/src/components/Search/Search.jsx
@@ -118,8 +118,10 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize, c
      * Deselect category and clear results list.
      */
     useEffect(() => {
-        setSearchResults([]);
-        setSelectedCategory(null);
+        if (selectedCategory) {
+            setSearchResults([]);
+            setSelectedCategory(null);
+        }
     }, [currentVenueName]);
 
 

--- a/packages/map-template/src/components/Search/Search.jsx
+++ b/packages/map-template/src/components/Search/Search.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import './Search.scss';
-import { useRef, useState } from 'react';
+import { useRef, useState, useEffect } from 'react';
 import { snapPoints } from '../../constants/snapPoints';
 import { usePreventSwipe } from '../../hooks/usePreventSwipe';
 import ListItemLocation from '../WebComponentWrappers/ListItemLocation/ListItemLocation';
@@ -17,9 +17,10 @@ const mapsindoors = window.mapsindoors;
  * @param {[[string, number]]} props.categories - All the unique categories that users can filter through.
  * @param {function} props.onLocationsFiltered - Function that is run when the user performs a filter through any category.
  * @param {function} props.onSetSize - Callback that is fired when the search field takes focus.
+ * @param {string} props.currentVenueName - The currently selected venue.
  * @returns
  */
-function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize }) {
+function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize, currentVenueName }) {
 
     /** Referencing the search field */
     const searchFieldRef = useRef();
@@ -59,7 +60,6 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize })
 
         if (selectedCategory === category) {
             // If the clicked category is the same as currently selected, "deselect" it.
-
             setSearchResults([]);
             setSelectedCategory(null);
 
@@ -112,6 +112,16 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize })
 
         onLocationsFiltered([]);
     }
+
+    /*
+     * React on changes in the venue prop.
+     * Deselect category and clear results list.
+     */
+    useEffect(() => {
+        setSearchResults([]);
+        setSelectedCategory(null);
+    }, [currentVenueName]);
+
 
     return (
         <div className="search">

--- a/packages/map-template/src/components/Sidebar/Sidebar.jsx
+++ b/packages/map-template/src/components/Sidebar/Sidebar.jsx
@@ -20,9 +20,10 @@ const VIEWS = {
  * @param {function} props.onLocationsFiltered - The list of locations after filtering through the categories.
  * @param {function} props.onDirectionsOpened - Check if the directions page state is open.
  * @param {function} props.onDirectionsClosed - Check if the directions page state is closed.
+ * @param {string} props.currentVenueName - The currently selected venue.
  *
 */
-function Sidebar({ currentLocation, setCurrentLocation, currentCategories, onLocationsFiltered, onDirectionsOpened, onDirectionsClosed }) {
+function Sidebar({ currentLocation, setCurrentLocation, currentCategories, onLocationsFiltered, onDirectionsOpened, onDirectionsClosed, currentVenueName }) {
     const [activePage, setActivePage] = useState(null);
 
     const [directions, setDirections] = useState();
@@ -59,6 +60,7 @@ function Sidebar({ currentLocation, setCurrentLocation, currentCategories, onLoc
                 onLocationClick={(location) => setCurrentLocation(location)}
                 categories={currentCategories}
                 onLocationsFiltered={(locations) => onLocationsFiltered(locations)}
+                currentVenueName={currentVenueName}
             />
         </Modal>,
         <Modal isOpen={activePage === VIEWS.LOCATION_DETAILS} key="B">


### PR DESCRIPTION
# What 
- Reset categories when changing the venue 

# How 
- Pass the `currentVenueName` prop to the `Sidebar` and `Bottom sheet`, and then to the `Search` component
- Implement `useEffect` hook and listen to the changes in the `currentVenueName`
- If there is a selected category, deselect it and clear the results list