### PR TITLE
Change error message on the Wayfinding page

### DIFF
--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.3] - 2023-07-04
+
+### Fixed
+
+- Changed error message on the Wayfinding page.
+
 ## [1.4.2] - 2023-07-03
 
 ### Fixed

--- a/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
+++ b/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
@@ -72,9 +72,6 @@ function Wayfinding({ onStartDirections, onBack, directionsToLocation, direction
     /** Indicate if search results have been found */
     const [hasSearchResults, setHasSearchResults] = useState(true);
 
-    /** Indicate if the searched route throws errors */
-    const [hasError, setHasError] = useState(false);
-
     /** Indicate if the search has been triggered */
     const [searchTriggered, setSearchTriggered] = useState(false);
 
@@ -193,7 +190,6 @@ function Wayfinding({ onStartDirections, onBack, directionsToLocation, direction
     function onSearchClicked(searchFieldIdentifier) {
         setActiveSearchField(searchFieldIdentifier);
         triggerSearch(searchFieldIdentifier);
-        setHasError(false);
         setHasFoundRoute(true);
         setHasGooglePlaces(false);
     }
@@ -207,7 +203,6 @@ function Wayfinding({ onStartDirections, onBack, directionsToLocation, direction
         setActiveSearchField(searchFieldIdentifier);
         resetSearchField(searchFieldIdentifier);
         setSearchResults([]);
-        setHasError(false);
         setHasFoundRoute(true);
         setHasGooglePlaces(false);
     }
@@ -322,7 +317,6 @@ function Wayfinding({ onStartDirections, onBack, directionsToLocation, direction
                 avoidStairs: accessibilityOn
             }).then(directionsResult => {
                 if (directionsResult && directionsResult.legs) {
-                    setHasError(false);
                     setHasFoundRoute(true);
                     // Calculate total distance and time
                     const totalDistance = directionsResult.legs.reduce((accumulator, current) => accumulator + current.distance.value, 0);
@@ -339,7 +333,7 @@ function Wayfinding({ onStartDirections, onBack, directionsToLocation, direction
                         directionsResult
                     });
                 } else {
-                    setHasError(true);
+                    setHasFoundRoute(false);
                 }
             }, () => {
                 setHasFoundRoute(false);
@@ -411,8 +405,7 @@ function Wayfinding({ onStartDirections, onBack, directionsToLocation, direction
                     </p>}
                 </div>
             </div>
-            {!hasFoundRoute && <p className="wayfinding__error">No route has been found</p>}
-            {hasError && <p className="wayfinding__error">Something went wrong. Please try again.</p>}
+            {!hasFoundRoute && <p className="wayfinding__error">No route found</p>}
             {!hasSearchResults && <p className="wayfinding__error">Nothing was found</p>}
             {searchResults.length > 0 &&
                 <div className="wayfinding__scrollable" {...scrollableContentSwipePrevent}>
@@ -427,7 +420,7 @@ function Wayfinding({ onStartDirections, onBack, directionsToLocation, direction
                         {hasGooglePlaces && <img className="wayfinding__google" alt="Powered by Google" src={GooglePlaces} />}
                     </div>
                 </div>}
-            {!searchTriggered && hasFoundRoute && !hasError && originLocation && destinationLocation && <div className={`wayfinding__details`} ref={detailsRef}>
+            {!searchTriggered && hasFoundRoute && originLocation && destinationLocation && <div className={`wayfinding__details`} ref={detailsRef}>
                 <div className="wayfinding__settings">
                     <div className="wayfinding__accessibility">
                         <input className="mi-toggle" type="checkbox" checked={accessibilityOn} onChange={e => setAccessibilityOn(e.target.checked)} style={{backgroundColor: accessibilityOn ? primaryColor : ''}}/>


### PR DESCRIPTION
# What 
- Change error message on the wayfinding page.

# How 
- Remove the error state and only show the `No route found` error message in both scenarios.