### PR TITLE
Implement kioskOriginLocationId prop

### DIFF
--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.18.0] - 2023-11-17
+
+### Added
+
+- Added support for having `kioskOriginLocationId` property.
+- Adjust UI to center the sidebar based on the `kioskOriginLocationId` property.
+
 ## [1.17.1] - 2023-11-15
 
 ### Fixed

--- a/packages/map-template/releaseTools/webcomponent.js
+++ b/packages/map-template/releaseTools/webcomponent.js
@@ -26,6 +26,7 @@ MapsIndoorsMap.propTypes = {
     supportsUrlParameters: PropTypes.bool,
     bearing: PropTypes.number,
     pitch: PropTypes.number,
+    kioskOriginLocationId: PropTypes.string
 };
 
 const WebMapsIndoorsMap = reactToWebComponent(MapsIndoorsMap, React, ReactDOM);

--- a/packages/map-template/src/atoms/currentKioskLocationState.js
+++ b/packages/map-template/src/atoms/currentKioskLocationState.js
@@ -1,8 +1,0 @@
-import { atom } from 'recoil';
-
-const currentKioskLocationState = atom({
-    key: 'currentKioskLocation',
-    default: null
-});
-
-export default currentKioskLocationState;

--- a/packages/map-template/src/atoms/currentKioskLocationState.js
+++ b/packages/map-template/src/atoms/currentKioskLocationState.js
@@ -1,0 +1,8 @@
+import { atom } from 'recoil';
+
+const currentKioskLocationState = atom({
+    key: 'currentKioskLocation',
+    default: null
+});
+
+export default currentKioskLocationState;

--- a/packages/map-template/src/atoms/kioskOriginLocationIdState.js
+++ b/packages/map-template/src/atoms/kioskOriginLocationIdState.js
@@ -1,0 +1,8 @@
+import { atom } from 'recoil';
+
+const kioskOriginLocationIdState = atom({
+    key: 'kioskOriginLocationId',
+    default: null
+});
+
+export default kioskOriginLocationIdState;

--- a/packages/map-template/src/components/Directions/Directions.jsx
+++ b/packages/map-template/src/components/Directions/Directions.jsx
@@ -15,8 +15,8 @@ import directionsResponseState from "../../atoms/directionsResponseState";
 import activeStepState from "../../atoms/activeStep";
 import { snapPoints } from "../../constants/snapPoints";
 import substepsToggledState from "../../atoms/substepsToggledState";
-import getDesktopPadding from "../../helpers/GetDesktopPadding";
-import getMobilePadding from "../../helpers/GetMobilePadding";
+import getDesktopPaddingLeft from "../../helpers/GetDesktopPaddingLeft";
+import getMobilePaddingBottom from "../../helpers/GetMobilePaddingBottom";
 
 let directionsRenderer;
 
@@ -71,8 +71,8 @@ function Directions({ isOpen, onBack, onSetSize, snapPointSwiped }) {
                 mapsIndoors: mapsIndoorsInstance,
                 fitBoundsPadding: {
                     top: padding,
-                    bottom: isDesktop ? padding : getMobilePadding(),
-                    left: isDesktop ? getDesktopPadding() : padding,
+                    bottom: isDesktop ? padding : getMobilePaddingBottom(),
+                    left: isDesktop ? getDesktopPaddingLeft() : padding,
                     right: padding
                 }
             });

