### PR TITLE
MIAJS-1748 feature/matb: Add 'Level' word translation

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.9.0] - 2023-07-25
+
+### Added
+
+- **mi-location-info** now supports translation of the word 'Level'.
+
 ## [13.8.1] - 2023-07-11
 
 ### Fixed

--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -360,6 +360,10 @@ export namespace Components {
     }
     interface MiLocationInfo {
         /**
+          * @description Level info.
+         */
+        "level": string;
+        /**
           * @description Location object.
          */
         "location": any;
@@ -1698,6 +1702,10 @@ declare namespace LocalJSX {
     };
     }
     interface MiLocationInfo {
+        /**
+          * @description Level info.
+         */
+        "level"?: string;
         /**
           * @description Location object.
          */

--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -360,7 +360,7 @@ export namespace Components {
     }
     interface MiLocationInfo {
         /**
-          * @description Level info.
+          * @description The word used for "Level" when showing level info. Default is "Level".
          */
         "level": string;
         /**
@@ -1703,7 +1703,7 @@ declare namespace LocalJSX {
     }
     interface MiLocationInfo {
         /**
-          * @description Level info.
+          * @description The word used for "Level" when showing level info. Default is "Level".
          */
         "level"?: string;
         /**

--- a/packages/components/src/components/location-info/location-info.tsx
+++ b/packages/components/src/components/location-info/location-info.tsx
@@ -13,6 +13,11 @@ export class LocationInfo implements ComponentInterface {
     @Prop() location;
 
     /**
+     * @description Level info.
+     */
+    @Prop() level: string = 'Level';
+
+    /**
      * @description Whether to show the External ID.
      */
     @Prop() showExternalId: boolean = true;
@@ -31,7 +36,7 @@ export class LocationInfo implements ComponentInterface {
         }
         // Floor name
         if (this.location.properties.floorName) {
-            details.push(`Level ${this.location.properties.floorName}`);
+            details.push(`${this.level} ${this.location.properties.floorName}`);
         }
         // Building
         if (this.location.properties.building) {
@@ -58,6 +63,8 @@ export class LocationInfo implements ComponentInterface {
     }
 
     /**
+     * Renders location list-info.
+     *
      * @description Render location list-info.
      * @returns {JSX.Element}
      */

--- a/packages/components/src/components/location-info/location-info.tsx
+++ b/packages/components/src/components/location-info/location-info.tsx
@@ -13,7 +13,7 @@ export class LocationInfo implements ComponentInterface {
     @Prop() location;
 
     /**
-     * @description Level.
+     * @description Location's level property that can by translatable for specific languages. By default level value is 'Level'.
      */
     @Prop() level: string = 'Level';
 

--- a/packages/components/src/components/location-info/location-info.tsx
+++ b/packages/components/src/components/location-info/location-info.tsx
@@ -13,7 +13,7 @@ export class LocationInfo implements ComponentInterface {
     @Prop() location;
 
     /**
-     * @description Level info.
+     * @description Level.
      */
     @Prop() level: string = 'Level';
 

--- a/packages/components/src/components/location-info/location-info.tsx
+++ b/packages/components/src/components/location-info/location-info.tsx
@@ -13,7 +13,7 @@ export class LocationInfo implements ComponentInterface {
     @Prop() location;
 
     /**
-     * @description Location's level property that can by translatable for specific languages. By default level value is 'Level'.
+     * @description The word used for "Level" when showing level info. Default is "Level".
      */
     @Prop() level: string = 'Level';
 

--- a/packages/components/src/components/location-info/readme.md
+++ b/packages/components/src/components/location-info/readme.md
@@ -59,6 +59,7 @@ If false, the component will not show the location's Extrenal ID. The attribute 
 
 | Property         | Attribute          | Description | Type      | Default     |
 | ---------------- | ------------------ | ----------- | --------- | ----------- |
+| `level`          | `level`            |             | `string`  | `'Level'`   |
 | `location`       | `location`         |             | `any`     | `undefined` |
 | `showExternalId` | `show-external-id` |             | `boolean` | `true`      |
 


### PR DESCRIPTION
I created a property with default value of 'Level'.
When we bind to it inside kiosk we will pipe it through translation for languages that we support with translations.