### PR TITLE
MIAJS-1740: Add parameter to not show External ID on list-item-location Web Component

### DIFF
--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -294,7 +294,7 @@ export namespace Components {
          */
         "iconBadge": string;
         /**
-          * @description The value of the badge
+          * @description The value of the badge.
           * @type {string} For availability, use "true" or "false".
          */
         "iconBadgeValue": string;
@@ -1557,7 +1557,7 @@ declare namespace LocalJSX {
          */
         "iconBadge"?: string;
         /**
-          * @description The value of the badge
+          * @description The value of the badge.
           * @type {string} For availability, use "true" or "false".
          */
         "iconBadgeValue"?: string;

--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -280,6 +280,10 @@ export namespace Components {
     }
     interface MiListItemLocation {
         /**
+          * Whether to show the External ID.
+         */
+        "hideExternalID": boolean;
+        /**
           * @description Optional URL to icon to render for the Location. If not set, imageURL on the Location data will be used.
           * @type {string}
          */
@@ -344,6 +348,10 @@ export namespace Components {
     };
     }
     interface MiLocationInfo {
+        /**
+          * @description Whether to show the External ID.
+         */
+        "hideExternalID": boolean;
         /**
           * @description Location object.
          */
@@ -1535,6 +1543,10 @@ declare namespace LocalJSX {
     }
     interface MiListItemLocation {
         /**
+          * Whether to show the External ID.
+         */
+        "hideExternalID"?: boolean;
+        /**
           * @description Optional URL to icon to render for the Location. If not set, imageURL on the Location data will be used.
           * @type {string}
          */
@@ -1631,6 +1643,10 @@ declare namespace LocalJSX {
     };
     }
     interface MiLocationInfo {
+        /**
+          * @description Whether to show the External ID.
+         */
+        "hideExternalID"?: boolean;
         /**
           * @description Location object.
          */

--- a/packages/components/src/components/list-item-location/list-item-location.tsx
+++ b/packages/components/src/components/list-item-location/list-item-location.tsx
@@ -51,7 +51,7 @@ export class ListItemLocation {
     }
 
     /**
-     * @description The value of the badge
+     * @description The value of the badge.
      * @type {string} For availability, use "true" or "false".
      */
     @Prop() iconBadgeValue: string;
@@ -81,6 +81,8 @@ export class ListItemLocation {
     private iconDisplaySize = parseInt(midtIcon.icon.size.medium.value);
 
     /**
+     * Emits the location to event listeners.
+     *
      * @description Emits the location to event listeners.
      * @param {*} location - Location object.
      * @memberof List
@@ -89,11 +91,17 @@ export class ListItemLocation {
         this.locationClicked.emit(location);
     }
 
+    /**
+     * Called once just after the component is first connected to the DOM.
+     */
     componentWillLoad(): void {
         this.iconURLToRender = this.icon ? this.icon : this.location?.properties.imageURL;
         this.updateBadge();
     }
 
+    /**
+     * Called after every render().
+     */
     componentDidRender(): void {
         if (!this.location) {
             return;
@@ -109,7 +117,7 @@ export class ListItemLocation {
     }
 
     /**
-     * Apply badge to location icon
+     * Apply badge to location icon.
      */
     updateBadge(): void {
         if (this.iconBadge && this.iconBadgeValue && this.iconURLToRender) {
@@ -118,6 +126,8 @@ export class ListItemLocation {
     }
 
     /**
+     * Set image as background image.
+     *
      * @description Set image as background image.
      * @param {HTMLImageElement} image
      */
@@ -171,6 +181,7 @@ export class ListItemLocation {
 
     /**
      * Create and return an Image from URL.
+     *
      * @param {string} url
      * @returns {Image}
      */
@@ -191,6 +202,8 @@ export class ListItemLocation {
     }
 
     /**
+     * Render location list-item.
+     *
      * @description Render location list-item.
      * @returns {JSX.Element}
      */
@@ -210,6 +223,8 @@ export class ListItemLocation {
     }
 
     /**
+     * Get JSX template for icon.
+     *
      * @description Get JSX template for icon.
      * @returns {JSX.Element}
      */
@@ -223,6 +238,8 @@ export class ListItemLocation {
     }
 
     /**
+     * Get JSX template for distance.
+     *
      * @description Get JSX template for distance.
      * @returns {JSX.Element}
      */

--- a/packages/components/src/components/list-item-location/list-item-location.tsx
+++ b/packages/components/src/components/list-item-location/list-item-location.tsx
@@ -18,6 +18,11 @@ export class ListItemLocation {
     @Prop() location;
 
     /**
+     * Whether to show the External ID.
+     */
+    @Prop() hideExternalID: boolean = false;
+
+    /**
      * @description Set imperial or metric as unit for distance.
      * @type {UnitSystem}
      */
@@ -196,7 +201,7 @@ export class ListItemLocation {
 
                 <div class="details">
                     <p class="details-title">{this.location.properties.name}</p>
-                    <mi-location-info ref={(el) => this.infoElement = el as HTMLMiLocationInfoElement}></mi-location-info>
+                    <mi-location-info ref={(el) => this.infoElement = el as HTMLMiLocationInfoElement} hideExternalID={this.hideExternalID}></mi-location-info>
                 </div>
 
                 {this.location.properties.geodesicDistance && this.renderDistance()}

--- a/packages/components/src/components/list-item-location/readme.md
+++ b/packages/components/src/components/list-item-location/readme.md
@@ -13,6 +13,7 @@ Working example:
         .then(location => {
             location.properties.imageURL = 'https://app.mapsindoors.com/mapsindoors/cms/assets/icons/building-icons/hall.png';
             document.querySelector('mi-list-item-location').location = location;
+            document.querySelector('mi-list-item-location').hideExternalID = false;
         });
 </script>
 
@@ -28,12 +29,17 @@ Example usage:
     .then(location => {
         location.properties.imageURL = 'https://app.mapsindoors.com/mapsindoors/cms/assets/icons/building-icons/hall.png';
         document.querySelector('mi-list-item-location').location = location;
+        document.querySelector('mi-list-item-location').hideExternalID = false;
     });
 ```
 
 ## `location` attribute
 
 A `location` attribute is available on the `<mi-list-item-location>` element, which should be used to set the MapsIndoors Location to display information for. The attribute is required.
+
+## `hideExternalID` event
+
+If true, the component will not show the location's Extrenal ID. The attribute is not required.
 
 ## `unit` attribute
 
@@ -75,13 +81,14 @@ A `listItemDidRender` event is emitted from the `<mi-list-item-location>` elemen
 
 ## Properties
 
-| Property         | Attribute          | Description | Type                                       | Default     |
-| ---------------- | ------------------ | ----------- | ------------------------------------------ | ----------- |
-| `icon`           | `icon`             |             | `string`                                   | `undefined` |
-| `iconBadge`      | `icon-badge`       |             | `string`                                   | `undefined` |
-| `iconBadgeValue` | `icon-badge-value` |             | `string`                                   | `undefined` |
-| `location`       | `location`         |             | `any`                                      | `undefined` |
-| `unit`           | `unit`             |             | `UnitSystem.Imperial \| UnitSystem.Metric` | `undefined` |
+| Property         | Attribute           | Description                      | Type                                       | Default     |
+| ---------------- | ------------------- | -------------------------------- | ------------------------------------------ | ----------- |
+| `hideExternalID` | `hide-external-i-d` | Whether to show the External ID. | `boolean`                                  | `false`     |
+| `icon`           | `icon`              |                                  | `string`                                   | `undefined` |
+| `iconBadge`      | `icon-badge`        |                                  | `string`                                   | `undefined` |
+| `iconBadgeValue` | `icon-badge-value`  |                                  | `string`                                   | `undefined` |
+| `location`       | `location`          |                                  | `any`                                      | `undefined` |
+| `unit`           | `unit`              |                                  | `UnitSystem.Imperial \| UnitSystem.Metric` | `undefined` |
 
 
 ## Events

--- a/packages/components/src/components/list-item-location/test.html
+++ b/packages/components/src/components/list-item-location/test.html
@@ -61,8 +61,8 @@ You can change the MapsIndoors apiKey in start of the script below
     <hr />
 
     <script>
-        const apiKey = 'demo'; // <----- set MapsIndoors API key here
-        document.querySelector('input[name="locationId"]').setAttribute('value', '337006664e044df99916054c');
+        const apiKey = '7315b5a1de3a42f0b379d782'; // <----- set MapsIndoors API key here
+        document.querySelector('input[name="locationId"]').setAttribute('value', '0ffc4d9737d5475e86d392b4');
 
         mapsindoors.MapsIndoors.setMapsIndoorsApiKey(apiKey);
 
@@ -71,6 +71,7 @@ You can change the MapsIndoors apiKey in start of the script below
 
             const listItemLocationComponent = document.createElement('mi-list-item-location');
             listItemLocationComponent.location = location;
+            listItemLocationComponent.hideExternalID = true;
 
             if (unit) {
                 listItemLocationComponent.setAttribute('unit', unit);

--- a/packages/components/src/components/location-info/location-info.tsx
+++ b/packages/components/src/components/location-info/location-info.tsx
@@ -13,6 +13,11 @@ export class LocationInfo implements ComponentInterface {
     @Prop() location;
 
     /**
+     * @description Whether to show the External ID.
+     */
+    @Prop() hideExternalID: boolean = false;
+
+    /**
      * Get locations info as a string.
      * @returns {string}
      */
@@ -20,7 +25,7 @@ export class LocationInfo implements ComponentInterface {
         const details = [];
 
         // External Id
-        if (this.location.properties.externalId) {
+        if (this.location.properties.externalId && !this.hideExternalID) {
             details.push(this.location.properties.externalId);
         }
         // Floor name

--- a/packages/components/src/components/location-info/location-info.tsx
+++ b/packages/components/src/components/location-info/location-info.tsx
@@ -19,6 +19,7 @@ export class LocationInfo implements ComponentInterface {
 
     /**
      * Get locations info as a string.
+     *
      * @returns {string}
      */
     getInfoString(): string {
@@ -56,6 +57,12 @@ export class LocationInfo implements ComponentInterface {
         return details.join(' · ');
     }
 
+    /**
+     * Render location list-info.
+     *
+     * @description Render location list-info.
+     * @returns {JSX.Element}
+     */
     render(): JSX.Element {
         return (
             this.location?.properties ? this.getInfoString() : null

--- a/packages/components/src/components/location-info/readme.md
+++ b/packages/components/src/components/location-info/readme.md
@@ -16,6 +16,7 @@ const mockLocation = {
     }
 }
 locationInfoComponent.location = mockLocation;
+locationInfoComponent.hideExternalID = false;
 </script>
 
 Example usage:
@@ -39,11 +40,16 @@ const mockLocation = {
     }
 }
 locationInfoComponent.location = mockLocation;
+locationInfoComponent.hideExternalID = false;
 ```
 
 ## `location` attribute
 
 A `location` attribute is available on the `<mi-location-info>` element which should be used to pass a MapsIndoors `Location`. When the `Building` and `Venue` names is alike only the name of the `Venue` is displayed. The attribute is required.
+
+## `hideExternalID` event
+
+If true, the component will not show the location's Extrenal ID. The attribute is not required.
 
 <!-- markdownlint-disable -->
 <!-- Auto Generated Below -->
@@ -51,9 +57,10 @@ A `location` attribute is available on the `<mi-location-info>` element which sh
 
 ## Properties
 
-| Property   | Attribute  | Description | Type  | Default     |
-| ---------- | ---------- | ----------- | ----- | ----------- |
-| `location` | `location` |             | `any` | `undefined` |
+| Property         | Attribute           | Description | Type      | Default     |
+| ---------------- | ------------------- | ----------- | --------- | ----------- |
+| `hideExternalID` | `hide-external-i-d` |             | `boolean` | `false`     |
+| `location`       | `location`          |             | `any`     | `undefined` |
 
 
 ----------------------------------------------


### PR DESCRIPTION
_It would be helpful if there was some handle on this component that may show the external ID by default, but has some parameters that can determine to not show it if set to false._

I added a not required `@Prop()` to the `list-item-location` component called `hideExternalID` - I set the default value to be `false`. The component passes this value to the `location-info` component where the `@Prop()` is also not required and also has the default value of `false`. With this property I extended the check for displaying/hiding the info about the location's external id.

I also did some minor clean-ups for the JSDoc.