### PR TITLE
Fix scrollable list on Safari

### DIFF
--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.2] - 2023-08-01
+
+### Fixed
+
+- Fixed search results not being scrollable on Safari. 
+
 ## [1.8.1] - 2023-08-01
 
 ### Fixed

--- a/packages/map-template/src/components/Sidebar/Modal/Modal.scss
+++ b/packages/map-template/src/components/Sidebar/Modal/Modal.scss
@@ -9,7 +9,6 @@
     background: var(--color-white-white);
     transform: translateY(calc(100% + var(--spacing-large)));
     max-height: 80%; // UX spec
-    min-height: fit-content;
     overflow: auto;
     display: none;
 


### PR DESCRIPTION
# What 
- Fix scrollable list not respecting the height on Safari

# How 
- Remove the `min-height` property from the modal, which Safari interprets differently than other browsers
- Tested it on other browsers as well and it works as intended