### PR TITLE
Fix visibility of multiple modals 

### DIFF
--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.2] - 2023-07-03
+
+### Fixed
+
+- Fixed visibility of multiple modals.
+
 ## [1.4.1] - 2023-07-03
 
 ### Fixed

--- a/packages/map-template/src/components/Sidebar/Modal/Modal.scss
+++ b/packages/map-template/src/components/Sidebar/Modal/Modal.scss
@@ -11,9 +11,11 @@
     max-height: 80%; // UX spec
     min-height: fit-content;
     overflow: auto;
+    display: none;
 
     &--open {
         transform: translateY(0);
+        display: block;
     }
 
     &--full {


### PR DESCRIPTION
# What 
- Fix visibility of multiple modals shown at the same time.

# How 
- Use the css `display` property in order to only show the active modal. 