### PR TITLE
Add support for Google Maps Map ID prop

### DIFF
--- a/packages/map-template/.github/README.md
+++ b/packages/map-template/.github/README.md
@@ -74,7 +74,8 @@ When loading the MapsIndoors Map component for the first time, the map will resp
 |`externalIDs`|`array`|Array of external IDs which filters the map and shows a list of locations. Because of the way browsers work, you can not use External IDs with the `,`, `&`, `#` and `+`, character in them, as they are interpreted by the browser in a particular way. |
 |`tileStyle`|`string`|Name of Tile Style to display on the map. |
 |`startZoomLevel`|`number`|The initial zoom level of the map. |
-|`supports-url-parameters`|`supportsUrlParameters`|`bool`|Indicates if the Map Template supports URL parameters. |
+|`supportsUrlParameters`|`bool`|Indicates if the Map Template supports URL parameters. |
+|`gmMapId`|`string`|The map ID associated with a specific map style or feature. |
 
 ## Using Query Parameters
 

--- a/packages/map-template/.github/README.md
+++ b/packages/map-template/.github/README.md
@@ -95,8 +95,10 @@ The supported query parameters are the following:
 11. `mapboxAccessToken` - Used like this `mapboxAccessToken=yourMapboxAccessToken`. If both the `mapboxAccessToken` and the `gmApiKey` are present, the app will load a Mapbox map.  
 12. `gmApiKey` - Used like this `gmApiKey=yourGmApiKey`. If both the `mapboxAccessToken` and the `gmApiKey` are present, the app will load a Mapbox map.  
 13. `startZoomLevel` - Used like this `startZoomLevel=22`.  
+14. `gmMapId` - Used like this `gmMapId=yourGmMapId`.  
 
-**Note!** All the query parameters need to be separated with the `&` symbol, without any spaces in between. Note! When using parameters such as `directionsTo`, `directionsFrom`, `locationId`, `externalIDs`, and `tileStyle` make sure you are using the correct `apiKey` parameter to which they belong.
+**Note!** All the query parameters need to be separated with the `&` symbol, without any spaces in between. **Note!** When using parameters such as `directionsTo`, `directionsFrom`, `locationId`, `externalIDs`, and `tileStyle` make sure you are using the correct `apiKey` parameter to which they belong.
+**Note!** When using the `gmMapId` property, you need to use it together with the `gmApiKey` that it is associated with.
 
 Example of URL:
 

--- a/packages/map-template/.github/README.md
+++ b/packages/map-template/.github/README.md
@@ -75,7 +75,7 @@ When loading the MapsIndoors Map component for the first time, the map will resp
 |`tileStyle`|`string`|Name of Tile Style to display on the map. |
 |`startZoomLevel`|`number`|The initial zoom level of the map. |
 |`supportsUrlParameters`|`bool`|Indicates if the Map Template supports URL parameters. |
-|`gmMapId`|`string`|The map ID associated with a specific map style or feature. |
+|`gmMapId`|`string`|The Google Maps Map ID associated with a specific map style or feature. |
 
 ## Using Query Parameters
 

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.0] - 2023-08-24
+
+### Added
+
+- Added support for Google Maps Map ID prop.
+
 ## [1.11.2] - 2023-08-23
 
 ### Fixed

--- a/packages/map-template/README.md
+++ b/packages/map-template/README.md
@@ -126,6 +126,7 @@ Note that when using the React component, the properties should conform to JSX p
 |`tile-style`|`tileStyle`|`string`|Name of Tile Style to display on the map. |
 |`start-zoom-level`|`startZoomLevel`|`number`|The initial zoom level of the map. |
 |`supports-url-parameters`|`supportsUrlParameters`|`bool`|Indicates if the Map Template supports URL parameters. |
+|`gm-map-id`|`gmMapId`|`string`|The map ID associated with a specific map style or feature. |
 
 ## Using Query Parameters
 

