### PR TITLE
Bugfix/list item location

### DIFF
--- a/packages/components/src/components/list-item-location/list-item-location.tsx
+++ b/packages/components/src/components/list-item-location/list-item-location.tsx
@@ -80,7 +80,7 @@ export class ListItemLocation {
     }
 
     componentWillLoad(): void {
-        this.iconURLToRender = this.icon ? this.icon : this.location.properties.imageURL;
+        this.iconURLToRender = this.icon ? this.icon : this.location?.properties.imageURL;
         this.updateBadge();
     }
 


### PR DESCRIPTION
# What 
- Fix the issue of not having a location and assigning the `imageURL`

# How
- Add a check for the existence of the location before assigning the `imageURL` to it