### PR TITLE
Feature/build web component into one file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22827,7 +22827,7 @@
     },
     "packages/components": {
       "name": "@mapsindoors/components",
-      "version": "13.11.1",
+      "version": "13.14.0",
       "license": "MIT",
       "dependencies": {
         "@11ty/eleventy": "^2.0.0",
@@ -22867,7 +22867,7 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.14.1",
+      "version": "1.17.0",
       "dependencies": {
         "@turf/turf": "^6.5.0"
       },
@@ -22892,6 +22892,7 @@
         "recoil": "^0.7.7",
         "sass": "^1.57.1",
         "standard-version": "^9.5.0",
+        "uuid": "^9.0.1",
         "vite": "^4.3.4",
         "vite-plugin-css-injected-by-js": "^3.1.0",
         "vite-plugin-eslint": "^1.8.1",
@@ -22909,6 +22910,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.17.1] - 2023-11-15
+
+### Fixed
+
+- Bundling the exported Web Component into one file instead of several chunks.
+- Fix missing possibility to test the Web Component locally.
+
 ## [1.17.0] - 2023-11-06
 
 ### Added
@@ -15,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed floor selector not updating when exiting directions.
-- Fixed floor selector not updating when selecting a location on a different floor. 
+- Fixed floor selector not updating when selecting a location on a different floor.
 
 ## [1.16.0] - 2023-10-09
 
@@ -87,7 +94,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Upgrade to MapsIndoors JavaScript SDK v4.24.6. 
+- Upgrade to MapsIndoors JavaScript SDK v4.24.6.
 
 ## [1.11.1] - 2023-08-17
 
@@ -129,7 +136,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed error message appearing in weird states on Google Maps. 
+- Fixed error message appearing in weird states on Google Maps.
 
 ## [1.9.0] - 2023-08-01
 
@@ -147,7 +154,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed search results not being scrollable on Safari. 
+- Fixed search results not being scrollable on Safari.
 
 ## [1.8.1] - 2023-08-01
 

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -9,8 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Bundling the exported Web Component into one file instead of several chunks.
-- Fix missing possibility to test the Web Component locally.
+- Bundling the exported Web Component into one file instead of several chunks to mitigate slow loading times when using the Web Component.
 
 ## [1.17.0] - 2023-11-06
 

--- a/packages/map-template/releaseTools/buildForNpm.mjs
+++ b/packages/map-template/releaseTools/buildForNpm.mjs
@@ -19,6 +19,12 @@ const libraries = [
                 formats: ['es', 'umd']
             },
             emptyOutDir: false,
+            rollupOptions: {
+                output: {
+                    manualChunks: false,
+                    inlineDynamicImports: true
+                }
+            }
         },
         plugins: [
             cssInjectedByJsPlugin()

--- a/packages/tests/README.md
+++ b/packages/tests/README.md
@@ -1,0 +1,14 @@
+# MapsIndoors Web UI Tests
+
+## `web-component`
+
+Use a locally built Map Template Web Component on a simple HTML page.
+
+### Running it
+
+The page requires the web component to be built in the Map Template package:
+
+1. From within the `packages/map-template` folder, run `npm run build-for-npm`.
+2. In the file `packages/tests/web-component/index.html` configure the Map Template Web Component, `<mapsindoors-map />` with the props that you want (access tokens, API keys etc.).
+3. From within the `packages/tests/web-component` folder, serve the HTML file by running `npm run dev`.
+4. Open `http://localhost:3000` in your browser.

--- a/packages/tests/web-component/index.html
+++ b/packages/tests/web-component/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MapsIndoors Map Template</title>
+    <script type="module">
+        import MapsindoorsMap from 'http://localhost:3002/mapsindoors-webcomponent.es.js';
+        window.customElements.define('mapsindoors-map', MapsindoorsMap)
+    </script>
+    <style>
+        body {
+            margin: 0;
+        }
+        mapsindoors-map {
+            display: block;
+            width: 100vw;
+            height: 100svh;
+        }
+    </style>
+</head>
+<body>
+    <mapsindoors-map></mapsindoors-map>
+</body>
+</html>

--- a/packages/tests/web-component/package.json
+++ b/packages/tests/web-component/package.json
@@ -1,0 +1,17 @@
+{
+    "name": "webcomponent",
+    "version": "1.0.0",
+    "private": true,
+    "description": "Test setup for testing the Map Template Web Component locally.",
+    "main": "index.js",
+    "scripts": {
+      "dev": "npx serve . -p 3000 & npx serve ../../map-template/dist -p 3002 --cors",
+      "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "keywords": [],
+    "author": "",
+    "license": "ISC",
+    "devDependencies": {
+      "serve": "*"
+    }
+  }


### PR DESCRIPTION
# What

- When building the Map Template as web component distribution files, bundle all files together in one. This is done to reduce the number of HTTP requests needed to run the Map Template as a Web Component.
- Made it possible to test the Map Template web component locally.

# How

- In the Rollup config, disable making chunks.
- Expose a new monorepo package, tests, which for now has a test HTML page for the locally built Map Template web component.