### PR TITLE
Remove error message when My Position is selected

### DIFF
--- a/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
+++ b/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
@@ -180,6 +180,7 @@ function Wayfinding({ onStartDirections, onBack, directionsToLocation, direction
         fromFieldRef.current.setDisplayText(myPositionLocation.properties.name);
         setOriginLocation(myPositionLocation);
         setHasFoundRoute(true);
+        setHasSearchResults(true);
     }
 
     /**
@@ -205,6 +206,7 @@ function Wayfinding({ onStartDirections, onBack, directionsToLocation, direction
         setSearchResults([]);
         setHasFoundRoute(true);
         setHasGooglePlaces(false);
+        setHasSearchResults(true);
     }
 
     /**


### PR DESCRIPTION
# What 
- Fix error message not disappearing after selecting My Position as origin location.

# How 
- Set the useState `setHasSearchResults` to true when selecting the My Position as origin location and when clearing the search field.