### PR TITLE
Remove call for resetting the tilt when having an untracked position

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23141,7 +23141,7 @@
     },
     "packages/components": {
       "name": "@mapsindoors/components",
-      "version": "13.16.0",
+      "version": "13.17.0",
       "license": "MIT",
       "dependencies": {
         "@11ty/eleventy": "^2.0.0",
@@ -23181,7 +23181,7 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.32.0",
+      "version": "1.33.0",
       "devDependencies": {
         "@googlemaps/js-api-loader": "^1.15.1",
         "@mapsindoors/components": "*",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.17.1] - 2024-02-06
+
+### Fixed
+
+- Fixed `my-position` component resetting the tilt of the map.
+
 ## [13.17.0] - 2024-01-30
 
 ### Added

--- a/packages/components/src/components/my-position/my-position.tsx
+++ b/packages/components/src/components/my-position/my-position.tsx
@@ -254,7 +254,6 @@ export class MyPositionComponent {
                         this.setPositionState(PositionStateTypes.POSITION_UNTRACKED);
                     } else if (this.positionState !== PositionStateTypes.POSITION_UNTRACKED) {
                         this.setPositionState(PositionStateTypes.POSITION_KNOWN);
-                        this.mapView.tilt(0);
                     }
                     window.removeEventListener('deviceorientation', this.handleDeviceOrientationReference);
                 }


### PR DESCRIPTION
# What 

- Fix issue of map resetting the tilt when having the position enabled 

# How

- Remove call for resetting the tilt when having the position enabled but untracked 