### PR TITLE
Add support for "startZoomLevel" to take priority over "locationId" 

### DIFF
--- a/packages/map-template/src/components/Map/Map.jsx
+++ b/packages/map-template/src/components/Map/Map.jsx
@@ -131,10 +131,14 @@ function Map({ apiKey, gmApiKey, mapboxAccessToken, venues, venueName, onLocatio
 
                     // Check if the solution allows the zoom level to be 22.
                     // If yes, set the zoom level to 22, otherwise set it to 21.
-                    mapsindoors.services.SolutionsService.getSolution().then(solution => {
-                        const hasZoom22 = Object.values(solution.modules).find(zoomLevel => zoomLevel === 'z22')
-                        miInstance?.setZoom(hasZoom22 ? 22 : 21);
-                    });
+                    if (startZoomLevel) {
+                        miInstance?.setZoom(startZoomLevel);
+                    } else {
+                        mapsindoors.services.SolutionsService.getSolution().then(solution => {
+                            const hasZoom22 = Object.values(solution.modules).find(zoomLevel => zoomLevel === 'z22')
+                            miInstance?.setZoom(hasZoom22 ? 22 : 21);
+                        });
+                    }
                 }
             });
         }


### PR DESCRIPTION
# What 
- Add support for the `startZoomLevel` to take priority over the `locationId` when present 

# How
- Add a check for the existence of the `startZoomLevel` when zooming into the `locationId`
- If `startZoomLevel` is present, then the map should not zoom to the max zoom level on the selected location