### PR TITLE
Replace mapsindoors global variable

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [13.7.2] - 2023-07-11
+## [13.8.1] - 2023-07-11
 
 ### Fixed
 

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.1] - 2023-07-11
+
+### Fixed
+
+- Replace mapsindoors global variable.
+
 ## [1.7.0] - 2023-07-11
 
 ### Added

--- a/packages/map-template/src/components/Directions/Directions.jsx
+++ b/packages/map-template/src/components/Directions/Directions.jsx
@@ -14,8 +14,6 @@ import { travelModes } from "../../constants/travelModes";
 import directionsResponseState from "../../atoms/directionsResponseState";
 import activeStepState from "../../atoms/activeStep";
 
-const mapsindoors = window.mapsindoors;
-
 let directionsRenderer;
 
 /**
@@ -59,7 +57,7 @@ function Directions({ isOpen, onBack }) {
             directionsRenderer?.setRoute(null);
             directionsRenderer = null;
 
-            directionsRenderer = new mapsindoors.directions.DirectionsRenderer({
+            directionsRenderer = new window.mapsindoors.directions.DirectionsRenderer({
                 mapsIndoors: mapsIndoorsInstance,
                 fitBoundsPadding: {
                     top: padding,

--- a/packages/map-template/src/components/Search/Search.jsx
+++ b/packages/map-template/src/components/Search/Search.jsx
@@ -10,9 +10,6 @@ import SearchField from '../WebComponentWrappers/Search/Search';
 import filteredLocationsState from '../../atoms/filteredLocationsState';
 import primaryColorState from '../../atoms/primaryColorState';
 
-/** Initialize the MapsIndoors instance. */
-const mapsindoors = window.mapsindoors;
-
 /**
  * Show the search results.
  *
@@ -55,7 +52,7 @@ function Search({ onLocationClick, onSetSize }) {
      * @param {string} category
      */
     function getFilteredLocations(category) {
-        mapsindoors.services.LocationsService.getLocations({
+        window.mapsindoors.services.LocationsService.getLocations({
             categories: category,
         }).then(onResults);
     }

--- a/packages/map-template/src/helpers/SetMapZoomLevel.js
+++ b/packages/map-template/src/helpers/SetMapZoomLevel.js
@@ -1,11 +1,9 @@
-const mapsindoors = window.mapsindoors;
-
 /**
  * Check if the solution allows the zoom level to be 22.
  * If yes, set the zoom level to 22, otherwise set it to 21.
  */
 export default function setMapZoomLevel(mapsIndoorsInstance) {
-    return mapsindoors.services.SolutionsService.getSolution().then(solution => {
+    return window.mapsindoors.services.SolutionsService.getSolution().then(solution => {
         const hasZoom22 = Object.values(solution.modules).find(zoomLevel => zoomLevel === 'z22')
         mapsIndoorsInstance?.setZoom(hasZoom22 ? 22 : 21);
     });

--- a/packages/map-template/src/hooks/useLocationForWayfinding.js
+++ b/packages/map-template/src/hooks/useLocationForWayfinding.js
@@ -4,9 +4,6 @@ import userPositionState from '../atoms/userPositionState';
 import positionControlState from '../atoms/positionControlState';
 import generateMyPositionLocation from '../helpers/MyPositionLocation';
 
-const mapsindoors = window.mapsindoors;
-
-
 /**
  * Hook for a Location that can be both a MapsIndoors Location or a GeoJSON feature
  * that contains the user's position.
@@ -26,7 +23,7 @@ const useLocationForWayfinding = (locationID) => {
                 setLocation('USER_POSITION_PENDING');
                 positionControl.watchPosition();
             } else if (locationID !== 'USER_POSITION') {
-                mapsindoors.services.LocationsService.getLocation(locationID)
+                window.mapsindoors.services.LocationsService.getLocation(locationID)
                     .then(mapsIndoorsLocation => setLocation(mapsIndoorsLocation));
             }
 


### PR DESCRIPTION
# What 
- Replace mapsindoors global variable

# Why 
- A previous merge which took care of loading the MapsIndoors JS SDK if not available changed the way we use the mapsindoors, and we had to replace the instances where the global variable was used. Some of the instances were not changed and therefore threw errors 

# How 
- Remove all the global variables for the `window.mapsindoors`