--- a/packages/map-template/src/components/Map/Map.jsx
+++ b/packages/map-template/src/components/Map/Map.jsx
@@ -91,7 +91,7 @@ function Map({ onLocationClick, onVenueChangedOnMap }) {
         if (mapsIndoorsInstance) {
             window.localStorage.removeItem(localStorageKeyForVenue);
             const venueToShow = getVenueToShow(venueName, venues);
-            if (venueToShow && !isLocationClicked) {
+            if (venueToShow && !isLocationClicked && !locationId && !kioskOriginLocationId) {
                 setVenue(venueToShow, mapsIndoorsInstance).then(() => {
                     onVenueChangedOnMap(venueToShow);
                 });
@@ -209,7 +209,7 @@ function Map({ onLocationClick, onVenueChangedOnMap }) {
         setDirectionsService(directionsService);
 
         const venueToShow = getVenueToShow(venueName, venues);
-        if (venueToShow) {
+        if (venueToShow && !locationId && !kioskOriginLocationId) {
             setVenue(venueToShow, miInstance);
         }
     };

--- a/packages/map-template/src/components/Map/Map.jsx
+++ b/packages/map-template/src/components/Map/Map.jsx
@@ -23,12 +23,11 @@ import bearingState from '../../atoms/bearingState';
 import pitchState from '../../atoms/pitchState';
 import isLocationClickedState from "../../atoms/isLocationClickedState";
 import kioskOriginLocationIdState from "../../atoms/kioskOriginLocationIdState";
-import currentKioskLocationState from "../../atoms/currentKioskLocationState";
 import fitBoundsLocation from "../../helpers/fitBoundsLocation";
 import useMediaQuery from "../../hooks/useMediaQuery";
 import isMapReadyState from "../../atoms/isMapReadyState";
-import getMobilePaddingBottom from "../../helpers/GetMobilePaddingBottom";
 import getDesktopPaddingLeft from "../../helpers/GetDesktopPaddingLeft";
+import getDesktopPaddingBottom from "../../helpers/GetDesktopPaddingBottom";
 
 const localStorageKeyForVenue = 'MI-MAP-TEMPLATE-LAST-VENUE';
 
@@ -66,7 +65,6 @@ function Map({ onLocationClick, onVenueChangedOnMap }) {
     const locationId = useRecoilValue(locationIdState);
     const isLocationClicked = useRecoilValue(isLocationClickedState);
     const kioskOriginLocationId = useRecoilValue(kioskOriginLocationIdState);
-    const [, setCurrentKioskLocation] = useRecoilState(currentKioskLocationState);
 
     const isMapReady = useRecoilValue(isMapReadyState);
 
@@ -254,8 +252,6 @@ function Map({ onLocationClick, onVenueChangedOnMap }) {
             if (kioskOriginLocationId && isDesktop) {
                 window.mapsindoors.services.LocationsService.getLocation(kioskOriginLocationId).then(kioskOriginLocation => {
                     if (kioskOriginLocation) {
-                        setCurrentKioskLocation(kioskOriginLocation);
-
                         // Replace icon with "you are here" icon
                         const displayRule = mapsIndoorsInstance.getDisplayRule(kioskOriginLocation);
 
@@ -270,7 +266,7 @@ function Map({ onLocationClick, onVenueChangedOnMap }) {
                         const locationFloor = kioskOriginLocation.properties.floor;
                         mapsIndoorsInstance.setFloor(locationFloor);
 
-                        fitBoundsLocation(kioskOriginLocation, mapsIndoorsInstance, getMobilePaddingBottom(), 0);
+                        fitBoundsLocation(kioskOriginLocation, mapsIndoorsInstance, getDesktopPaddingBottom(), 0);
                     }
                 });
             } else if (locationId) {

--- a/packages/map-template/src/components/Map/Map.jsx
+++ b/packages/map-template/src/components/Map/Map.jsx
@@ -28,6 +28,7 @@ import useMediaQuery from "../../hooks/useMediaQuery";
 import isMapReadyState from "../../atoms/isMapReadyState";
 import getDesktopPaddingLeft from "../../helpers/GetDesktopPaddingLeft";
 import getDesktopPaddingBottom from "../../helpers/GetDesktopPaddingBottom";
+import getMobilePaddingBottom from "../../helpers/GetMobilePaddingBottom";
 
 const localStorageKeyForVenue = 'MI-MAP-TEMPLATE-LAST-VENUE';
 
@@ -245,14 +246,17 @@ function Map({ onLocationClick, onVenueChangedOnMap }) {
     }, [tileStyle]);
 
     /*
-    * React on changes in the kioskOriginLocationId and locationId.
-    */
+     * React on changes in the kioskOriginLocationId and locationId.
+     */
     useEffect(() => {
         if (isMapReady && mapsIndoorsInstance) {
+            // If kioskOriginLocationId prop is present, set the display rule for the kiosk location.
+            // Set the icon size representing the kiosk to be double the size.
+            // Set the floor based on the floor that the kiosk is located on.
+            // Fit the map to the kiosk location bounds and add the padding calculated based on the modal.
             if (kioskOriginLocationId && isDesktop) {
                 window.mapsindoors.services.LocationsService.getLocation(kioskOriginLocationId).then(kioskOriginLocation => {
                     if (kioskOriginLocation) {
-                        // Replace icon with "you are here" icon
                         const displayRule = mapsIndoorsInstance.getDisplayRule(kioskOriginLocation);
 
                         displayRule.visible = true;
@@ -276,11 +280,11 @@ function Map({ onLocationClick, onVenueChangedOnMap }) {
                         const locationFloor = location.properties.floor;
                         mapsIndoorsInstance.setFloor(locationFloor);
 
-                        fitBoundsLocation(location, mapsIndoorsInstance, 0, getDesktopPaddingLeft());
+                        // Fit the map to the location bounds and add the padding calculated based on the modal.
+                        fitBoundsLocation(location, mapsIndoorsInstance, isDesktop ? 0 : getMobilePaddingBottom(), isDesktop ? getDesktopPaddingLeft() : 0);
                     }
                 });
             }
-
         }
     }, [kioskOriginLocationId, locationId, isMapReady]);
 

--- a/packages/map-template/src/components/Map/Map.jsx
+++ b/packages/map-template/src/components/Map/Map.jsx
@@ -288,7 +288,6 @@ function Map({ onLocationClick, onVenueChangedOnMap }) {
         }
     }, [kioskOriginLocationId, locationId, isMapReady]);
 
-
     return (<>
         {mapType === mapTypes.Google && <GoogleMapsMap onMapView={onMapView} onPositionControl={onPositionControlCreated} />}
         {mapType === mapTypes.Mapbox && <MapboxMap onMapView={onMapView} onPositionControl={onPositionControlCreated} />}

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -338,9 +338,9 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
     }
 
     /**
-     * Handle the clicked location on the map.
-     * Set the current location if not in directions mode,
-     * and if the clicked location is not the same as the kioskOriginLocationId.
+     * Handle the clicked location on the map. Set the current location if not in directions mode.
+     * Do not set the current location if the clicked location is the same as the kioskOriginLocationId, 
+     * due to the logic of displaying directions right away when selecting a location on the map, when in kiosk mode.
      *
      * @param {object} location
      */

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -30,6 +30,8 @@ import gmMapIdState from '../../atoms/gmMapIdState';
 import bearingState from '../../atoms/bearingState';
 import pitchState from '../../atoms/pitchState';
 import mapsIndoorsInstanceState from '../../atoms/mapsIndoorsInstanceState';
+import kioskOriginLocationIdState from '../../atoms/kioskOriginLocationIdState';
+import currentKioskLocationState from '../../atoms/currentKioskLocationState';
 
 defineCustomElements();
 
@@ -52,8 +54,9 @@ defineCustomElements();
  * @param {number} [props.bearing] - The bearing of the map as a number. Not recommended for Google Maps with 2D Models.
  * @param {number} [props.pitch] - The pitch of the map as a number. Not recommended for Google Maps with 2D Models.
  * @param {string} [props.gmMapId] - The Google Maps Map ID associated with a specific map style or feature.
+ * @param {string} [props.kioskOriginLocationId] - If running the Map Template as a kiosk, provide the Location ID that represents the location of the kiosk.
  */
-function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, primaryColor, logo, appUserRoles, directionsFrom, directionsTo, externalIDs, tileStyle, startZoomLevel, bearing, pitch, gmMapId }) {
+function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, primaryColor, logo, appUserRoles, directionsFrom, directionsTo, externalIDs, tileStyle, startZoomLevel, bearing, pitch, gmMapId, kioskOriginLocationId }) {
 
     const [, setApiKey] = useRecoilState(apiKeyState);
     const [, setGmApyKey] = useRecoilState(gmApiKeyState);
@@ -68,6 +71,8 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
     const [, setLogo] = useRecoilState(logoState);
     const [, setGmMapId] = useRecoilState(gmMapIdState);
     const mapsIndoorsInstance = useRecoilValue(mapsIndoorsInstanceState);
+    const [, setKioskOriginLocationId] = useRecoilState(kioskOriginLocationIdState);
+    const currentKioskLocation = useRecoilValue(currentKioskLocationState);
 
     const directionsFromLocation = useLocationForWayfinding(directionsFrom);
     const directionsToLocation = useLocationForWayfinding(directionsTo);
@@ -296,7 +301,7 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
     }, [logo]);
 
     useEffect(() => {
-        if (currentLocation) {
+        if (currentLocation && currentLocation.id !== currentKioskLocation.id) {
             if (mapsIndoorsInstance?.selectLocation) {
                 mapsIndoorsInstance.selectLocation(currentLocation);
             }
@@ -306,6 +311,17 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
             }
         }
     }, [currentLocation]);
+
+    /*
+     * React on changes to the kioskOriginLocationId prop.
+     */
+    useEffect(() => {
+        if (mapsindoorsSDKAvailable) {
+            if (kioskOriginLocationId) {
+                setKioskOriginLocationId(kioskOriginLocationId);
+            }
+        }
+    }, [kioskOriginLocationId, mapsindoorsSDKAvailable]);
 
     /**
      * When venue is fitted while initializing the data,

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -53,7 +53,7 @@ defineCustomElements();
  * @param {number} [props.bearing] - The bearing of the map as a number. Not recommended for Google Maps with 2D Models.
  * @param {number} [props.pitch] - The pitch of the map as a number. Not recommended for Google Maps with 2D Models.
  * @param {string} [props.gmMapId] - The Google Maps Map ID associated with a specific map style or feature.
- * @param {string} [props.kioskOriginLocationId] - If running the Map Template as a kiosk, provide the Location ID that represents the location of the kiosk.
+ * @param {string} [props.kioskOriginLocationId] - If running the Map Template as a kiosk (upcoming feature), provide the Location ID that represents the location of the kiosk.
  */
 function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, primaryColor, logo, appUserRoles, directionsFrom, directionsTo, externalIDs, tileStyle, startZoomLevel, bearing, pitch, gmMapId, kioskOriginLocationId }) {
 

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -31,7 +31,6 @@ import bearingState from '../../atoms/bearingState';
 import pitchState from '../../atoms/pitchState';
 import mapsIndoorsInstanceState from '../../atoms/mapsIndoorsInstanceState';
 import kioskOriginLocationIdState from '../../atoms/kioskOriginLocationIdState';
-import currentKioskLocationState from '../../atoms/currentKioskLocationState';
 
 defineCustomElements();
 
@@ -72,8 +71,6 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
     const [, setGmMapId] = useRecoilState(gmMapIdState);
     const mapsIndoorsInstance = useRecoilValue(mapsIndoorsInstanceState);
     const [, setKioskOriginLocationId] = useRecoilState(kioskOriginLocationIdState);
-    const currentKioskLocation = useRecoilValue(currentKioskLocationState);
-
 
     const directionsFromLocation = useLocationForWayfinding(directionsFrom);
     const directionsToLocation = useLocationForWayfinding(directionsTo);

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -74,6 +74,7 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
     const [, setKioskOriginLocationId] = useRecoilState(kioskOriginLocationIdState);
     const currentKioskLocation = useRecoilValue(currentKioskLocationState);
 
+
     const directionsFromLocation = useLocationForWayfinding(directionsFrom);
     const directionsToLocation = useLocationForWayfinding(directionsTo);
 
@@ -300,8 +301,13 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
         setLogo(logo);
     }, [logo]);
 