--- a/packages/map-template/README.md
+++ b/packages/map-template/README.md
@@ -126,7 +126,7 @@ Note that when using the React component, the properties should conform to JSX p
 |`tile-style`|`tileStyle`|`string`|Name of Tile Style to display on the map. |
 |`start-zoom-level`|`startZoomLevel`|`number`|The initial zoom level of the map. |
 |`supports-url-parameters`|`supportsUrlParameters`|`bool`|Indicates if the Map Template supports URL parameters. |
-|`gm-map-id`|`gmMapId`|`string`|The map ID associated with a specific map style or feature. |
+|`gm-map-id`|`gmMapId`|`string`|The Google Maps Map ID associated with a specific map style or feature. |
 
 ## Using Query Parameters
 

--- a/packages/map-template/README.md
+++ b/packages/map-template/README.md
@@ -146,8 +146,10 @@ The supported query parameters are the following:
 11. `mapboxAccessToken` - Used like this `mapboxAccessToken=yourMapboxAccessToken`. If both the `mapboxAccessToken` and the `gmApiKey` are present, the app will load a Mapbox map.  
 12. `gmApiKey` - Used like this `gmApiKey=yourGmApiKey`. If both the `mapboxAccessToken` and the `gmApiKey` are present, the app will load a Mapbox map.  
 13. `startZoomLevel` - Used like this `startZoomLevel=22`.  
+14. `gmMapId` - Used like this `gmMapId=yourGmMapId`.  
 
-**Note!** All the query parameters need to be separated with the `&` symbol, without any spaces in between. Note! When using parameters such as `directionsTo`, `directionsFrom`, `locationId`, `externalIDs`, and `tileStyle` make sure you are using the correct `apiKey` parameter to which they belong.
+**Note!** All the query parameters need to be separated with the `&` symbol, without any spaces in between. **Note!** When using parameters such as `directionsTo`, `directionsFrom`, `locationId`, `externalIDs`, and `tileStyle` make sure you are using the correct `apiKey` parameter to which they belong.
+**Note!** When using the `gmMapId` property, you need to use it together with the `gmApiKey` that it is associated with.
 
 Example of URL:
 

--- a/packages/map-template/releaseTools/webcomponent.js
+++ b/packages/map-template/releaseTools/webcomponent.js
@@ -21,8 +21,9 @@ MapsIndoorsMap.propTypes = {
     directionsTo: PropTypes.string,
     externalIDs: PropTypes.array,
     tileStyle: PropTypes.string,
-    startZoomLevel: PropTypes.number, 
-    supportsUrlParameters: PropTypes.bool
+    startZoomLevel: PropTypes.number,
+    supportsUrlParameters: PropTypes.bool,
+    gmMapId: PropTypes.string,
 };
 
 const WebMapsIndoorsMap = reactToWebComponent(MapsIndoorsMap, React, ReactDOM);

--- a/packages/map-template/releaseTools/webcomponent.js
+++ b/packages/map-template/releaseTools/webcomponent.js
@@ -22,8 +22,8 @@ MapsIndoorsMap.propTypes = {
     externalIDs: PropTypes.array,
     tileStyle: PropTypes.string,
     startZoomLevel: PropTypes.number,
-    supportsUrlParameters: PropTypes.bool,
     gmMapId: PropTypes.string,
+    supportsUrlParameters: PropTypes.bool,
 };
 
 const WebMapsIndoorsMap = reactToWebComponent(MapsIndoorsMap, React, ReactDOM);

--- a/packages/map-template/src/atoms/gmMapIdState.js
+++ b/packages/map-template/src/atoms/gmMapIdState.js
@@ -1,0 +1,8 @@
+import { atom } from 'recoil';
+
+const gmMapIdState = atom({
+    key: 'gmMapId',
+    default: null
+});
+
+export default gmMapIdState;

