### PR TITLE
My position button is sometimes hidden behind floor selector

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.7.2] - 2023-07-11
+
+### Fixed
+
+- **mi-my-position** is now positioned according to the normal flow of the document .
+
 ## [13.7.1] - 2023-07-06
 
 ### Fixed

--- a/packages/components/src/components/my-position/my-position.scss
+++ b/packages/components/src/components/my-position/my-position.scss
@@ -7,7 +7,6 @@
     margin: 10px;
     display: flex;
     flex-direction: column;
-    position: absolute;
     pointer-events: auto;
     gap: 16px;
     right: 0;


### PR DESCRIPTION
# What
The `mi-my-position` button is hard to style and is sometimes hiding behind other elements - most often behind the `mi-floor-selector`.

# How
I removed the `position: absolute` styling from this component.