### PR TITLE
Resize the search view when no categories are shown

### DIFF
--- a/packages/map-template/src/App.jsx
+++ b/packages/map-template/src/App.jsx
@@ -31,7 +31,7 @@ function App() {
         <div className="app">
             {/* This is the Map Template component */}
             <MapsIndoorsMap
-                apiKey={apiKey ? apiKey : 'c6260c238cee496b8a0453e9'}
+                apiKey={apiKey ? apiKey : '3ddemo'}
                 venue={venue}
                 locationId={locationId}
                 primaryColor={hexPrimaryColor}

--- a/packages/map-template/src/App.jsx
+++ b/packages/map-template/src/App.jsx
@@ -31,7 +31,7 @@ function App() {
         <div className="app">
             {/* This is the Map Template component */}
             <MapsIndoorsMap
-                apiKey={apiKey ? apiKey : '3ddemo'}
+                apiKey={apiKey ? apiKey : 'c6260c238cee496b8a0453e9'}
                 venue={venue}
                 locationId={locationId}
                 primaryColor={hexPrimaryColor}

--- a/packages/map-template/src/components/BottomSheet/BottomSheet.jsx
+++ b/packages/map-template/src/components/BottomSheet/BottomSheet.jsx
@@ -79,7 +79,7 @@ function BottomSheet({ currentLocation, setCurrentLocation, currentCategories, o
 
     const bottomSheets = [
         <Sheet
-            minHeight={currentCategories.length > 0 ? "144" : "100"}
+            minHeight={currentCategories.length > 0 ? "136" : "80"}
             preferredSizeSnapPoint={searchSheetSize}
             isOpen={currentAppView === appViews.SEARCH}
             key="A">

--- a/packages/map-template/src/components/BottomSheet/BottomSheet.jsx
+++ b/packages/map-template/src/components/BottomSheet/BottomSheet.jsx
@@ -79,7 +79,7 @@ function BottomSheet({ currentLocation, setCurrentLocation, currentCategories, o
 
     const bottomSheets = [
         <Sheet
-            minHeight="144"
+            minHeight={currentCategories.length > 0 ? "144" : "100"}
             preferredSizeSnapPoint={searchSheetSize}
             isOpen={currentAppView === appViews.SEARCH}
             key="A">

--- a/packages/map-template/src/components/BottomSheet/Sheet/Sheet.jsx
+++ b/packages/map-template/src/components/BottomSheet/Sheet/Sheet.jsx
@@ -64,10 +64,10 @@ function Sheet({ children, isOpen, minHeight, preferredSizeSnapPoint, onSwipedTo
         requestAnimationFrame(() => {
             switch (targetSize) {
                 case snapPoints.MAX:
-                    setStyle({ height: `${container.current.clientHeight}px`});
+                    setStyle({ height: `${container.current.clientHeight}px` });
                     break;
                 case snapPoints.FIT:
-                    setStyle({ height: `${contentHeight}px`});
+                    setStyle({ height: `${contentHeight}px` });
                     break;
                 case snapPoints.MIN:
                     setStyle({ height: `${minHeight}px` });
@@ -91,6 +91,10 @@ function Sheet({ children, isOpen, minHeight, preferredSizeSnapPoint, onSwipedTo
      * the sheet to be set to a certain snap point.
      */
     useEffect(() => {
+        if (preferredSizeSnapPoint === undefined) {
+            return
+        }
+
         sheetRef.current.style.height = `${sheetRef.current.clientHeight}px`;
 
         requestAnimationFrame(() => {
@@ -164,7 +168,7 @@ function Sheet({ children, isOpen, minHeight, preferredSizeSnapPoint, onSwipedTo
         sheetRef.current = el;
     };
 
-    return <div {...swipeHandler} ref={refPassthrough} style={style} className={`sheet ${isOpen ? 'sheet--active' : ''} ${isDragging ? 'sheet--dragging': ''}`}>
+    return <div {...swipeHandler} ref={refPassthrough} style={style} className={`sheet ${isOpen ? 'sheet--active' : ''} ${isDragging ? 'sheet--dragging' : ''}`}>
         <div ref={contentRef} className="sheet__content" style={style}>
             {children}
         </div>

--- a/packages/map-template/src/components/BottomSheet/Sheet/Sheet.jsx
+++ b/packages/map-template/src/components/BottomSheet/Sheet/Sheet.jsx
@@ -91,8 +91,9 @@ function Sheet({ children, isOpen, minHeight, preferredSizeSnapPoint, onSwipedTo
      * the sheet to be set to a certain snap point.
      */
     useEffect(() => {
+        // Do not set the height of the sheet if the preferredSizeSnapPoint is undefined.
         if (preferredSizeSnapPoint === undefined) {
-            return
+            return;
         }
 
         sheetRef.current.style.height = `${sheetRef.current.clientHeight}px`;

--- a/packages/map-template/src/components/Search/Search.jsx
+++ b/packages/map-template/src/components/Search/Search.jsx
@@ -150,11 +150,7 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize, c
      * React on changes in categories prop.
      */
     useEffect(() => {
-        if (categories.length > 0) {
-            setHasCategories(true);
-        } else {
-            setHasCategories(false);
-        }
+        setHasCategories(categories.length > 0);
     }, [categories]);
 
     return (

--- a/packages/map-template/src/components/Search/Search.jsx
+++ b/packages/map-template/src/components/Search/Search.jsx
@@ -29,8 +29,6 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize, c
     const [searchDisabled, setSearchDisabled] = useState(true);
     const [searchResults, setSearchResults] = useState([]);
 
-    const [hasCategories, setHasCategories] = useState(false);
-
     /** Indicate if search results have been found */
     const [showNotFoundMessage, setShowNotFoundMessage] = useState(false);
 
@@ -146,17 +144,10 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize, c
         }
     }, [currentVenueName]);
 
-    /*
-     * React on changes in categories prop.
-     */
-    useEffect(() => {
-        setHasCategories(categories.length > 0);
-    }, [categories]);
-
     return (
         <div className="search"
             ref={searchRef}
-            style={{ minHeight: hasCategories ? '136px' : '80px' }}>
+            style={{ minHeight: categories.length > 0 ? '136px' : '80px' }}>
             <SearchField
                 ref={searchFieldRef}
                 mapsindoors={true}

--- a/packages/map-template/src/components/Search/Search.jsx
+++ b/packages/map-template/src/components/Search/Search.jsx
@@ -8,8 +8,6 @@ import SearchField from '../WebComponentWrappers/Search/Search';
 /** Initialize the MapsIndoors instance. */
 const mapsindoors = window.mapsindoors;
 
-let _hasCategories;
-
 /**
  * Show the search results.
  *
@@ -148,18 +146,21 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize, c
         }
     }, [currentVenueName]);
 
+    /*
+     * React on changes in categories prop.
+     */
     useEffect(() => {
         if (categories.length > 0) {
             setHasCategories(true);
-            _hasCategories = true;
         } else {
             setHasCategories(false);
-            _hasCategories = false;
         }
     }, [categories]);
 
     return (
-        <div className={`search ${_hasCategories === true ? "search--with-categories" : "search--no-categories"}`} ref={searchRef}>
+        <div className="search"
+            ref={searchRef}
+            style={{ minHeight: hasCategories ? '136px' : '80px' }}>
             <SearchField
                 ref={searchFieldRef}
                 mapsindoors={true}
@@ -183,16 +184,18 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize, c
                             </mi-chip>
                         )}
                     </div>}
-                <div className="search__results">
-                    {showNotFoundMessage && <p>Nothing was found</p>}
-                    {searchResults.map(location =>
-                        <ListItemLocation
-                            key={location.id}
-                            location={location}
-                            locationClicked={e => onLocationClick(e)}
-                        />
-                    )}
-                </div>
+                {searchResults.length > 0 &&
+                    <div className="search__results">
+                        {showNotFoundMessage && <p>Nothing was found</p>}
+                        {searchResults.map(location =>
+                            <ListItemLocation
+                                key={location.id}
+                                location={location}
+                                locationClicked={e => onLocationClick(e)}
+                            />
+                        )}
+                    </div>
+                }
             </div>
         </div >
     )

--- a/packages/map-template/src/components/Search/Search.jsx
+++ b/packages/map-template/src/components/Search/Search.jsx
@@ -8,6 +8,8 @@ import SearchField from '../WebComponentWrappers/Search/Search';
 /** Initialize the MapsIndoors instance. */
 const mapsindoors = window.mapsindoors;
 
+let _hasCategories;
+
 /**
  * Show the search results.
  *
@@ -28,6 +30,8 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize, c
 
     const [searchDisabled, setSearchDisabled] = useState(true);
     const [searchResults, setSearchResults] = useState([]);
+
+    const [hasCategories, setHasCategories] = useState(false);
 
     /** Indicate if search results have been found */
     const [showNotFoundMessage, setShowNotFoundMessage] = useState(false);
@@ -144,8 +148,18 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize, c
         }
     }, [currentVenueName]);
 
+    useEffect(() => {
+        if (categories.length > 0) {
+            setHasCategories(true);
+            _hasCategories = true;
+        } else {
+            setHasCategories(false);
+            _hasCategories = false;
+        }
+    }, [categories]);
+
     return (
-        <div className="search" ref={searchRef}>
+        <div className={`search ${_hasCategories === true ? "search--with-categories" : "search--no-categories"}`} ref={searchRef}>
             <SearchField
                 ref={searchFieldRef}
                 mapsindoors={true}
@@ -157,18 +171,18 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize, c
                 disabled={searchDisabled} // Disabled initially to prevent content jumping when clicking and changing sheet size.
             />
             <div className="search__scrollable prevent-scroll" {...scrollableContentSwipePrevent}>
-                <div ref={categoriesListRef} className="search__categories">
-                    {categories?.map(([category, categoryInfo]) =>
-                        <mi-chip
-                            icon={categoryInfo.iconUrl}
-                            content={categoryInfo.displayName}
-                            active={selectedCategory === category}
-                            onClick={() => categoryClicked(category)}
-                            key={category}>
-                        </mi-chip>
-                    )
-                    }
-                </div>
+                {categories.length > 0 &&
+                    <div ref={categoriesListRef} className="search__categories">
+                        {categories?.map(([category, categoryInfo]) =>
+                            <mi-chip
+                                icon={categoryInfo.iconUrl}
+                                content={categoryInfo.displayName}
+                                active={selectedCategory === category}
+                                onClick={() => categoryClicked(category)}
+                                key={category}>
+                            </mi-chip>
+                        )}
+                    </div>}
                 <div className="search__results">
                     {showNotFoundMessage && <p>Nothing was found</p>}
                     {searchResults.map(location =>
@@ -180,7 +194,7 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize, c
                     )}
                 </div>
             </div>
-        </div>
+        </div >
     )
 }
 

--- a/packages/map-template/src/components/Search/Search.jsx
+++ b/packages/map-template/src/components/Search/Search.jsx
@@ -197,7 +197,7 @@ function Search({ onLocationClick, categories, onLocationsFiltered, onSetSize, c
                     </div>
                 }
             </div>
-        </div >
+        </div>
     )
 }
 

--- a/packages/map-template/src/components/Search/Search.scss
+++ b/packages/map-template/src/components/Search/Search.scss
@@ -1,24 +1,14 @@
 @import '../../variables.scss';
 
 .search {
-    padding: var(--spacing-large) var(--spacing-x-small) var(--spacing-x-small) var(--spacing-x-small);
+    padding: var(--spacing-medium);
     display: grid;
-    gap: var(--spacing-x-small);
     grid-auto-rows: min-content;
     overflow: auto;
-
-    &--with-categories {
-        min-height: 144px;
-    }
-
-    &--no-categories {
-        min-height: 99px;
-    }
 
     &__scrollable {
         overflow: auto;
         display: grid;
-        gap: var(--spacing-x-small);
     }
 
     &__categories {
@@ -27,6 +17,7 @@
         gap: var(--spacing-x-small);
         overflow: auto hidden;
         grid-auto-columns: min-content;
+        margin-top: var(--spacing-x-small);
     }
 
     &__results {
@@ -34,9 +25,14 @@
         gap: var(--spacing-x-small);
         overflow: auto;
         grid-auto-rows: min-content;
+        margin-top: var(--spacing-x-small);
 
         p {
             text-align: center;
         }
+    }
+
+    @media (max-width: $desktop-breakpoint) {
+        padding: var(--spacing-medium) var(--spacing-x-small) var(--spacing-medium) var(--spacing-x-small);
     }
 }

--- a/packages/map-template/src/components/Search/Search.scss
+++ b/packages/map-template/src/components/Search/Search.scss
@@ -6,7 +6,14 @@
     gap: var(--spacing-x-small);
     grid-auto-rows: min-content;
     overflow: auto;
-    min-height: 144px;
+
+    &--with-categories {
+        min-height: 144px;
+    }
+
+    &--no-categories {
+        min-height: 99px;
+    }
 
     &__scrollable {
         overflow: auto;


### PR DESCRIPTION
# What 
- Resize the search view when no categories are shown 

# How 
- Add a check if the preferredSizeSnapPoint is undefined and do not set the height of the sheet if that is the case
- Conditionally render the categories if they exist 
- Adjust the styles and the heights of the elements in order to fit the view they need to be rendered in