### PR TITLE
Version update for release candidate 2 on NPM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21073,7 +21073,7 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.0.0-rc.1",
+      "version": "1.0.0-rc.2",
       "devDependencies": {
         "@googlemaps/js-api-loader": "^1.15.1",
         "@mapsindoors/components": "*",

--- a/packages/map-template/package.json
+++ b/packages/map-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapsindoors/map-template",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0-rc.2",
   "private": false,
   "files": ["dist/*.js", "dist/*.mjs"],
   "dependencies": {},


### PR DESCRIPTION
# What

- Bump the version of the Map Template package.

# Why

- We need the latest changes published as a release candidate to NPM.