### PR TITLE
Update build workflows

### DIFF
--- a/.github/workflows/components-bump-version-release.yml
+++ b/.github/workflows/components-bump-version-release.yml
@@ -32,7 +32,7 @@ jobs:
           scope: "@mapsindoors"
       # Build the project to ensure it's up to date. If this steps fails, the job fails.
       - name: Build
-        run: cd packages/components && npm ci && npm run build
+        run: npm ci && npx lerna run build && cd packages/components && npm ci && npm run build
       # You need to set the git config or you can't commit the changes later.
       # The name and email here is for the GitHub Actions user.
       - name: Set git config

--- a/.github/workflows/components-bump-version-release.yml
+++ b/.github/workflows/components-bump-version-release.yml
@@ -32,7 +32,7 @@ jobs:
           scope: "@mapsindoors"
       # Build the project to ensure it's up to date. If this steps fails, the job fails.
       - name: Build
-        run: npm ci && npx lerna run build && cd packages/components && npm ci && npm run build
+        run: npm ci && npx lerna run build && cd packages/components && npm run build
       # You need to set the git config or you can't commit the changes later.
       # The name and email here is for the GitHub Actions user.
       - name: Set git config

--- a/.github/workflows/components-bump-version-release.yml
+++ b/.github/workflows/components-bump-version-release.yml
@@ -32,7 +32,7 @@ jobs:
           scope: "@mapsindoors"
       # Build the project to ensure it's up to date. If this steps fails, the job fails.
       - name: Build
-        run: npm ci && npx lerna run build && cd packages/components && npm run build
+        run: npm ci && npx lerna run build
       # You need to set the git config or you can't commit the changes later.
       # The name and email here is for the GitHub Actions user.
       - name: Set git config

--- a/packages/map-template/package.json
+++ b/packages/map-template/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mapsindoors/map-template",
   "description": "Get a MapsIndoors map up and running in less than 10 mins.",
-  "version": "1.0.0-rc.2",
+  "version": "1.0.0",
   "private": false,
   "files": [
     "dist/*.js",

--- a/packages/map-template/package.json
+++ b/packages/map-template/package.json
@@ -41,7 +41,7 @@
     "build-for-npm": "node releaseTools/buildForNpm.mjs",
     "serve": "vite preview",
     "test": "",
-    "release": "standard-version"
+    "release": "sh ./release.sh"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
@andreeaceachir142 @ammapspeople I missed a spot, so it actually didn't run the right `release` command when we merged in earlier today. It means that we didn't tag the commit correctly, but I can do that retroactively. Also, as a side-effect, now we have the world's largest `changelog.md` file, so something good came out of it.

If we label this PR, we'll release new versions of both Components and Map Template, and I'm unsure if we want that because of some internal build process updates.