### PR TITLE
Add "deploy-to-gcloud" script

### DIFF
--- a/packages/map-template/.github/README.md
+++ b/packages/map-template/.github/README.md
@@ -87,3 +87,13 @@ At this point you can upload the files manually to your bucket, or use the helpf
 ```zsh
 $ gsutil -m -h "Cache-Control:public, max-age=0, no-store, no-cache" cp -r build gs://YOUR_BUCKET_NAME
 ```
+
+### Using the `deploy-to-gcloud` npm script
+
+To make this even easier (mostly for ourselves), there's a `deploy-to-gcloud` script. It takes one argument which is the bucket name, and is used like this:
+
+```
+$ npm run deploy-to-gcloud -- BUCKET_NAME
+```
+
+This script will only work if you've already authenticated using the `gsutil` CLI on your machine, and have the proper access rights to deploy to the specified bucket.

--- a/packages/map-template/deploy-to-gcloud.sh
+++ b/packages/map-template/deploy-to-gcloud.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+if [ $# -eq 0 ]; then
+    echo "Please provide a bucket name like so:"
+    echo "'npm run deploy-to-gcloud -- BUCKET_NAME'"
+    echo ""
+    exit 1
+fi
+
+npx lerna run build
+vite build --base=/$1
+cd build
+gsutil -m -h "Cache-Control:public, max-age=0, no-store, no-cache" cp -r . gs://$1

--- a/packages/map-template/package.json
+++ b/packages/map-template/package.json
@@ -42,7 +42,8 @@
     "build-for-npm": "node releaseTools/buildForNpm.mjs",
     "serve": "vite preview",
     "test": "",
-    "release": "sh ./release.sh"
+    "release": "sh ./release.sh",
+    "deploy-to-gcloud": "sh ./deploy-to-gcloud.sh"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
To test this, run the following commands in a shell:

```
$ cd package/map-template
$ npm run deploy-to-gcloud
```

This will fail, because no argument is given.

In the same folder:

```
$ npm run deploy-to-gcloud -- BUCKET_NAME
```

If you have the rights to deploy to that bucket, it will succeed. If not, it will fail.