### PR TITLE
Calculate width of location text based on closing button

### DIFF
--- a/packages/map-template/src/components/Directions/Directions.scss
+++ b/packages/map-template/src/components/Directions/Directions.scss
@@ -21,7 +21,7 @@
         display: grid;
         gap: var(--spacing-medium);
         position: relative;
-        width: fit-content;
+        width: calc(100% - 36px);
     }
 
     &__container {


### PR DESCRIPTION
# What 
- Fix issue of closing button not being clickable due to long location name 

# How 
- Calculate the width of the locations info and subtract the width of the closing button in order to avoid overlapping content 