### PR TITLE
Show error message on the search page

### DIFF
--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2023-06-14
+
+### Fixed
+
+- Fixed showing error message when no results are found.
+
 ## [1.3.0] - 2023-06-12
 
 ### Added

--- a/packages/map-template/src/components/Search/Search.jsx
+++ b/packages/map-template/src/components/Search/Search.jsx
@@ -176,9 +176,9 @@ function Search({ onLocationClick, onSetSize }) {
                             </mi-chip>
                         )}
                     </div>}
+                {showNotFoundMessage && <p className="search__error">Nothing was found</p>}
                 {searchResults.length > 0 &&
                     <div className="search__results">
-                        {showNotFoundMessage && <p>Nothing was found</p>}
                         {searchResults.map(location =>
                             <ListItemLocation
                                 key={location.id}

--- a/packages/map-template/src/components/Search/Search.scss
+++ b/packages/map-template/src/components/Search/Search.scss
@@ -20,16 +20,16 @@
         margin-top: var(--spacing-x-small);
     }
 
+    &__error {
+        text-align: center;
+    }
+
     &__results {
         display: grid;
         gap: var(--spacing-x-small);
         overflow: auto;
         grid-auto-rows: min-content;
         margin-top: var(--spacing-x-small);
-
-        p {
-            text-align: center;
-        }
     }
 
     @media (max-width: $desktop-breakpoint) {


### PR DESCRIPTION
# What 
- Show the error message when no results are found on the search page 

# How 
- Move the error message outside of the search results list container, which is conditioned to be shown only when having search results 