### PR TITLE
Add support for searching within the same venue in kiosk mode

### DIFF
--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.34.0] - 2024-02-07
+
+### Added
+
+- Added support for searching for locations within the same venue when in kiosk mode.
+
 ## [1.33.4] - 2024-02-07
 
 ### Fixed

--- a/packages/map-template/src/components/Search/Search.jsx
+++ b/packages/map-template/src/components/Search/Search.jsx
@@ -325,7 +325,7 @@ function Search({ onSetSize, isOpen }) {
 
 
             { /* Search field that allows users to search for locations (MapsIndoors Locations and external) */}
-            
+
             <SearchField
                 ref={searchFieldRef}
                 mapsindoors={true}
@@ -351,11 +351,11 @@ function Search({ onSetSize, isOpen }) {
             { /* Message shown if no search results were found */}
 
             {showNotFoundMessage && <p className="search__error"> {t('Nothing was found')}</p>}
-            
-            
+
+
 
             { /* Vertical list of search results. Scrollable. */}
-            
+
             {searchResults.length > 0 &&
                 <div className="search__results prevent-scroll" {...scrollableContentSwipePrevent}>
                     {searchResults.map(location =>
@@ -373,8 +373,8 @@ function Search({ onSetSize, isOpen }) {
             { /* Keyboard */}
 
             {isKeyboardVisible && isDesktop && <Keyboard ref={keyboardRef} searchInputElement={searchInput}></Keyboard>}
-            
-            
+
+
 
             { /* Buttons to scroll in the list of search results if in kiosk context */}
 

--- a/packages/map-template/src/components/Search/Search.jsx
+++ b/packages/map-template/src/components/Search/Search.jsx
@@ -321,7 +321,11 @@ function Search({ onSetSize, isOpen }) {
         <div className="search"
             ref={searchRef}
             style={calculateContainerStyle()}>
+
+
             { /* Search field that allows users to search for locations (MapsIndoors Locations and external) */}
+            
+            
             <SearchField
                 ref={searchFieldRef}
                 mapsindoors={true}
@@ -332,14 +336,26 @@ function Search({ onSetSize, isOpen }) {
                 category={selectedCategory}
                 disabled={searchDisabled} // Disabled initially to prevent content jumping when clicking and changing sheet size.
             />
+
+
             { /* Horizontal list of Categories */}
+
+
             {categories.length > 0 && <Categories onSetSize={onSetSize}
                 searchFieldRef={searchFieldRef}
                 getFilteredLocations={category => getFilteredLocations(category)}
             />}
+
+
             { /* Message shown if no search results were found */}
+
+
             {showNotFoundMessage && <p className="search__error"> {t('Nothing was found')}</p>}
+            
+            
             { /* Vertical list of search results. Scrollable. */}
+            
+            
             {searchResults.length > 0 &&
                 <div className="search__results prevent-scroll" {...scrollableContentSwipePrevent}>
                     {searchResults.map(location =>
@@ -351,9 +367,17 @@ function Search({ onSetSize, isOpen }) {
                         />)}
                 </div>
             }
+
+
             { /* Keyboard */}
+
+
             {isKeyboardVisible && isDesktop && <Keyboard ref={keyboardRef} searchInputElement={searchInput}></Keyboard>}
+            
+            
             { /* Buttons to scroll in the list of search results if in kiosk context */}
+
+            
             {isOpen && isKioskContext && searchResults.length > 0 && createPortal(
                 <div className="search__scroll-buttons">
                     <mi-scroll-buttons ref={scrollButtonsRef}></mi-scroll-buttons>

--- a/packages/map-template/src/components/Search/Search.jsx
+++ b/packages/map-template/src/components/Search/Search.jsx
@@ -94,6 +94,7 @@ function Search({ onSetSize, isOpen }) {
     function getFilteredLocations(category) {
         window.mapsindoors.services.LocationsService.getLocations({
             categories: category,
+            venue: kioskLocation && isKioskContext ? kioskLocation.properties.venueId : undefined,
         }).then(onResults);
     }
 
@@ -245,7 +246,7 @@ function Search({ onSetSize, isOpen }) {
 
             return { display: 'flex', flexDirection: 'column', maxHeight, overflow: 'hidden' };
         } else {
-            return { minHeight: categories.length > 0 ? '136px' : '80px'};
+            return { minHeight: categories.length > 0 ? '136px' : '80px' };
         }
     }
 
@@ -316,75 +317,49 @@ function Search({ onSetSize, isOpen }) {
         }
     }, [useKeyboard]);
 
-
     return (
         <div className="search"
             ref={searchRef}
-            style={calculateContainerStyle()}
-            >
-
-                { /* Search field that allows users to search for locations (MapsIndoors Locations and external) */ }
-
-                <SearchField
-                    ref={searchFieldRef}
-                    mapsindoors={true}
-                    placeholder={t('Search by name, category, building...')}
-                    results={locations => onResults(locations)}
-                    clicked={() => searchFieldClicked()}
-                    cleared={() => cleared()}
-                    category={selectedCategory}
-                    disabled={searchDisabled} // Disabled initially to prevent content jumping when clicking and changing sheet size.
-                />
-
-
-
-                { /* Horizontal list of Categories */ }
-
-                {categories.length > 0 && <Categories onSetSize={onSetSize}
-                    searchFieldRef={searchFieldRef}
-                    getFilteredLocations={category => getFilteredLocations(category)}
-                />}
-
-
-
-
-                { /* Message shown if no search results were found */ }
-
-                {showNotFoundMessage && <p className="search__error"> {t('Nothing was found')}</p>}
-
-
-
-                { /* Vertical list of search results. Scrollable. */ }
-
-                {searchResults.length > 0 &&
-                    <div className="search__results prevent-scroll" {...scrollableContentSwipePrevent}>
-                        {searchResults.map(location =>
-                            <ListItemLocation
-                                key={location.id}
-                                location={location}
-                                locationClicked={() => onLocationClicked(location)}
-                                isHovered={location?.id === hoveredLocation?.id}
-                            />
-                        )}
-                    </div>
-                }
-
-
-
-                { /* Keyboard */ }
-
-                {isKeyboardVisible && isDesktop && <Keyboard ref={keyboardRef} searchInputElement={searchInput}></Keyboard>}
-
-
-
-                { /* Buttons to scroll in the list of search results if in kiosk context */ }
-
-                {isOpen && isKioskContext && searchResults.length > 0 && createPortal(
-                    <div className="search__scroll-buttons">
-                        <mi-scroll-buttons ref={scrollButtonsRef}></mi-scroll-buttons>
-                    </div>,
-                    document.querySelector('.mapsindoors-map')
-                )}
+            style={calculateContainerStyle()}>
+            { /* Search field that allows users to search for locations (MapsIndoors Locations and external) */}
+            <SearchField
+                ref={searchFieldRef}
+                mapsindoors={true}
+                placeholder={t('Search by name, category, building...')}
+                results={locations => onResults(locations)}
+                clicked={() => searchFieldClicked()}
+                cleared={() => cleared()}
+                category={selectedCategory}
+                disabled={searchDisabled} // Disabled initially to prevent content jumping when clicking and changing sheet size.
+            />
+            { /* Horizontal list of Categories */}
+            {categories.length > 0 && <Categories onSetSize={onSetSize}
+                searchFieldRef={searchFieldRef}
+                getFilteredLocations={category => getFilteredLocations(category)}
+            />}
+            { /* Message shown if no search results were found */}
+            {showNotFoundMessage && <p className="search__error"> {t('Nothing was found')}</p>}
+            { /* Vertical list of search results. Scrollable. */}
+            {searchResults.length > 0 &&
+                <div className="search__results prevent-scroll" {...scrollableContentSwipePrevent}>
+                    {searchResults.map(location =>
+                        <ListItemLocation
+                            key={location.id}
+                            location={location}
+                            locationClicked={() => onLocationClicked(location)}
+                            isHovered={location?.id === hoveredLocation?.id}
+                        />)}
+                </div>
+            }
+            { /* Keyboard */}
+            {isKeyboardVisible && isDesktop && <Keyboard ref={keyboardRef} searchInputElement={searchInput}></Keyboard>}
+            { /* Buttons to scroll in the list of search results if in kiosk context */}
+            {isOpen && isKioskContext && searchResults.length > 0 && createPortal(
+                <div className="search__scroll-buttons">
+                    <mi-scroll-buttons ref={scrollButtonsRef}></mi-scroll-buttons>
+                </div>,
+                document.querySelector('.mapsindoors-map')
+            )}
         </div>
     )
 }

--- a/packages/map-template/src/components/Search/Search.jsx
+++ b/packages/map-template/src/components/Search/Search.jsx
@@ -323,8 +323,8 @@ function Search({ onSetSize, isOpen }) {
             style={calculateContainerStyle()}>
 
 
+
             { /* Search field that allows users to search for locations (MapsIndoors Locations and external) */}
-            
             
             <SearchField
                 ref={searchFieldRef}
@@ -338,8 +338,8 @@ function Search({ onSetSize, isOpen }) {
             />
 
 
-            { /* Horizontal list of Categories */}
 
+            { /* Horizontal list of Categories */}
 
             {categories.length > 0 && <Categories onSetSize={onSetSize}
                 searchFieldRef={searchFieldRef}
@@ -347,14 +347,14 @@ function Search({ onSetSize, isOpen }) {
             />}
 
 
-            { /* Message shown if no search results were found */}
 
+            { /* Message shown if no search results were found */}
 
             {showNotFoundMessage && <p className="search__error"> {t('Nothing was found')}</p>}
             
             
+
             { /* Vertical list of search results. Scrollable. */}
-            
             
             {searchResults.length > 0 &&
                 <div className="search__results prevent-scroll" {...scrollableContentSwipePrevent}>
@@ -369,15 +369,15 @@ function Search({ onSetSize, isOpen }) {
             }
 
 
-            { /* Keyboard */}
 
+            { /* Keyboard */}
 
             {isKeyboardVisible && isDesktop && <Keyboard ref={keyboardRef} searchInputElement={searchInput}></Keyboard>}
             
             
+
             { /* Buttons to scroll in the list of search results if in kiosk context */}
 
-            
             {isOpen && isKioskContext && searchResults.length > 0 && createPortal(
                 <div className="search__scroll-buttons">
                     <mi-scroll-buttons ref={scrollButtonsRef}></mi-scroll-buttons>

--- a/packages/map-template/src/components/WebComponentWrappers/Search/Search.jsx
+++ b/packages/map-template/src/components/WebComponentWrappers/Search/Search.jsx
@@ -4,6 +4,8 @@ import { useRecoilValue, useRecoilState } from 'recoil';
 import userPositionState from '../../../atoms/userPositionState';
 import languageState from '../../../atoms/languageState';
 import searchInputState from '../../../atoms/searchInputState';
+import kioskLocationState from '../../../atoms/kioskLocationState';
+import { useIsKioskContext } from '../../../hooks/useIsKioskContext';
 
 /**
  * React wrapper around the custom element <mi-search>.
@@ -27,6 +29,10 @@ const SearchField = forwardRef(({ placeholder, mapsindoors, results, clicked, cl
     const language = useRecoilValue(languageState);
 
     const [, setSearchInput] = useRecoilState(searchInputState)
+
+    const kioskLocation = useRecoilValue(kioskLocationState);
+
+    const isKioskContext = useIsKioskContext();
 
     const mapboxPlacesSessionToken = sessionStorage.getItem('mapboxPlacesSessionToken');
 
@@ -112,6 +118,7 @@ const SearchField = forwardRef(({ placeholder, mapsindoors, results, clicked, cl
         disabled={disabled}
         mapbox={mapbox}
         google={google}
+        mi-venue={kioskLocation && isKioskContext ? kioskLocation.properties.venueId : undefined}
         language={language} />
 });
 

--- a/packages/map-template/src/components/WebComponentWrappers/Search/Search.jsx
+++ b/packages/map-template/src/components/WebComponentWrappers/Search/Search.jsx
@@ -118,7 +118,7 @@ const SearchField = forwardRef(({ placeholder, mapsindoors, results, clicked, cl
         disabled={disabled}
         mapbox={mapbox}
         google={google}
-        mi-venue={kioskLocation && isKioskContext ? kioskLocation.properties.venueId : undefined}
+        mi-venue={kioskLocation && isKioskContext ? kioskLocation.properties.venueId : undefined} // Restrict the search to the kiosk location venue when in kiosk mode.
         language={language} />
 });
 


### PR DESCRIPTION
# What 

- Add support for searching for locations which are in the same venue in the kiosk mode

# How

- Add `mi-venue` attribute to the `mi-search` component which checks if kiosk we are in kiosk mode
- Add `venue` attribute when getting the filtered locations after clicking on a location 
- Add the `venueId` from the kiosk location to both instances