### PR TITLE
Reset origin location when exiting wayfinding

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.15.2] - 2024-01-22
+
+### Fixed
+
+- **mi-search** Make sure the display text is set on the input element value.
+
 ## [13.15.1] - 2024-01-16
 
 ### Fixed

--- a/packages/components/src/components/search/search.tsx
+++ b/packages/components/src/components/search/search.tsx
@@ -188,6 +188,7 @@ export class Search implements ComponentInterface {
     @Method()
     setDisplayText(displayText: string): void {
         this.preventSearch = true;
+        this.inputElement.value = displayText;
         this.value = displayText;
         this.preventSearch = false;
     }

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.29.1] - 2024-01-22
+
+### Fixed
+
+- Fixed resetting the origin location when exiting the Wayfinding page.
+
 ## [1.29.0] - 2024-01-11
 
 ### Added

--- a/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
+++ b/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
@@ -306,6 +306,7 @@ function Wayfinding({ onStartDirections, onBack, directionsToLocation, direction
 
     /**
      * Function that handles the closing of the Wayfinding page.
+     * Reset the originLocation and the display text of the input field.
      */
     function closeWayfinding() {
         setOriginLocation();

--- a/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
+++ b/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
@@ -304,6 +304,15 @@ function Wayfinding({ onStartDirections, onBack, directionsToLocation, direction
         }
     }
 
+    /**
+     * Function that handles the closing of the Wayfinding page.
+     */
+    function closeWayfinding() {
+        setOriginLocation();
+        fromFieldRef.current.setDisplayText('');
+        onBack();
+    }
+
     useEffect(() => {
         setSize(snapPoints.MAX);
         let originLocationWasSet = false;
@@ -382,7 +391,7 @@ function Wayfinding({ onStartDirections, onBack, directionsToLocation, direction
             <div className="wayfinding__directions">
                 <div className="wayfinding__title">{t('Start wayfinding')}</div>
                 <button className="wayfinding__close"
-                    onClick={() => onBack()}
+                    onClick={() => closeWayfinding()}
                     aria-label="Close">
                     <CloseIcon />
                 </button>


### PR DESCRIPTION
# What 

- Reset origin location when exiting Wayfinding page 

# How 

- Create function that handles the closing of the Wayfinding page 
- Reset the origin location and also the display text 
- Adjust the `setDisplayText()` method on the `search.jsx` component and set the `inputElement.value` to also be equal to the `displayText`, otherwise the input field would keep the old value 