--- a/packages/map-template/src/components/Map/GoogleMapsMap/GoogleMapsMap.jsx
+++ b/packages/map-template/src/components/Map/GoogleMapsMap/GoogleMapsMap.jsx
@@ -4,6 +4,7 @@ import mapsIndoorsInstanceState from '../../../atoms/mapsIndoorsInstanceState';
 import { Loader as GoogleMapsApiLoader } from '@googlemaps/js-api-loader';
 import gmApiKeyState from '../../../atoms/gmApiKeyState';
 import primaryColorState from '../../../atoms/primaryColorState';
+import gmMapIdState from '../../../atoms/gmMapIdState';
 
 /**
  * Takes care of instantiating a MapsIndoors Google Maps MapView.
@@ -15,6 +16,7 @@ import primaryColorState from '../../../atoms/primaryColorState';
 function GoogleMapsMap({ onMapView, onPositionControl }) {
 
     const gmApiKey = useRecoilValue(gmApiKeyState);
+    const gmMapId = useRecoilValue(gmMapIdState);
     const [google, setGoogle] = useState();
     const [mapView, setMapView] = useState();
     const [hasFloorSelector, setHasFloorSelector] = useState(false);
@@ -39,7 +41,8 @@ function GoogleMapsMap({ onMapView, onPositionControl }) {
                 // Always set a center so the map so the bounds or center can be read from the start.
                 center: { lat: 0, lng: 0 },
                 // Set a large zoom so we prevent a "zoom 0 glitch" (showing the whole globe temporarily)
-                zoom: 21
+                zoom: 21, 
+                mapId: gmMapId
             };
 
             const mapViewInstance = new window.mapsindoors.mapView.GoogleMapsView(mapViewOptions);

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -26,6 +26,7 @@ import filteredLocationsByExternalIDState from '../../atoms/filteredLocationsByE
 import startZoomLevelState from '../../atoms/startZoomLevelState';
 import primaryColorState from '../../atoms/primaryColorState';
 import logoState from '../../atoms/logoState';
+import gmMapIdState from '../../atoms/gmMapIdState';
 
 defineCustomElements();
 
@@ -45,8 +46,9 @@ defineCustomElements();
  * @param {array} [props.externalIDs] - Filter locations shown on the map based on the external IDs.
  * @param {string} [props.tileStyle] - Tile style name to change the interface of the map.
  * @param {number} [props.startZoomLevel] - The initial zoom level of the map.
+ * @param {string} [props.gmMapId] - The map ID associated with a specific map style or feature.
  */
-function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, primaryColor, logo, appUserRoles, directionsFrom, directionsTo, externalIDs, tileStyle, startZoomLevel }) {
+function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, primaryColor, logo, appUserRoles, directionsFrom, directionsTo, externalIDs, tileStyle, startZoomLevel, gmMapId }) {
 
     const [, setApiKey] = useRecoilState(apiKeyState);
     const [, setGmApyKey] = useRecoilState(gmApiKeyState);
@@ -59,6 +61,7 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
     const [, setLocationId] = useRecoilState(locationIdState);
     const [, setPrimaryColor] = useRecoilState(primaryColorState);
     const [, setLogo] = useRecoilState(logoState);
+    const [, setGmMapId] = useRecoilState(gmMapIdState);
 
     const directionsFromLocation = useLocationForWayfinding(directionsFrom);
     const directionsToLocation = useLocationForWayfinding(directionsTo);
@@ -204,7 +207,14 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
         }
     }, [locationId, mapsindoorsSDKAvailable]);
 
