### PR TITLE
Bugfix/external id list

### DIFF
--- a/packages/map-template/src/components/BottomSheet/BottomSheet.jsx
+++ b/packages/map-template/src/components/BottomSheet/BottomSheet.jsx
@@ -85,7 +85,7 @@ function BottomSheet({ currentLocation, setCurrentLocation, currentCategories, o
             />
         </Sheet>,
         <Sheet
-            minHeight="165"
+            minHeight="200"
             isOpen={currentAppView === appViews.EXTERNALIDS}
             key="B">
             <LocationsList

--- a/packages/map-template/src/components/LocationsList/LocationsList.jsx
+++ b/packages/map-template/src/components/LocationsList/LocationsList.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import './LocationsList.scss';
 import { ReactComponent as CloseIcon } from '../../assets/close.svg';
 import ListItemLocation from "../WebComponentWrappers/ListItemLocation/ListItemLocation";
+import { usePreventSwipe } from "../../hooks/usePreventSwipe";
 
 /**
  * Show list of locations.
@@ -13,6 +14,9 @@ import ListItemLocation from "../WebComponentWrappers/ListItemLocation/ListItemL
  *
  */
 function LocationsList({ onBack, onLocationClick, locations }) {
+
+    const scrollableContentSwipePrevent = usePreventSwipe();
+
     return (
         <div className="locations-list">
             <div className="locations-list__header">
@@ -21,14 +25,16 @@ function LocationsList({ onBack, onLocationClick, locations }) {
                     <CloseIcon />
                 </button>
             </div>
-            <div className="locations-list__list">
-                {locations?.map(location =>
-                    <ListItemLocation
-                        key={location.id}
-                        location={location}
-                        locationClicked={e => onLocationClick(e)}
-                    />
-                )}
+            <div className="locations-list__scrollable prevent-scroll" {...scrollableContentSwipePrevent}>
+                <div className="locations-list__list">
+                    {locations?.map(location =>
+                        <ListItemLocation
+                            key={location.id}
+                            location={location}
+                            locationClicked={e => onLocationClick(e)}
+                        />
+                    )}
+                </div>
             </div>
         </div>
     )

--- a/packages/map-template/src/components/LocationsList/LocationsList.scss
+++ b/packages/map-template/src/components/LocationsList/LocationsList.scss
@@ -28,4 +28,8 @@
         grid-auto-rows: min-content;
         padding: var(--spacing-x-small);;
     }
+
+    &__scrollable {
+        overflow: auto;
+    }
 }

--- a/packages/map-template/src/components/LocationsList/LocationsList.scss
+++ b/packages/map-template/src/components/LocationsList/LocationsList.scss
@@ -1,6 +1,6 @@
-.locations-list {
-    min-height: 165px;
+@import '../../variables.scss';
 
+.locations-list {
     &__header {
         padding: var(--spacing-medium);
         position: relative;
@@ -31,5 +31,9 @@
 
     &__scrollable {
         overflow: auto;
+    }
+
+    @media (max-width: $desktop-breakpoint) {
+        height: 200px;
     }
 }


### PR DESCRIPTION
# What 
- Set bottom sheet height when having a list of external IDs to only show 1,5 list items

# How
- Set the height of the `LocationsList` component to be 200px on mobile devices using the media queries 
- Use the `usePreventSwipe` hook to allow the users to scroll the content on the bottom sheet