+
+    /*
+     * React on changes in the current location prop.
+     * Apply location selection if the current location exists and is not the same as the kioskOriginLocationId. 
+     */
     useEffect(() => {
-        if (currentLocation && currentLocation.id !== currentKioskLocation.id) {
+        if (currentLocation && currentLocation.id !== kioskOriginLocationId) {
             if (mapsIndoorsInstance?.selectLocation) {
                 mapsIndoorsInstance.selectLocation(currentLocation);
             }
@@ -336,12 +342,13 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
 
     /**
      * Handle the clicked location on the map.
-     * Set the current location if not in directions mode.
+     * Set the current location if not in directions mode,
+     * and if the clicked location is not the same as the kioskOriginLocationId.
      *
      * @param {object} location
      */
     function locationClicked(location) {
-        if (locationsDisabledRef.current !== true) {
+        if (locationsDisabledRef.current !== true && location.id !== kioskOriginLocationId) {
             setCurrentLocation(location);
         }
     }

--- a/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
+++ b/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
@@ -22,7 +22,7 @@ import defaultLogo from "../../assets/logo.svg";
  * @param {number} [props.bearing] - The bearing of the map as a number. Not recommended for Google Maps with 2D Models.
  * @param {boolean} [props.supportsUrlParameters] - If you want to support URL Parameters to configure the Map Template.
  * @param {string} [props.gmMapId] - The Google Maps Map ID associated with a specific map style or feature.
- * @param {string} [props.kioskOriginLocationId] - If running the Map Template as a kiosk, provide the Location ID that represents the location of the kiosk.
+ * @param {string} [props.kioskOriginLocationId] - If running the Map Template as a kiosk (upcoming feature), provide the Location ID that represents the location of the kiosk.
  */
 function MapsIndoorsMap(props) {
 

--- a/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
+++ b/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
@@ -22,6 +22,7 @@ import defaultLogo from "../../assets/logo.svg";
  * @param {number} [props.bearing] - The bearing of the map as a number. Not recommended for Google Maps with 2D Models.
  * @param {boolean} [props.supportsUrlParameters] - If you want to support URL Parameters to configure the Map Template.
  * @param {string} [props.gmMapId] - The Google Maps Map ID associated with a specific map style or feature.
+ * @param {string} [props.kioskOriginLocationId] - If running the Map Template as a kiosk, provide the Location ID that represents the location of the kiosk.
  */
 function MapsIndoorsMap(props) {
 
@@ -59,6 +60,7 @@ function MapsIndoorsMap(props) {
         const appUserRolesQueryParameter = queryStringParams.get('appUserRoles')?.split(',');
         const externalIDsQueryParameter = queryStringParams.get('externalIDs')?.split(',');
         const gmMapIdQueryParameter = queryStringParams.get('gmMapId');
+        const kioskOriginLocationId = queryStringParams.get('kioskOriginLocationId');
 
         setMapTemplateProps({
             apiKey: props.supportsUrlParameters && apiKeyQueryParameter ? apiKeyQueryParameter : (props.apiKey || defaultProps.apiKey),
@@ -76,7 +78,8 @@ function MapsIndoorsMap(props) {
             primaryColor: props.supportsUrlParameters && primaryColorQueryParameter ? '#' + primaryColorQueryParameter : (props.primaryColor || defaultProps.primaryColor),
             appUserRoles: props.supportsUrlParameters && appUserRolesQueryParameter ? appUserRolesQueryParameter : props.appUserRoles,
             externalIDs: props.supportsUrlParameters && externalIDsQueryParameter ? externalIDsQueryParameter : props.externalIDs, 
-            gmMapId: props.supportsUrlParameters && gmMapIdQueryParameter ? gmMapIdQueryParameter : props.gmMapId
+            gmMapId: props.supportsUrlParameters && gmMapIdQueryParameter ? gmMapIdQueryParameter : props.gmMapId, 
+            kioskOriginLocationId: props.supportsUrlParameters && kioskOriginLocationId ? kioskOriginLocationId : props.kioskOriginLocationId,
         });
     }, [props]);
 

--- a/packages/map-template/src/components/Search/Search.jsx
+++ b/packages/map-template/src/components/Search/Search.jsx
@@ -10,11 +10,11 @@ import SearchField from '../WebComponentWrappers/Search/Search';
 import filteredLocationsState from '../../atoms/filteredLocationsState';
 import primaryColorState from '../../atoms/primaryColorState';
 import mapsIndoorsInstanceState from '../../atoms/mapsIndoorsInstanceState';
-import { calculateBounds } from '../../helpers/CalculateBounds';
 import currentLocationState from '../../atoms/currentLocationState';
 import isLocationClickedState from '../../atoms/isLocationClickedState';
-import getDesktopPadding from '../../helpers/GetDesktopPadding';
 import useMediaQuery from '../../hooks/useMediaQuery';
+import fitBoundsLocation from '../../helpers/fitBoundsLocation';
+import getDesktopPaddingLeft from '../../helpers/GetDesktopPaddingLeft';
 
 /**
  * Show the search results.
@@ -187,11 +187,7 @@ function Search({ onSetSize }) {
             mapsIndoorsInstance.setFloor(locationFloor);
         }
 
-        // Calculate the location bbox
-        const locationBbox = calculateBounds(location.geometry)
-        let coordinates = { west: locationBbox[0], south: locationBbox[1], east: locationBbox[2], north: locationBbox[3] }
-        // Fit map to the bounds of the location coordinates, and add left padding
-        mapsIndoorsInstance.getMapView().fitBounds(coordinates, { top: 0, right: 0, bottom: isDesktop ? 0 : 200, left: isDesktop ? getDesktopPadding() : 0 });
+        fitBoundsLocation(location, mapsIndoorsInstance, isDesktop ? 0 : 200, isDesktop ? getDesktopPaddingLeft() : 0)
     }
 
     /*

--- a/packages/map-template/src/components/Sidebar/Modal/Modal.jsx
+++ b/packages/map-template/src/components/Sidebar/Modal/Modal.jsx
@@ -45,14 +45,7 @@ function Modal({ children, isOpen }) {
     }, [contentRef]);
 
     return <div ref={modalRef}
-        className={`modal ${isOpen ? 'modal--open' : ''} ${fullHeight ? 'modal--full' : ''} ${substeps ? 'modal--substeps' : ''}`}
-        style={{
-            left: kioskOriginLocationId ? '0' : null,
-            right: kioskOriginLocationId ? '0' : null,
-            marginLeft: kioskOriginLocationId ? 'auto' : null,
-            marginRight: kioskOriginLocationId ? 'auto' : null,
-            maxHeight: kioskOriginLocationId ? '50%' : '80%'
-        }}>
+        className={`modal ${isOpen ? 'modal--open' : ''} ${fullHeight ? 'modal--full' : ''} ${substeps ? 'modal--substeps' : ''} ${kioskOriginLocationId ? 'modal--kiosk' : ''}`}>
         <div ref={contentRef} className="modal__content">
             {children}
         </div>

--- a/packages/map-template/src/components/Sidebar/Modal/Modal.jsx
+++ b/packages/map-template/src/components/Sidebar/Modal/Modal.jsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import substepsToggledState from '../../../atoms/substepsToggledState';
 import './Modal.scss';
+import kioskOriginLocationIdState from '../../../atoms/kioskOriginLocationIdState';
 
 /**
  * A Modal for showing content in the Sidebar.
@@ -18,6 +19,8 @@ function Modal({ children, isOpen }) {
     const [fullHeight, setFullHeight] = useState(false);
 
     const substeps = useRecoilValue(substepsToggledState);
+
+    const kioskOriginLocationId = useRecoilValue(kioskOriginLocationIdState);
 
     const modalRef = useRef();
     const contentRef = useRef();
@@ -41,7 +44,15 @@ function Modal({ children, isOpen }) {
         }
     }, [contentRef]);
 
-    return <div ref={modalRef} className={`modal ${isOpen ? 'modal--open' : ''} ${fullHeight ? 'modal--full' : ''} ${substeps ? 'modal--substeps' : ''}`}>
+    return <div ref={modalRef}
+        className={`modal ${isOpen ? 'modal--open' : ''} ${fullHeight ? 'modal--full' : ''} ${substeps ? 'modal--substeps' : ''}`}
+        style={{
+            left: kioskOriginLocationId ? '0' : null,
+            right: kioskOriginLocationId ? '0' : null,
+            marginLeft: kioskOriginLocationId ? 'auto' : null,
+            marginRight: kioskOriginLocationId ? 'auto' : null,
+            maxHeight: kioskOriginLocationId ? '50%' : '80%'
+        }}>
         <div ref={contentRef} className="modal__content">
             {children}
         </div>

--- a/packages/map-template/src/components/Sidebar/Modal/Modal.scss
+++ b/packages/map-template/src/components/Sidebar/Modal/Modal.scss
@@ -10,6 +10,7 @@
     transform: translateY(calc(100% + var(--spacing-large)));
     overflow: auto;
     display: none;
+    max-height: 80%;
 
     &--open {
         transform: translateY(0);
@@ -30,5 +31,13 @@
         .modal__content {
             height: 100%;
         }
+    }
+
+    &--kiosk {
+        left: 0;
+        right: 0;
+        margin-left: auto;
+        margin-right: auto;
+        max-height: 50%;
     }
 }

--- a/packages/map-template/src/components/Sidebar/Modal/Modal.scss
+++ b/packages/map-template/src/components/Sidebar/Modal/Modal.scss
@@ -8,7 +8,6 @@
     border: 1px solid var(--color-gray-30);
     background: var(--color-white-white);
     transform: translateY(calc(100% + var(--spacing-large)));
-    max-height: 80%; // UX spec
     overflow: auto;
     display: none;
 

--- a/packages/map-template/src/helpers/GetDesktopPadding.js
+++ b/packages/map-template/src/helpers/GetDesktopPadding.js
@@ -4,5 +4,5 @@
 export default function getDesktopPadding() {
     // The width of the sidebar plus adequate padding
     const sidebar = document.querySelector('.modal--open');
-    return sidebar.offsetWidth + sidebar.offsetLeft * 2;
+    return sidebar?.offsetWidth + sidebar?.offsetLeft * 2;
 }

--- a/packages/map-template/src/helpers/GetDesktopPaddingBottom.js
+++ b/packages/map-template/src/helpers/GetDesktopPaddingBottom.js
@@ -1,0 +1,9 @@
+/**
+ * Get bottom padding on desktop.
+ */
+export default function getDesktopPaddingBottom() {
+    const sidebar = document.querySelector('.modal--open');
+    const mapContainer = document.querySelector('.mapsindoors-map');
+    // Subtract the top padding from the height of the map container element.
+    return mapContainer.offsetHeight - sidebar?.offsetTop;
+}

--- a/packages/map-template/src/helpers/GetDesktopPaddingLeft.js
+++ b/packages/map-template/src/helpers/GetDesktopPaddingLeft.js
@@ -1,7 +1,7 @@
 /**
- * Get left padding for directions on desktop.
+ * Get left padding on desktop.
  */
-export default function getDesktopPadding() {
+export default function getDesktopPaddingLeft() {
     // The width of the sidebar plus adequate padding
     const sidebar = document.querySelector('.modal--open');
     return sidebar?.offsetWidth + sidebar?.offsetLeft * 2;

--- a/packages/map-template/src/helpers/GetMobilePaddingBottom.js
+++ b/packages/map-template/src/helpers/GetMobilePaddingBottom.js
@@ -1,7 +1,7 @@
 /**
- * Get left padding for directions on desktop.
+ * Get bottom padding on mobile.
  */
-export default function getMobilePadding() {
+export default function getMobilePaddingBottom() {
     const bottomSheet = document.querySelector('.sheet--active');
     const mapContainer = document.querySelector('.mapsindoors-map');
     // Subtract the top padding from the height of the map container element.

--- a/packages/map-template/src/helpers/GetMobilePaddingBottom.js
+++ b/packages/map-template/src/helpers/GetMobilePaddingBottom.js
@@ -5,5 +5,5 @@ export default function getMobilePaddingBottom() {
     const bottomSheet = document.querySelector('.sheet--active');
     const mapContainer = document.querySelector('.mapsindoors-map');
     // Subtract the top padding from the height of the map container element.
-    return mapContainer.offsetHeight - bottomSheet.offsetTop;
+    return mapContainer.offsetHeight - bottomSheet?.offsetTop;
 }

--- a/packages/map-template/src/helpers/fitBoundsLocation.js
+++ b/packages/map-template/src/helpers/fitBoundsLocation.js
@@ -3,6 +3,11 @@ import { calculateBounds } from "./CalculateBounds";
 /**
  * Calculate the location bbox, and then fit bounds of a location.
  * Add padding left and bottom as parameters, due to needing to dynamically calculate that. 
+ * 
+ * @param {object} location
+ * @param {object} mapsIndoorsInstance
+ * @param {number} paddingBottom
+ * @param {number} paddingLeft
  */
 export default function fitBoundsLocation(location, mapsIndoorsInstance, paddingBottom, paddingLeft) {
     // Calculate the location bbox

--- a/packages/map-template/src/helpers/fitBoundsLocation.js
+++ b/packages/map-template/src/helpers/fitBoundsLocation.js
@@ -2,6 +2,7 @@ import { calculateBounds } from "./CalculateBounds";
 
 /**
  * Calculate the location bbox, and then fit bounds of a location.
+ * Add padding left and bottom as parameters, due to needing to dynamically calculate that. 
  */
 export default function fitBoundsLocation(location, mapsIndoorsInstance, paddingBottom, paddingLeft) {
     // Calculate the location bbox

--- a/packages/map-template/src/helpers/fitBoundsLocation.js
+++ b/packages/map-template/src/helpers/fitBoundsLocation.js
@@ -1,0 +1,12 @@
+import { calculateBounds } from "./CalculateBounds";
+
+/**
+ * Calculate the location bbox, and then fit bounds of a location.
+ */
+export default function fitBoundsLocation(location, mapsIndoorsInstance, paddingBottom, paddingLeft) {
+    // Calculate the location bbox
+    const locationBbox = calculateBounds(location.geometry)
+    let coordinates = { west: locationBbox[0], south: locationBbox[1], east: locationBbox[2], north: locationBbox[3] }
+    // Fit map to the bounds of the location coordinates, and add left padding
+    mapsIndoorsInstance.getMapView().fitBounds(coordinates, { top: 0, right: 0, bottom: paddingBottom, left: paddingLeft});
+}


### PR DESCRIPTION
# What 

- Implement kioskOriginLocationId prop 
- Center the sidebar instead of having it placed in the left side
- Use the `fitBounds` function when having both `kioskOriginLocationId` and `locationId` props
- Restrict the kiosk to only be on desktop devices
- Create a new function `fitBoundsLocation` which is reused in three different places

# How 

- Refactor the `onLocationIdChanged` function to happen in a `useEffect`, and make sure the map is ready at the time the changes are happening 
- Handle both the `kioskOriginLocationId` and the `locationId` in the same `useEffect`
- Create helper functions for getting the desktop padding to the left and bottom, and the mobile padding to the bottom
- Do not allow location selection or clicking the location if it's the `kioskOriginLocationId` (meaning that it should not take the selection pin, and it should also not be selected to show the Location Details page)
- Make the kiosk icon double the size based on the display rule (UX Spec)
- Create a new function `fitBoundsLocation` which calculates the bbox of the location, takes a MapsIndoors instance and padding left and bottom, then it calls `fitBounds` method.