### PR TITLE
Show the location on the map when setting the "locationId" prop

### DIFF
--- a/packages/map-template/src/App.jsx
+++ b/packages/map-template/src/App.jsx
@@ -32,7 +32,7 @@ function App() {
             <MapsIndoorsMap
                 apiKey={apiKey ? apiKey : '3ddemo'}
                 venue={venue}
-                locationId={`${locationId}`}
+                locationId={locationId}
                 primaryColor={hexPrimaryColor}
                 logo={logo ? logo : undefined}
                 appUserRoles={appUserRoles}

--- a/packages/map-template/src/components/Map/Map.jsx
+++ b/packages/map-template/src/components/Map/Map.jsx
@@ -112,12 +112,15 @@ function Map({ apiKey, gmApiKey, mapboxAccessToken, venues, venueName, onLocatio
         if (locationId && miInstance) {
             mapsindoors.services.LocationsService.getLocation(locationId).then(location => {
                 if (location) {
+                    // Set the floor to the one that the location belongs to.
                     const locationFloor = location.properties.floor;
                     miInstance.setFloor(locationFloor);
 
+                    // Center the map to the location coordinates.
                     const locationGeometry = location.geometry.type === 'Point' ? location.geometry.coordinates : location.properties.anchor.coordinates;
                     miInstance.getMapView().setCenter({ lat: locationGeometry[1], lng: locationGeometry[0] });
 
+                    // Set the zoom level in order to see the location closer on the map.
                     miInstance?.setZoom(21);
                 }
             });

--- a/packages/map-template/src/components/Map/Map.jsx
+++ b/packages/map-template/src/components/Map/Map.jsx
@@ -131,10 +131,10 @@ function Map({ apiKey, gmApiKey, mapboxAccessToken, venues, venueName, onLocatio
     }
 
     /**
-    * Replace the default tile URL style to the incoming tile style.
-    *
-    * @param {object} miInstance
-    */
+     * Replace the default tile URL style to the incoming tile style.
+     *
+     * @param {object} miInstance
+     */
     const onTileStyleChanged = (miInstance) => {
         if (miInstance && _tileStyle) {
             let tileURL = miInstance.getTileURL();

--- a/packages/map-template/src/components/Map/Map.jsx
+++ b/packages/map-template/src/components/Map/Map.jsx
@@ -99,14 +99,20 @@ function Map({ apiKey, gmApiKey, mapboxAccessToken, venues, venueName, onLocatio
 
     /**
      * Handle the tile style changes and the locationId property.
-     * If the locationId property is present, set the correct floor, center and zoom the map.
      *
      * @param {object} miInstance
      */
     const onBuildingChanged = (miInstance) => {
-
         onTileStyleChanged(miInstance);
+        onLocationIdChanged(miInstance)
+    }
 
+    /**
+     * If the locationId property is present, set the correct floor, center and zoom the map.
+     *
+     * @param {object} miInstance
+     */
+    const onLocationIdChanged = (miInstance) => {
         if (locationId && miInstance) {
             mapsindoors.services.LocationsService.getLocation(locationId).then(location => {
                 if (location) {

--- a/packages/map-template/src/components/Map/Map.jsx
+++ b/packages/map-template/src/components/Map/Map.jsx
@@ -61,7 +61,7 @@ function Map({ apiKey, gmApiKey, mapboxAccessToken, venues, venueName, onLocatio
         if (mapsIndoorsInstance) {
             window.localStorage.clear(localStorageKeyForVenue);
             const venueToShow = getVenueToShow(venueName, venues);
-            if (venueToShow) {
+            if (venueToShow && !locationId) {
                 setVenue(venueToShow, mapsIndoorsInstance).then(() => {
                     onVenueChangedOnMap(venueToShow);
                 });
@@ -92,11 +92,7 @@ function Map({ apiKey, gmApiKey, mapboxAccessToken, venues, venueName, onLocatio
      */
     const setVenue = (venue, mapsIndoorsInstance) => {
         window.localStorage.setItem(localStorageKeyForVenue, venue.name);
-        if (locationId) {
-            return Promise.resolve();
-        } else {
-            return mapsIndoorsInstance.fitVenue(venue);
-        }
+        return mapsIndoorsInstance.fitVenue(venue);
     }
 
     /**
@@ -172,7 +168,7 @@ function Map({ apiKey, gmApiKey, mapboxAccessToken, venues, venueName, onLocatio
         onDirectionsService(directionsService);
 
         const venueToShow = getVenueToShow(venueName, venues);
-        if (venueToShow) {
+        if (venueToShow && !locationId) {
             setVenue(venueToShow, miInstance);
         }
     };

--- a/packages/map-template/src/components/Map/Map.jsx
+++ b/packages/map-template/src/components/Map/Map.jsx
@@ -87,7 +87,6 @@ function Map({ apiKey, gmApiKey, mapboxAccessToken, venues, venueName, onLocatio
 
     /**
      * Set the venue to show on the map.
-     * If locationId property is present, resolve the promise without fitting the venue.
      *
      * @param {object} venue
      * @param {object} mapsIndoorsInstance

--- a/packages/map-template/src/components/Map/Map.jsx
+++ b/packages/map-template/src/components/Map/Map.jsx
@@ -123,8 +123,16 @@ function Map({ apiKey, gmApiKey, mapboxAccessToken, venues, venueName, onLocatio
                     const locationGeometry = location.geometry.type === 'Point' ? location.geometry.coordinates : location.properties.anchor.coordinates;
                     miInstance.getMapView().setCenter({ lat: locationGeometry[1], lng: locationGeometry[0] });
 
-                    // Set the zoom level in order to see the location closer on the map.
-                    miInstance?.setZoom(21);
+                    // Check if the solution allows the zoom level to be 22.
+                    // If yes, set the zoom level to 22, otherwise set it to 21.
+                    mapsindoors.services.SolutionsService.getSolution().then(solution => {
+                        const hasZoom22 = Object.values(solution.modules).find(zoomLevel => zoomLevel === 'z22')
+                        if (hasZoom22) {
+                            miInstance?.setZoom(22);
+                        } else {
+                            miInstance?.setZoom(21);
+                        }
+                    });
                 }
             });
         }

--- a/packages/map-template/src/components/Map/Map.jsx
+++ b/packages/map-template/src/components/Map/Map.jsx
@@ -32,10 +32,11 @@ let _tileStyle;
  * @param {function} props.onMapTypeChanged - Function that is run when the map type is changed.
  * @param {array} props.filteredLocationsByExternalIDs - Array of IDs of the filtered locations based on external ID.
  * @param {string} props.tileStyle - Tile style name to change the interface of the map.
+ * @param {string} props.locationId
 
  * @returns
  */
-function Map({ apiKey, gmApiKey, mapboxAccessToken, venues, venueName, onLocationClick, onMapsIndoorsInstance, onDirectionsService, onVenueChangedOnMap, onUserPosition, filteredLocationIds, onMapTypeChanged, filteredLocationsByExternalIDs, tileStyle }) {
+function Map({ apiKey, gmApiKey, mapboxAccessToken, venues, venueName, onLocationClick, onMapsIndoorsInstance, onDirectionsService, onVenueChangedOnMap, onUserPosition, filteredLocationIds, onMapTypeChanged, filteredLocationsByExternalIDs, tileStyle, locationId }) {
     const [mapType, setMapType] = useState();
     const [mapsIndoorsInstance, setMapsIndoorsInstance] = useState(null);
 

--- a/packages/map-template/src/components/Map/Map.jsx
+++ b/packages/map-template/src/components/Map/Map.jsx
@@ -32,7 +32,7 @@ let _tileStyle;
  * @param {function} props.onMapTypeChanged - Function that is run when the map type is changed.
  * @param {array} props.filteredLocationsByExternalIDs - Array of IDs of the filtered locations based on external ID.
  * @param {string} props.tileStyle - Tile style name to change the interface of the map.
- * @param {string} props.locationId
+ * @param {string} props.locationId - Location Id property used to handle the centering and zooming of the map.
 
  * @returns
  */

--- a/packages/map-template/src/components/Map/Map.jsx
+++ b/packages/map-template/src/components/Map/Map.jsx
@@ -127,11 +127,7 @@ function Map({ apiKey, gmApiKey, mapboxAccessToken, venues, venueName, onLocatio
                     // If yes, set the zoom level to 22, otherwise set it to 21.
                     mapsindoors.services.SolutionsService.getSolution().then(solution => {
                         const hasZoom22 = Object.values(solution.modules).find(zoomLevel => zoomLevel === 'z22')
-                        if (hasZoom22) {
-                            miInstance?.setZoom(22);
-                        } else {
-                            miInstance?.setZoom(21);
-                        }
+                        miInstance?.setZoom(hasZoom22 ? 22 : 21);
                     });
                 }
             });

--- a/packages/map-template/src/components/Map/Map.jsx
+++ b/packages/map-template/src/components/Map/Map.jsx
@@ -101,14 +101,20 @@ function Map({ apiKey, gmApiKey, mapboxAccessToken, venues, venueName, onLocatio
 
     /**
      * Handle the tile style changes and the locationId property.
-     * If the locationId property is present, set the correct floor, center and zoom the map.
      *
      * @param {object} miInstance
      */
     const onBuildingChanged = (miInstance) => {
-
         onTileStyleChanged(miInstance);
+        onLocationIdSet(miInstance)
+    }
 
+    /**
+     * Set the correct floor, center and zoom the map.
+     *
+     * @param {object} miInstance
+     */
+    const onLocationIdSet = (miInstance) => {
         if (locationId && miInstance) {
             mapsindoors.services.LocationsService.getLocation(locationId).then(location => {
                 if (location) {
@@ -128,10 +134,10 @@ function Map({ apiKey, gmApiKey, mapboxAccessToken, venues, venueName, onLocatio
     }
 
     /**
-    * Replace the default tile URL style to the incoming tile style.
-    *
-    * @param {object} miInstance
-    */
+     * Replace the default tile URL style to the incoming tile style.
+     *
+     * @param {object} miInstance
+     */
     const onTileStyleChanged = (miInstance) => {
         if (miInstance && _tileStyle) {
             let tileURL = miInstance.getTileURL();

--- a/packages/map-template/src/components/Map/Map.jsx
+++ b/packages/map-template/src/components/Map/Map.jsx
@@ -65,7 +65,9 @@ function Map({ apiKey, gmApiKey, mapboxAccessToken, venues, venueName, onLocatio
                 setVenue(venueToShow, mapsIndoorsInstance).then(() => {
                     onVenueChangedOnMap(venueToShow);
                 });
-            };
+            } else if (venueToShow) {
+                onVenueChangedOnMap(venueToShow);
+            }
         }
     }, [venueName, venues]); // eslint-disable-line react-hooks/exhaustive-deps
     // We ignore eslint warnings about missing dependencies because mapsIndoorsInstance should never change runtime anyway.
@@ -97,20 +99,14 @@ function Map({ apiKey, gmApiKey, mapboxAccessToken, venues, venueName, onLocatio
 
     /**
      * Handle the tile style changes and the locationId property.
+     * If the locationId property is present, set the correct floor, center and zoom the map.
      *
      * @param {object} miInstance
      */
     const onBuildingChanged = (miInstance) => {
-        onTileStyleChanged(miInstance);
-        onLocationIdSet(miInstance)
-    }
 
-    /**
-     * Set the correct floor, center and zoom the map.
-     *
-     * @param {object} miInstance
-     */
-    const onLocationIdSet = (miInstance) => {
+        onTileStyleChanged(miInstance);
+
         if (locationId && miInstance) {
             mapsindoors.services.LocationsService.getLocation(locationId).then(location => {
                 if (location) {
@@ -130,10 +126,10 @@ function Map({ apiKey, gmApiKey, mapboxAccessToken, venues, venueName, onLocatio
     }
 
     /**
-     * Replace the default tile URL style to the incoming tile style.
-     *
-     * @param {object} miInstance
-     */
+    * Replace the default tile URL style to the incoming tile style.
+    *
+    * @param {object} miInstance
+    */
     const onTileStyleChanged = (miInstance) => {
         if (miInstance && _tileStyle) {
             let tileURL = miInstance.getTileURL();

--- a/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
+++ b/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
@@ -187,6 +187,10 @@ function MapsIndoorsMap({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId
         if (locationId) {
             mapsindoors.services.LocationsService.getLocation(locationId).then(location => {
                 if (location) {
+                    setCurrentVenueName(location.properties.venueId)
+                    const locationGeometry = location.geometry.type === 'Point' ? location.geometry.coordinates : location.properties.anchor.coordinates;
+                    mapsIndoorsInstance?.getMapView().setCenter({ lat: locationGeometry[1], lng: locationGeometry[0]})
+                    // mapsIndoorsInstance?.setZoom(21);
                     setCurrentLocation(location);
                 }
             });
@@ -312,6 +316,7 @@ function MapsIndoorsMap({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId
                             filteredLocationIds={filteredLocations?.map(location => location.id)}
                             filteredLocationsByExternalIDs={filteredLocationsByExternalID?.map(location => location.id)}
 							tileStyle={tileStyle}
+                            locationId={locationId}
                         />
                     </div>
                 </UserPositionContext.Provider>

--- a/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
+++ b/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
@@ -209,9 +209,9 @@ function MapsIndoorsMap({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId
     }, [apiKey]);
 
     /**
-    * React on changes to the locationId prop.
-    * Set as current location and change the venue according to the venue that the location belongs to.
-    */
+     * React on changes to the locationId prop.
+     * Set as current location and change the venue according to the venue that the location belongs to.
+     */
     useEffect(() => {
         if (locationId) {
             mapsindoors.services.LocationsService.getLocation(locationId).then(location => {
@@ -222,7 +222,6 @@ function MapsIndoorsMap({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId
             });
         }
     }, [locationId]);
-
 
     /*
      * React on changes in directions opened state.

--- a/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
+++ b/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
@@ -208,7 +208,7 @@ function MapsIndoorsMap({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId
 
     }, [apiKey]);
 
-    /**
+    /*
      * React on changes to the locationId prop.
      * Set as current location and change the venue according to the venue that the location belongs to.
      */

--- a/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
+++ b/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
@@ -180,23 +180,6 @@ function MapsIndoorsMap({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId
         }
     }, [externalIDs]);
 
-    /**
-     * React on changes to the locationId prop: Set as current location and make the map center on it.
-     */
-    useEffect(() => {
-        if (locationId) {
-            mapsindoors.services.LocationsService.getLocation(locationId).then(location => {
-                if (location) {
-                    setCurrentVenueName(location.properties.venueId)
-                    const locationGeometry = location.geometry.type === 'Point' ? location.geometry.coordinates : location.properties.anchor.coordinates;
-                    mapsIndoorsInstance?.getMapView().setCenter({ lat: locationGeometry[1], lng: locationGeometry[0]})
-                    // mapsIndoorsInstance?.setZoom(21);
-                    setCurrentLocation(location);
-                }
-            });
-        }
-    }, [locationId]);
-
     /*
      * React on changes to the directionsFrom and directionsTo props. When both are set, wayfinding should be shown.
      * Setting the directionsFromLocation and directionsToLocation make that happen.
@@ -236,6 +219,21 @@ function MapsIndoorsMap({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId
         setMapReady(false);
 
     }, [apiKey]);
+
+    /**
+    * React on changes to the locationId prop.
+    * Set as current location and change the venue according to the venue that the location belongs to.
+    */
+    useEffect(() => {
+        if (locationId) {
+            mapsindoors.services.LocationsService.getLocation(locationId).then(location => {
+                if (location) {
+                    setCurrentVenueName(location.properties.venueId);
+                    setCurrentLocation(location);
+                }
+            });
+        }
+    }, [locationId]);
 
 
     /*
@@ -315,7 +313,7 @@ function MapsIndoorsMap({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId
                             onMapTypeChanged={(mapType) => setSelectedMapType(mapType)}
                             filteredLocationIds={filteredLocations?.map(location => location.id)}
                             filteredLocationsByExternalIDs={filteredLocationsByExternalID?.map(location => location.id)}
-							tileStyle={tileStyle}
+                            tileStyle={tileStyle}
                             locationId={locationId}
                         />
                     </div>


### PR DESCRIPTION
# What 
- Show the location on the map when setting the `locationId` property 
- Center the map and zoom in until level 21
- Handle the cases when the `locationId` belongs to a different venue
- Handle the cases when the `locationId` is on a different floor than the default one 

# How 
- Pass down the `locationId` property to the `Map` component 
- Resolve the promise instead of fitting the map to the venue when having the `locationId` property set
- Handle the floor selector, the centering of the map and the zooming on the location inside the `building_changed` event listener 
- Set the current venue to be the one that the `locationId` belongs to 