### PR TITLE
Add support for startZoomLevel, pitch and bearing working in combination with other props

### DIFF
--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.1] - 2023-12-14
+
+### Fixed
+
+- Fixed `startZoomLevel`, `pitch` and `bearing` properties not working together with other parameters.
+
 ## [1.24.0] - 2023-12-11
 
 ### Added

--- a/packages/map-template/src/components/Map/Map.jsx
+++ b/packages/map-template/src/components/Map/Map.jsx
@@ -327,7 +327,7 @@ function Map({ onLocationClick, onVenueChangedOnMap, useMapProviderModule }) {
                 const locationFloor = kioskLocation.properties.floor;
                 mapsIndoorsInstance.setFloor(locationFloor);
 
-                fitBoundsLocation(kioskLocation, mapsIndoorsInstance, getDesktopPaddingBottom(), 0);
+                fitBoundsLocation(kioskLocation, mapsIndoorsInstance, getDesktopPaddingBottom(), 0, startZoomLevel, pitch, bearing);
             } else if (locationId) {
                 window.mapsindoors.services.LocationsService.getLocation(locationId).then(location => {
                     if (location) {
@@ -336,12 +336,12 @@ function Map({ onLocationClick, onVenueChangedOnMap, useMapProviderModule }) {
                         mapsIndoorsInstance.setFloor(locationFloor);
 
                         // Fit the map to the location bounds and add the padding calculated based on the modal.
-                        fitBoundsLocation(location, mapsIndoorsInstance, isDesktop ? 0 : getMobilePaddingBottom(), isDesktop ? getDesktopPaddingLeft() : 0);
+                        fitBoundsLocation(location, mapsIndoorsInstance, isDesktop ? 0 : getMobilePaddingBottom(), isDesktop ? getDesktopPaddingLeft() : 0, startZoomLevel, pitch, bearing);
                     }
                 });
             }
         }
-    }, [kioskLocation, locationId, isMapReady]);
+    }, [kioskLocation, locationId, isMapReady, startZoomLevel, pitch, bearing]);
 
     return (<>
         {mapType === mapTypes.Google && <GoogleMapsMap onMapView={onMapView} onPositionControl={onPositionControlCreated} />}

--- a/packages/map-template/src/components/Search/Search.jsx
+++ b/packages/map-template/src/components/Search/Search.jsx
@@ -17,7 +17,6 @@ import fitBoundsLocation from '../../helpers/fitBoundsLocation';
 import getDesktopPaddingLeft from '../../helpers/GetDesktopPaddingLeft';
 import kioskLocationState from '../../atoms/kioskLocationState';
 import getDesktopPaddingBottom from '../../helpers/GetDesktopPaddingBottom';
-import getMobilePaddingBottom from '../../helpers/GetMobilePaddingBottom';
 
 /**
  * Show the search results.

--- a/packages/map-template/src/helpers/fitBoundsLocation.js
+++ b/packages/map-template/src/helpers/fitBoundsLocation.js
@@ -2,17 +2,34 @@ import { calculateBounds } from "./CalculateBounds";
 
 /**
  * Calculate the location bbox, and then fit bounds of a location.
- * Add padding left and bottom as parameters, due to needing to dynamically calculate that. 
+ * Add padding left and bottom as parameters, due to needing to dynamically calculate that.
+ * Add startZoomLevel, pitch and bearing as parameters.
  * 
  * @param {object} location
  * @param {object} mapsIndoorsInstance
  * @param {number} paddingBottom
  * @param {number} paddingLeft
+ * @param {number} startZoomLevel
+ * @param {number} pitch
+ * @param {number} bearing
  */
-export default function fitBoundsLocation(location, mapsIndoorsInstance, paddingBottom, paddingLeft) {
+export default function fitBoundsLocation(location, mapsIndoorsInstance, paddingBottom, paddingLeft, startZoomLevel, pitch, bearing) {
     // Calculate the location bbox
     const locationBbox = calculateBounds(location.geometry)
     let coordinates = { west: locationBbox[0], south: locationBbox[1], east: locationBbox[2], north: locationBbox[3] }
     // Fit map to the bounds of the location coordinates, and add left padding
-    mapsIndoorsInstance.getMapView().fitBounds(coordinates, { top: 0, right: 0, bottom: paddingBottom, left: paddingLeft});
+    mapsIndoorsInstance.getMapView().fitBounds(coordinates, { top: 0, right: 0, bottom: paddingBottom, left: paddingLeft }).then(() => {
+        // Set the map zoom level if the property is provided.
+        if (startZoomLevel) {
+            mapsIndoorsInstance.setZoom(parseInt(startZoomLevel));
+        }
+        // Set the map pitch if the property is provided.
+        if (!isNaN(parseInt(pitch))) {
+            mapsIndoorsInstance.getMapView().tilt(parseInt(pitch));
+        }
+        // Set the map bearing if the property is provided.
+        if (!isNaN(parseInt(bearing))) {
+            mapsIndoorsInstance.getMapView().rotate(parseInt(bearing));
+        }
+    });
 }

--- a/packages/map-template/src/helpers/fitBoundsLocation.js
+++ b/packages/map-template/src/helpers/fitBoundsLocation.js
@@ -3,15 +3,15 @@ import { calculateBounds } from "./CalculateBounds";
 /**
  * Calculate the location bbox, and then fit bounds of a location.
  * Add padding left and bottom as parameters, due to needing to dynamically calculate that.
- * Add startZoomLevel, pitch and bearing as parameters.
+ * Handle the presence of the startZoomLevel, pitch and bearing props.
  * 
- * @param {object} location
- * @param {object} mapsIndoorsInstance
- * @param {number} paddingBottom
- * @param {number} paddingLeft
- * @param {number} startZoomLevel
- * @param {number} pitch
- * @param {number} bearing
+ * @param {object} location - The location that the map should fit the bounds to.
+ * @param {object} mapsIndoorsInstance - The MapsIndoors instance.
+ * @param {number} paddingBottom - The padding that should be applied at the bottom.
+ * @param {number} paddingLeft - The padding that should be applied on the left side.
+ * @param {number} startZoomLevel - The initial zoom level of the map.
+ * @param {number} pitch - The pitch (Mapbox) or tilt (Google) value of the map.
+ * @param {number} bearing - The bearing (Mapbox) or heading (Google) value of the map.
  */
 export default function fitBoundsLocation(location, mapsIndoorsInstance, paddingBottom, paddingLeft, startZoomLevel, pitch, bearing) {
     // Calculate the location bbox


### PR DESCRIPTION
# What 

- Add support for `startZoomLevel`, `pitch` and `bearing` to be working in combination with locationId and kioskOriginLocationId

# How

- In the `fitBoundsLocation()` function, when calling the `fitBounds()` from the SDK, handle the presence of startZoomLevel, pitch and bearing properties.
- Add the additional 3 props when calling `fitBoundsLocation()` when having the `locationId` and `kioskOriginLocationId` props