### PR TITLE
fix/using-browser-back-button-from-directions-leaves-the-map-without-floor-selector

### DIFF
--- a/packages/map-template/src/components/BottomSheet/BottomSheet.jsx
+++ b/packages/map-template/src/components/BottomSheet/BottomSheet.jsx
@@ -14,14 +14,12 @@ import Search from '../Search/Search';
  * @param {Object} props.setCurrentLocation - The setter for the currently selected MapsIndoors Location.
  * @param {Object} props.currentCategories - The unique categories displayed based on the existing locations.
  * @param {function} props.onLocationsFiltered - The list of locations after filtering through the categories.
- * @param {function} props.onDirectionsOpened - Check if the directions page state is open.
- * @param {function} props.onDirectionsClosed - Check if the directions page state is closed.
  * @param {string} props.currentVenueName - The currently selected venue.
  * @param {function} props.pushAppView - Function to push to app view to browser history.
  * @param {string} props.currentAppView - Holds the current view/state of the Map Template.
  * @param {array} props.appViews - Array of all possible views.
  */
-function BottomSheet({ currentLocation, setCurrentLocation, currentCategories, onLocationsFiltered, onDirectionsOpened, onDirectionsClosed, currentVenueName, pushAppView, currentAppView, appViews}) {
+function BottomSheet({ currentLocation, setCurrentLocation, currentCategories, onLocationsFiltered, currentVenueName, pushAppView, currentAppView, appViews}) {
 
     const bottomSheetRef = useRef();
 
@@ -43,28 +41,10 @@ function BottomSheet({ currentLocation, setCurrentLocation, currentCategories, o
     }, [currentLocation]);
 
     /**
-     * Set the active bottom sheet and trigger the visibility of the floor selector to be shown.
-     *
-     * @param {number} bottomSheet
-     */
-    function setBottomSheet(bottomSheet) {
-        pushAppView(bottomSheet);
-        onDirectionsClosed();
-    }
-
-    /**
-     * Navigate to the directions screen and trigger the visibility of the floor selector to be hidden.
-     */
-    function setDirectionsBottomSheet() {
-        pushAppView(appViews.DIRECTIONS);
-        onDirectionsOpened();
-    }
-
-    /**
      * Navigate to the search screen and reset the location that has been previously selected.
      */
     function setSearchBottomSheet() {
-        setBottomSheet(appViews.SEARCH);
+        pushAppView(appViews.SEARCH);
         setCurrentLocation();
     }
 
@@ -90,7 +70,7 @@ function BottomSheet({ currentLocation, setCurrentLocation, currentCategories, o
             onSwipedToSnapPoint={snapPoint => setLocationDetailsSheetSwiped(snapPoint)}>
             <LocationDetails
                 onSetSize={size => setLocationDetailsSheetSize(size)}
-                onStartWayfinding={() => setBottomSheet(appViews.WAYFINDING)}
+                onStartWayfinding={() => pushAppView(appViews.WAYFINDING)}
                 location={currentLocation}
                 onBack={() => setSearchBottomSheet()}
                 snapPointSwiped={locationDetailsSheetSwiped}
@@ -103,10 +83,10 @@ function BottomSheet({ currentLocation, setCurrentLocation, currentCategories, o
             key="C">
             <Wayfinding
                 onSetSize={size => setWayfindingSheetSize(size)}
-                onStartDirections={() => setDirectionsBottomSheet()}
+                onStartDirections={() => pushAppView(appViews.DIRECTIONS)}
                 location={currentLocation}
                 onDirections={result => setDirections(result)}
-                onBack={() => setBottomSheet(appViews.LOCATION_DETAILS)}
+                onBack={() => pushAppView(appViews.LOCATION_DETAILS)}
                 isActive={currentAppView === appViews.WAYFINDING}
             />
         </Sheet>,
@@ -117,7 +97,7 @@ function BottomSheet({ currentLocation, setCurrentLocation, currentCategories, o
             <Directions
                 isOpen={currentAppView === appViews.DIRECTIONS}
                 directions={directions}
-                onBack={() => setBottomSheet(appViews.WAYFINDING)}
+                onBack={() => pushAppView(appViews.WAYFINDING)}
                 isActive={currentAppView === appViews.DIRECTIONS}
             />
         </Sheet>

--- a/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
+++ b/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
@@ -59,6 +59,9 @@ function MapsIndoorsMap({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId
         if (currentAppView === appStates.LOCATION_DETAILS && currentAppViewPayload && !currentLocation) {
             setCurrentLocation(currentAppViewPayload);
         }
+
+        setHasDirectionsOpen(currentAppView === appStates.DIRECTIONS);
+        _locationsDisabled = currentAppView === appStates.DIRECTIONS;
     }, [currentAppView]);
 
     /**
@@ -69,26 +72,6 @@ function MapsIndoorsMap({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId
             setMapReady(true);
         }
         getVenueCategories(currentVenueName);
-    }
-
-    /**
-     * Handle the state where directions are closed.
-     */
-    function directionsClosed() {
-        if (hasDirectionsOpen === true) {
-            setHasDirectionsOpen(false);
-            _locationsDisabled = false;
-        }
-    }
-
-    /**
-     * Handle the state where directions are open.
-     */
-    function directionsOpened() {
-        if (hasDirectionsOpen === false) {
-            setHasDirectionsOpen(true);
-            _locationsDisabled = true;
-        }
     }
 
     /**
@@ -238,8 +221,6 @@ function MapsIndoorsMap({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId
                             currentCategories={currentCategories}
                             onClose={() => setCurrentLocation(null)}
                             onLocationsFiltered={(locations) => setFilteredLocations(locations)}
-                            onDirectionsOpened={() => directionsOpened()}
-                            onDirectionsClosed={() => directionsClosed()}
                             pushAppView={pushAppView}
                             currentAppView={currentAppView}
                             appViews={appStates}
@@ -251,8 +232,6 @@ function MapsIndoorsMap({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId
                             setCurrentLocation={setCurrentLocation}
                             currentCategories={currentCategories}
                             onLocationsFiltered={(locations) => setFilteredLocations(locations)}
-                            onDirectionsOpened={() => directionsOpened()}
-                            onDirectionsClosed={() => directionsClosed()}
                             pushAppView={pushAppView}
                             currentAppView={currentAppView}
                             appViews={appStates}

--- a/packages/map-template/src/components/Sidebar/Sidebar.jsx
+++ b/packages/map-template/src/components/Sidebar/Sidebar.jsx
@@ -11,15 +11,13 @@ import Search from '../Search/Search';
  * @param {Object} props.setCurrentLocation - The setter for the currently selected MapsIndoors Location.
  * @param {Object} props.currentCategories - The unique categories displayed based on the existing locations.
  * @param {function} props.onLocationsFiltered - The list of locations after filtering through the categories.
- * @param {function} props.onDirectionsOpened - Check if the directions page state is open.
- * @param {function} props.onDirectionsClosed - Check if the directions page state is closed.
  * @param {string} props.currentVenueName - The currently selected venue.
  * @param {function} props.pushAppView - Function to push to app view to browser history.
  * @param {string} props.currentAppView - Holds the current view/state of the Map Template.
  * @param {array} props.appViews - Array of all possible views.
  *
  */
-function Sidebar({ currentLocation, setCurrentLocation, currentCategories, onLocationsFiltered, onDirectionsOpened, onDirectionsClosed, currentVenueName, pushAppView, currentAppView, appViews }) {
+function Sidebar({ currentLocation, setCurrentLocation, currentCategories, onLocationsFiltered, currentVenueName, pushAppView, currentAppView, appViews }) {
     const [directions, setDirections] = useState();
 
     /*
@@ -32,28 +30,10 @@ function Sidebar({ currentLocation, setCurrentLocation, currentCategories, onLoc
     }, [currentLocation]);
 
     /**
-     * Set the active page and trigger the visibility of the floor selector to be shown.
-     *
-     * @param {number} page
-     */
-    function setPage(page) {
-        pushAppView(page);
-        onDirectionsClosed();
-    }
-
-    /**
-     * Navigate to the directions page and trigger the visibility of the floor selector to be hidden.
-     */
-    function setDirectionsPage() {
-        pushAppView(appViews.DIRECTIONS);
-        onDirectionsOpened();
-    }
-
-    /**
      * Navigate to the search page and reset the location that has been previously selected.
      */
      function setSearchPage() {
-        setPage(appViews.SEARCH);
+        pushAppView(appViews.SEARCH);
         setCurrentLocation();
     }
 
@@ -68,17 +48,17 @@ function Sidebar({ currentLocation, setCurrentLocation, currentCategories, onLoc
         </Modal>,
         <Modal isOpen={currentAppView === appViews.LOCATION_DETAILS} key="B">
             <LocationDetails
-                onStartWayfinding={() => setPage(appViews.WAYFINDING)}
+                onStartWayfinding={() => pushAppView(appViews.WAYFINDING)}
                 location={currentLocation}
                 onBack={() => setSearchPage()}
             />
         </Modal>,
         <Modal isOpen={currentAppView === appViews.WAYFINDING} key="C">
             <Wayfinding
-                onStartDirections={() => setDirectionsPage()}
+                onStartDirections={() => pushAppView(appViews.DIRECTIONS)}
                 location={currentLocation}
                 onDirections={result => setDirections(result)}
-                onBack={() => setPage(appViews.LOCATION_DETAILS)}
+                onBack={() => pushAppView(appViews.LOCATION_DETAILS)}
                 isActive={currentAppView === appViews.WAYFINDING}
             />
         </Modal>,
@@ -86,7 +66,7 @@ function Sidebar({ currentLocation, setCurrentLocation, currentCategories, onLoc
             <Directions
                 isOpen={currentAppView === appViews.DIRECTIONS}
                 directions={directions}
-                onBack={() => setPage(appViews.WAYFINDING)}
+                onBack={() => pushAppView(appViews.WAYFINDING)}
             />
         </Modal>
     ]


### PR DESCRIPTION
# What

- Fix a bug that caused floor selector and other on-map elements to remain hidden when using the browser back button to go back from directions.

# How

- Use the currentAppView to set visibility of elements on the map instead of passing props.