### PR TITLE
Copy correct build path

### DIFF
--- a/packages/map-template/.github/README.md
+++ b/packages/map-template/.github/README.md
@@ -85,7 +85,7 @@ $ npx vite build --base=/YOUR_BUCKET_NAME
 At this point you can upload the files manually to your bucket, or use the helpful CLI [`gsutil`](https://cloud.google.com/storage/docs/gsutil) for the purpose. This command uploads the complete `build` folder, and prevents the files from being cached:
 
 ```zsh
-$ gsutil -m -h "Cache-Control:public, max-age=0, no-store, no-cache" cp -r ./build gs://YOUR_BUCKET_NAME
+$ gsutil -m -h "Cache-Control:public, max-age=0, no-store, no-cache" cp -r build/* gs://YOUR_BUCKET_NAME
 ```
 
 ### Using the `deploy-to-gcloud` npm script

--- a/packages/map-template/deploy-to-gcloud.sh
+++ b/packages/map-template/deploy-to-gcloud.sh
@@ -8,5 +8,4 @@ fi
 
 npx lerna run build
 vite build --base=/$1
-cd build
-gsutil -m -h "Cache-Control:public, max-age=0, no-store, no-cache" cp -r . gs://$1
+gsutil -m -h "Cache-Control:public, max-age=0, no-store, no-cache" cp -r build/* gs://$1


### PR DESCRIPTION
Reading up on the docs for `gsutil`'s `cp` function, the change now uploads the contents correctly.