### PR TITLE
Fix: Pan the map to correct location when clicking on search result not belonging to the current venue

### DIFF
--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,15 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.32.3] - 2024-01-24
+
+### Fixed
+
+- Fixed a bug where map would not always pan to a Location when clicked on it in a list of search results.
+
 ## [1.31.2] - 2024-01-23
 
-### Fix
+### Fixed
 
 - Fixed the directions not working on a mobile device.
 
 ## [1.31.1] - 2024-01-22
 
-### Fix
+### Fixed
 
 - Updated default values for `apiKey` and `venue` in the Map Template.
 

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.32.3] - 2024-01-24
+## [1.31.3] - 2024-01-24
 
 ### Fixed
 

--- a/packages/map-template/src/components/VenueSelector/VenueSelector.jsx
+++ b/packages/map-template/src/components/VenueSelector/VenueSelector.jsx
@@ -10,6 +10,8 @@ import Venue from './Venue/Venue';
 import currentVenueNameState from '../../atoms/currentVenueNameState';
 import isLocationClickedState from '../../atoms/isLocationClickedState';
 import useSetCurrentVenueName from '../../hooks/useSetCurrentVenueName';
+import fitBoundsLocation from '../../helpers/fitBoundsLocation';
+import mapsIndoorsInstanceState from '../../atoms/mapsIndoorsInstanceState';
 
 /**
  * Show a list of Venues. The user can click on a Venue to select it.
@@ -23,6 +25,7 @@ function VenueSelector({ onOpen, onClose, active }) {
 
     const venueSelectorContentRef = useRef(null);
     const venues = useRecoilValue(venuesState);
+    const mapsIndoorsInstance = useRecoilValue(mapsIndoorsInstanceState);
 
     const setCurrentVenueName = useSetCurrentVenueName();
 
@@ -36,6 +39,7 @@ function VenueSelector({ onOpen, onClose, active }) {
      */
     const selectVenue = venue => {
         setCurrentVenueName(venue.name);
+        fitBoundsLocation(venue, mapsIndoorsInstance, 0, 0);
         toggle();
     };
 

--- a/packages/map-template/src/hooks/useMapBoundsDeterminer.js
+++ b/packages/map-template/src/hooks/useMapBoundsDeterminer.js
@@ -70,7 +70,7 @@ const useMapBoundsDeterminer = () => {
      */
     useEffect(() =>  {
         determineMapBounds();
-    }, [mapsIndoorsInstance, currentVenueName, venues, locationId, kioskOriginLocationId, pitch, bearing, startZoomLevel, categories]);
+    }, [mapsIndoorsInstance, venue, venues, locationId, kioskOriginLocationId, pitch, bearing, startZoomLevel, categories]);
 
 
     /**


### PR DESCRIPTION
# What

- Fix bug where (when using `kioskOriginLocationId`) clicking on a search result not belonging to the currently set venue would not pan the map to the clicked Location, but instead reset the map to the initial settings.

# How

- Made the `useMapBoundsDeterminer` hook react to changes in the "venue" prop instead of the internal `venueName` state. Also manually trigger map pan when using the Venue Selector, since the responsibility of doing that was previously mistakenly given to the `useMapBoundsDeterminer` hook. 