### PR TITLE
Refactor usage of clear function on localStorage

### DIFF
--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.3] - 2023-09-11
+
+### Fixed
+
+- Fixed wrong usage of clear function on localStorage.
+
 ## [1.12.2] - 2023-09-04
 
 ### Fixed

--- a/packages/map-template/src/components/Map/Map.jsx
+++ b/packages/map-template/src/components/Map/Map.jsx
@@ -72,7 +72,7 @@ function Map({ onLocationClick, onVenueChangedOnMap }) {
      */
     useEffect(() => {
         if (mapsIndoorsInstance) {
-            window.localStorage.clear(localStorageKeyForVenue);
+            window.localStorage.removeItem(localStorageKeyForVenue);
             const venueToShow = getVenueToShow(venueName, venues);
             if (venueToShow && !locationId) {
                 setVenue(venueToShow, mapsIndoorsInstance).then(() => {


### PR DESCRIPTION
# What 

- Refactor usage of `clear` function on localStorage

# How

- Use the `removeItem` function instead of the `clear` function