### PR TITLE
Substeps timing issue when going back from last step.

### DIFF
--- a/packages/map-template/src/components/Directions/Directions.jsx
+++ b/packages/map-template/src/components/Directions/Directions.jsx
@@ -139,6 +139,15 @@ function Directions({ isOpen, onBack, onSetSize, snapPointSwiped }) {
         }
     }
 
+    /**
+     * Trigger to directions renderer to fit the map to the current directions step.
+     */
+    function onFitCurrentDirections() {
+        if (directionsRenderer) {
+            directionsRenderer.setStepIndex(directionsRenderer.getStepIndex(), directionsRenderer.getLegIndex());
+        }
+    }
+
     // FIXME: investigate if we can handle the height and width with hooks
     /**
      * Get bottom padding for directions on mobile.
@@ -280,6 +289,7 @@ function Directions({ isOpen, onBack, onSetSize, snapPointSwiped }) {
                     onNextStep={() => onNext()}
                     isOpen={isOpen}
                     onPreviousStep={() => onPrevious()}
+                    onFitCurrentDirections={() => onFitCurrentDirections()}
                 >
                 </RouteInstructions>
             </div>


### PR DESCRIPTION
refactor: move away from storing map center and zoom level in order to reset bounds when going back from destination step. Instead, trigger the SDK to refit the bounds.