### PR TITLE
Bugfix/ switch directions

### DIFF
--- a/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
+++ b/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
@@ -269,6 +269,8 @@ function Wayfinding({ onStartDirections, onBack, location, onSetSize, isActive, 
                 avoidStairs: accessibilityOn
             }).then(directionsResult => {
                 if (directionsResult && directionsResult.legs) {
+                    setHasError(false);
+                    setHasFoundRoute(true);
                     // Calculate total distance and time
                     const totalDistance = directionsResult.legs.reduce((accumulator, current) => accumulator + current.distance.value, 0);
                     const totalTime = directionsResult.legs.reduce((accumulator, current) => accumulator + current.duration.value, 0);


### PR DESCRIPTION
# What 
- Fix issue of not showing directions when switching between origin and destination 

# How
- Set the error messages to not be shown by default when calculating the directions, which was causing the `switch` button to not show any directions because the state was kept as having an error message, and has never been set to `false`.