### PR TITLE
Bugfix/Venue categories

### DIFF
--- a/packages/map-template/src/components/Map/Map.jsx
+++ b/packages/map-template/src/components/Map/Map.jsx
@@ -53,7 +53,7 @@ function Map({ apiKey, gmApiKey, mapboxAccessToken, venues, venueName, onLocatio
             const venueToShow = getVenueToShow(venueName, venues);
             if (venueToShow) {
                 setVenue(venueToShow, mapsIndoorsInstance).then(() => {
-                    onVenueChangedOnMap();
+                    onVenueChangedOnMap(venueToShow);
                 });
             };
         }

--- a/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
+++ b/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
@@ -68,20 +68,14 @@ function MapsIndoorsMap({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId
     }, [currentAppView]);
 
     /**
-     * When venue is fitted while initializing the data, set map to be ready.
+     * When venue is fitted while initializing the data,
+     * set map to be ready and get the venue categories.
      */
     function venueChangedOnMap(venue) {
         if (isMapReady === false) {
             setMapReady(true);
         }
-
-        // If a venue is passed from the Map component, use that to get the venue categories,
-        // otherwise use the venue that has been set in the prop to get the categories.
-        if (venue) {
-            getVenueCategories(venue.name);
-        } else {
-            getVenueCategories(currentVenueName);
-        }
+        getVenueCategories(venue.name);
     }
 
     /**

--- a/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
+++ b/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
@@ -44,7 +44,7 @@ function MapsIndoorsMap({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId
     const [directionsService, setDirectionsService] = useState();
     const [hasDirectionsOpen, setHasDirectionsOpen] = useState(false);
     const [userPosition, setUserPosition] = useState();
- 	const [appConfigResult, setAppConfigResult] = useState();
+    const [appConfigResult, setAppConfigResult] = useState();
 
     // The filtered locations that the user sets when selecting a category/location.
     const [filteredLocations, setFilteredLocations] = useState();
@@ -70,11 +70,18 @@ function MapsIndoorsMap({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId
     /**
      * When venue is fitted while initializing the data, set map to be ready.
      */
-    function venueChangedOnMap() {
+    function venueChangedOnMap(venue) {
         if (isMapReady === false) {
             setMapReady(true);
         }
-        getVenueCategories(currentVenueName);
+
+        // If a venue is passed from the Map component, use that to get the venue categories,
+        // otherwise use the venue that has been set in the prop to get the categories.
+        if (venue) {
+            getVenueCategories(venue.name);
+        } else {
+            getVenueCategories(currentVenueName);
+        }
     }
 
     /**
@@ -252,7 +259,7 @@ function MapsIndoorsMap({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId
                             mapboxAccessToken={mapboxAccessToken}
                             venues={venues}
                             venueName={currentVenueName}
-                            onVenueChangedOnMap={() => venueChangedOnMap()}
+                            onVenueChangedOnMap={(venue) => venueChangedOnMap(venue)}
                             onMapsIndoorsInstance={(instance) => setMapsIndoorsInstance(instance)}
                             onDirectionsService={(instance) => setDirectionsService(instance)}
                             onLocationClick={(location) => locationClicked(location)}


### PR DESCRIPTION
# What 
- Fix the issue of categories not being shown when non existent venue is set as a property 

# How 
- Pass the `venue` object to the `onVenueChangedOnMap` function on the `Map` component
- If the venue exists, get the categories for that specific venue, otherwise get the categories for the venue that is set on the prop `venue` on `MapsIndoorsMap` component