### PR TITLE
Hide floor selector when directions are open

### DIFF
--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.3] - 2023-08-01
+
+### Fixed
+
+- Fixed Floor Selector visibility on the Directions mode.
+
 ## [1.8.2] - 2023-08-01
 
 ### Fixed

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.scss
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.scss
@@ -13,7 +13,7 @@
     }
 
     &--show-elements {
-        .mapsindoors.floor-selector {
+        mi-floor-selector {
             display: block;
         }
 
@@ -23,7 +23,7 @@
     }
 
     &--hide-elements {
-        .mapsindoors.floor-selector {
+        mi-floor-selector {
             display: none;
         }
 
@@ -44,12 +44,6 @@
 
     #mi_map_logo {
         z-index: var(--z-index-dropdown) !important;
-    }
-
-    .floor-selector {
-        max-height: 346px; // UX Spec
-        overflow-y: auto;
-        overflow-x: hidden;
     }
 }
 


### PR DESCRIPTION
# What 
- Hide floor selector when directions are open

# How
- Due to the refactoring of the floor selector in the SDK, the class has been changed from `floor-selector` to `mi-floor-selector`, therefore the styling has been lost because the SCSS file has not been updated with the new class 