-
+    /*
+     * React to changes in the gmMapId prop.
+     */
+    useEffect(() => {
+        if (mapsindoorsSDKAvailable) {
+            setGmMapId(gmMapId);
+        }
+    }, [gmMapId, mapsindoorsSDKAvailable]);
 
     /*
      * Add Location to history payload to make it possible to re-enter location details with that Location.

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -46,7 +46,7 @@ defineCustomElements();
  * @param {array} [props.externalIDs] - Filter locations shown on the map based on the external IDs.
  * @param {string} [props.tileStyle] - Tile style name to change the interface of the map.
  * @param {number} [props.startZoomLevel] - The initial zoom level of the map.
- * @param {string} [props.gmMapId] - The map ID associated with a specific map style or feature.
+ * @param {string} [props.gmMapId] - The Google Maps Map ID associated with a specific map style or feature.
  */
 function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, primaryColor, logo, appUserRoles, directionsFrom, directionsTo, externalIDs, tileStyle, startZoomLevel, gmMapId }) {
 

--- a/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
+++ b/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
@@ -19,8 +19,8 @@ import defaultLogo from "../../assets/logo.svg";
  * @param {array} [props.externalIDs] - Filter locations shown on the map based on the external IDs.
  * @param {string} [props.tileStyle] - Tile style name to change the interface of the map.
  * @param {number} [props.startZoomLevel] - The initial zoom level of the map.
- * @param {string} [props.gmMapId] - The map ID associated with a specific map style or feature.
  * @param {boolean} [props.supportsUrlParameters] - If you want to support URL Parameters to configure the Map Template.
+ * @param {string} [props.gmMapId] - The Google Maps Map ID associated with a specific map style or feature.
  */
 function MapsIndoorsMap(props) {
 

--- a/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
+++ b/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
@@ -19,6 +19,7 @@ import defaultLogo from "../../assets/logo.svg";
  * @param {array} [props.externalIDs] - Filter locations shown on the map based on the external IDs.
  * @param {string} [props.tileStyle] - Tile style name to change the interface of the map.
  * @param {number} [props.startZoomLevel] - The initial zoom level of the map.
+ * @param {string} [props.gmMapId] - The map ID associated with a specific map style or feature.
  * @param {boolean} [props.supportsUrlParameters] - If you want to support URL Parameters to configure the Map Template.
  */
 function MapsIndoorsMap(props) {
@@ -54,6 +55,7 @@ function MapsIndoorsMap(props) {
         const primaryColorQueryParameter = queryStringParams.get('primaryColor'); // use without '#'. It will be prepended.
         const appUserRolesQueryParameter = queryStringParams.get('appUserRoles')?.split(',');
         const externalIDsQueryParameter = queryStringParams.get('externalIDs')?.split(',');
+        const gmMapIdQueryParameter = queryStringParams.get('gmMapId');
 
         setMapTemplateProps({
             apiKey: props.supportsUrlParameters && apiKeyQueryParameter ? apiKeyQueryParameter : (props.apiKey || defaultProps.apiKey),
@@ -68,7 +70,8 @@ function MapsIndoorsMap(props) {
             mapboxAccessToken: props.supportsUrlParameters && mapboxAccessTokenQueryParameter ? mapboxAccessTokenQueryParameter : props.mapboxAccessToken,
             primaryColor: props.supportsUrlParameters && primaryColorQueryParameter ? '#' + primaryColorQueryParameter : (props.primaryColor || defaultProps.primaryColor),
             appUserRoles: props.supportsUrlParameters && appUserRolesQueryParameter ? appUserRolesQueryParameter : props.appUserRoles,
-            externalIDs: props.supportsUrlParameters && externalIDsQueryParameter ? externalIDsQueryParameter : props.externalIDs
+            externalIDs: props.supportsUrlParameters && externalIDsQueryParameter ? externalIDsQueryParameter : props.externalIDs, 
+            gmMapId: props.supportsUrlParameters && gmMapIdQueryParameter ? gmMapIdQueryParameter : props.gmMapId
         });
     }, [props]);
 


### PR DESCRIPTION
# What 

- Add support for Google Maps Map ID prop

# How 

- Pass the new `gmMapId` prop to the `GoogleMapsMap.jsx` inside the `mapViewOptions` object