### PR TITLE
bugfix/tile-style-does-not-work-on-google-maps

### DIFF
--- a/packages/map-template/src/components/Map/Map.jsx
+++ b/packages/map-template/src/components/Map/Map.jsx
@@ -92,11 +92,14 @@ function Map({ apiKey, gmApiKey, mapboxAccessToken, venues, venueName, onLocatio
      */
     const onTileStyleChanged = (miInstance) => {
         if (miInstance && _tileStyle) {
-            const tileURL = miInstance.getTileURL().replace('default', _tileStyle);
+            let tileURL = miInstance.getTileURL();
+            if (tileURL) {
+                tileURL = miInstance.getTileURL().replace('default', _tileStyle);
 
-            // Replace the floor placeholder with the actual floor and set the tile URL on the MapView.
-            const tileStyleWithFloor = tileURL?.replace('{floor}', miInstance.getFloor());
-            miInstance.getMapView().setMapsIndoorsTileURL(tileStyleWithFloor);
+                // Replace the floor placeholder with the actual floor and set the tile URL on the MapView.
+                const tileStyleWithFloor = tileURL?.replace('{floor}', miInstance.getFloor());
+                miInstance.getMapView().setMapsIndoorsTileURL(tileStyleWithFloor);
+            }
         }
     }
 
@@ -143,7 +146,7 @@ function Map({ apiKey, gmApiKey, mapboxAccessToken, venues, venueName, onLocatio
      * React on changes in the tile style prop.
      */
     useEffect(() => {
-        _tileStyle = tileStyle || 'default' 
+        _tileStyle = tileStyle || 'default';
         onTileStyleChanged(mapsIndoorsInstance);
     }, [tileStyle]);
 


### PR DESCRIPTION
Fix a bug where tiles on Google Maps were never shown. This was caused by the very first call for onTileStyleChanged, where getTileURL would always return null. It is always called later, so the implemented check will not break anything.