### PR TITLE
Highlight with mouse should not close dropdown

### DIFF
--- a/packages/components/src/components/combo-box/combo-box.tsx
+++ b/packages/components/src/components/combo-box/combo-box.tsx
@@ -137,7 +137,7 @@ export class ComboBox {
      * @param {ev} ev
      */
     @Listen('mousedown', { target: 'window' })
-    clearSelectionOnClick(ev) {
+    clearSelectionOnMouseDown(ev) {
         if (!this.hostElement.contains(ev.target) && ev.target !== this.svgButtonToggleDropdown) {
             window.getSelection().empty();
         }

--- a/packages/components/src/components/combo-box/combo-box.tsx
+++ b/packages/components/src/components/combo-box/combo-box.tsx
@@ -496,7 +496,6 @@ export class ComboBox {
         return (
             <Host class={{ 'open': this.open }}>
                 <input
-                    id='comboBoxInputField'
                     type="text"
                     class="input"
                     onFocus={(event) => this.onClickExists(event)}


### PR DESCRIPTION
The scope of this task is to prevent dropdown to close when highlighting content inside input field, while mouse click is released outside the input field.

**How does it look like now:**

https://github.com/MapsPeople/web-ui/assets/56337591/08c51df1-b3bb-448a-b47a-29ee4a63887e

My implementation proposition:

Inside `checkForClickOutside()`:
- I created couple of consts: for listening clicks inside hostElement or inside canvas (map), also const that checks if anything inside an input is highlighted with mouse.
- Then I made if checks.

I tried to be descriptive with JSDocs, but let me know if you have any questions.

**My implementation in action:**

https://github.com/MapsPeople/web-ui/assets/56337591/85e96e8a-5772-49ef-8bfd-eab12d3d39b0


