### PR TITLE
Fix bottom sheet not being fully visible 

### DIFF
--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.2] - 2023-10-05
+
+### Fixed
+
+- Fixed bottom sheet not being fully visible on mobile devices.
+
 ## [1.14.1] - 2023-09-28
 
 ### Fixed

--- a/packages/map-template/README.md
+++ b/packages/map-template/README.md
@@ -21,7 +21,7 @@ In your styles make sure to give it a size. For example:
 mapsindoors-map {
     display: block;
     width: 100vw;
-    height: 100vh;
+    height: 100svh;
 }
 ```
 
@@ -67,7 +67,7 @@ Use query parameters to configure the Web Component by setting the `supports-url
         mapsindoors-map {
             display: block;
             width: 100vw;
-            height: 100vh;
+            height: 100svh;
         }
     </style>
 </head>
@@ -97,7 +97,7 @@ import MapsIndoorsMap from '@mapsindoors/map-template@stable/dist/mapsindoors-re
 <div style={{
       display: 'block',
       width: '100vw',
-      height: '100vh'
+      height: '100svh'
 }}>
       <MapsIndoorsMap></MapsIndoorsMap>
 </div>

--- a/packages/map-template/src/components/BottomSheet/BottomSheet.scss
+++ b/packages/map-template/src/components/BottomSheet/BottomSheet.scss
@@ -4,4 +4,5 @@
     inset: 0;
     z-index: var(--z-index-overlay);
     overflow: hidden;
+    padding-bottom: env(safe-area-inset-bottom);
 }

--- a/packages/map-template/src/components/BottomSheet/BottomSheet.scss
+++ b/packages/map-template/src/components/BottomSheet/BottomSheet.scss
@@ -4,5 +4,4 @@
     inset: 0;
     z-index: var(--z-index-overlay);
     overflow: hidden;
-    padding-bottom: env(safe-area-inset-bottom);
 }

--- a/packages/map-template/src/index.css
+++ b/packages/map-template/src/index.css
@@ -21,5 +21,5 @@ code {
 
 #root {
   width: 100%;
-  height: 100%;
+  height: 100svh;
 }


### PR DESCRIPTION
# What 

- Fix bottom sheet not being fully visible when running on a deployed version

# How 

- Use a new CSS property called `svh` instead of `vh` which takes the smallest viewport height 