### PR TITLE
Components: Use shell script when triggering release

### DIFF
--- a/.github/workflows/components-bump-version-release.yml
+++ b/.github/workflows/components-bump-version-release.yml
@@ -48,7 +48,7 @@ jobs:
         if: contains(github.event.pull_request.labels.*.name, 'patch')
         run: npm -w components run release -- patch
       - name: Publish to npm
-        run: npm -w components publish --access public --dry-run
+        run: npm -w components publish --access public
 
   # This job will release the Component documentation
   build_deploy_components_docs:

--- a/.github/workflows/components-bump-version-release.yml
+++ b/.github/workflows/components-bump-version-release.yml
@@ -38,16 +38,17 @@ jobs:
       - name: Set git config
         run: git config user.name github-actions[bot] && git config user.email 41898282+github-actions[bot]@users.noreply.github.com
       # The following steps will determine, based on a label, what version to bump to.
-      # The "%s" will output the version number in the commit message.
       - name: Major version bump
         if: contains(github.event.pull_request.labels.*.name, 'major')
-        run: cd packages/components && npm ci && npm run build && npm run docs.build && npm --tag-version-prefix="components-v" version major -m 'Release major version %s' && git push && git push --tags && npm publish --access public
+        run: npm -w components run release -- major
       - name: Minor version bump
         if: contains(github.event.pull_request.labels.*.name, 'minor')
-        run: cd packages/components && npm ci && npm run build && npm run docs.build && npm --tag-version-prefix="components-v" version minor -m 'Release minor version %s' && git push && git push --tags && npm publish --access public
+        run: npm -w components run release -- minor
       - name: Patch version bump
         if: contains(github.event.pull_request.labels.*.name, 'patch')
-        run: cd packages/components && npm ci && npm run build && npm run docs.build && npm --tag-version-prefix="components-v" version patch -m 'Release patch version %s' && git push && git push --tags && npm publish --access public
+        run: npm -w components run release -- patch
+      - name: Publish to npm
+        run: npm -w components publish --access public --dry-run
 
   # This job will release the Component documentation
   build_deploy_components_docs:

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -23,6 +23,7 @@
         "docs.sass": "sass src/docs/_sass:docs --no-source-map",
         "docs.start": "eleventy --serve --port=3000 & npm run sass.watch",
         "generate": "stencil generate",
+        "release": "sh ./release.sh",
         "sass.watch": "sass --watch src/docs/_sass:docs --no-source-map",
         "start": "stencil build --dev --watch --serve",
         "test.watch": "stencil test --spec --e2e --watchAll",

--- a/packages/components/release.sh
+++ b/packages/components/release.sh
@@ -10,7 +10,7 @@ fi
 npm version $1
 git add .
 export NPM_VERSION=$(npm pkg get version --workspaces=false | tr -d \")
-git commit -m 'Release Components'
+git commit -m "Release Components v$NPM_VERSION"
 git tag components-v$NPM_VERSION
 echo "Bumped version to v$NPM_VERSION"
 git push && git push --tags

--- a/packages/components/release.sh
+++ b/packages/components/release.sh
@@ -10,7 +10,7 @@ fi
 npm version $1
 git add .
 export NPM_VERSION=$(npm pkg get version --workspaces=false | tr -d \")
-git commit -m "Release Components v$NPM_VERSION"
-git tag components-v$NPM_VERSION
+git commit -m "Release @mapsindoors/components@$NPM_VERSION"
+git tag @mapsindoors/components@$NPM_VERSION
 echo "Bumped version to v$NPM_VERSION"
 git push && git push --tags

--- a/packages/components/release.sh
+++ b/packages/components/release.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+if [ "$1" != "major" ] && [ "$1" != "minor" ] && [ "$1" != "patch" ];
+then
+    echo "Could not release!"
+    echo "Usage: 'npm run release -- (major|minor|patch)'"
+    echo ""
+    exit 1
+fi
+
+npm version $1
+git add .
+export NPM_VERSION=$(npm pkg get version --workspaces=false | tr -d \")
+git commit -m 'Release Components'
+git tag components-v$NPM_VERSION
+echo "Bumped version to v$NPM_VERSION"
+git push && git push --tags


### PR DESCRIPTION
Files are based on a test repo here:

- https://github.com/markhougaard/github-workflow-test/blob/main/packages/components/package.json
- https://github.com/markhougaard/github-workflow-test/blob/main/packages/components/release.sh
- https://github.com/markhougaard/github-workflow-test/blob/main/.github/workflows/components-bump-version.yml

See tags in the test repo here:

- This run: https://github.com/markhougaard/github-workflow-test/actions/runs/5084733450/jobs/9137391524 created this tag: https://github.com/markhougaard/github-workflow-test/releases/tag/components-v33.1.0.

Tested it with the other workspace/package as well: https://github.com/markhougaard/github-workflow-test/actions/runs/5084940648/jobs/9137862560#step:6:29

All of this is because of this bug in the npm-cli: https://github.com/npm/cli/issues/2010 😔