### PR TITLE
Fix startZoomLevel property not working on Google Maps

### DIFF
--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.2] - 2023-08-03
+
+### Fixed
+
+- Fixed `startZoomLevel` query parameter not working on Google Maps.
+
 ## [1.9.1] - 2023-08-03
 
 ### Fixed

--- a/packages/map-template/src/components/Map/Map.jsx
+++ b/packages/map-template/src/components/Map/Map.jsx
@@ -109,7 +109,7 @@ function Map({ onLocationClick, onVenueChangedOnMap }) {
         return mapsIndoorsInstance.fitVenue(venue).then(() => {
             // Set the map zoom level if the property is provided.
             if (startZoomLevel) {
-                mapsIndoorsInstance.setZoom(startZoomLevel);
+                mapsIndoorsInstance.setZoom(parseInt(startZoomLevel));
             }
         });
     }


### PR DESCRIPTION
# What 
- Fix `startZoomLevel` property not working on Google Maps

# Why 
- The use of `startZoomLevel` on a Google Maps map was not working and it threw the error: `InvalidValueError: setZoom: not a number`

# How 
- After some investigation on the error that was being thrown, I converted the `startZoomLevel` value into an integer when setting the zoom of the map using the `parseInt()` method.