### PR TITLE
Hide zoom controls from mobile view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23141,7 +23141,7 @@
     },
     "packages/components": {
       "name": "@mapsindoors/components",
-      "version": "13.17.0",
+      "version": "13.17.1",
       "license": "MIT",
       "dependencies": {
         "@11ty/eleventy": "^2.0.0",
@@ -23181,7 +23181,7 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.33.0",
+      "version": "1.33.1",
       "devDependencies": {
         "@googlemaps/js-api-loader": "^1.15.1",
         "@mapsindoors/components": "*",

--- a/packages/map-template/src/components/Map/GoogleMapsMap/GoogleMapsMap.jsx
+++ b/packages/map-template/src/components/Map/GoogleMapsMap/GoogleMapsMap.jsx
@@ -8,6 +8,7 @@ import primaryColorState from '../../../atoms/primaryColorState';
 import gmMapIdState from '../../../atoms/gmMapIdState';
 import bearingState from '../../../atoms/bearingState';
 import pitchState from '../../../atoms/pitchState';
+import useMediaQuery from '../../../hooks/useMediaQuery';
 
 /**
  * Takes care of instantiating a MapsIndoors Google Maps MapView.
@@ -29,6 +30,7 @@ function GoogleMapsMap({ onMapView, onPositionControl }) {
     const primaryColor = useRecoilValue(primaryColorState);
     const bearing = useRecoilValue(bearingState);
     const pitch = useRecoilValue(pitchState);
+    const isDesktop = useMediaQuery('(min-width: 992px)');
 
     useEffect(() => {
         const loader = new GoogleMapsApiLoader({
@@ -84,7 +86,7 @@ function GoogleMapsMap({ onMapView, onPositionControl }) {
             setHasFloorSelector(true);
         }
 
-        if (mapsIndoorsInstance && mapView && google && !hasZoomControl) {
+        if (mapsIndoorsInstance && mapView && google && !hasZoomControl && isDesktop) {
             // Enable only the Zoom control
             mapView.getMap().setOptions({
                 zoomControl: true,

--- a/packages/map-template/src/components/Map/MapboxMap/MapboxMap.jsx
+++ b/packages/map-template/src/components/Map/MapboxMap/MapboxMap.jsx
@@ -9,6 +9,7 @@ import primaryColorState from '../../../atoms/primaryColorState';
 import bearingState from '../../../atoms/bearingState';
 import pitchState from '../../../atoms/pitchState';
 import { v4 as uuidv4 } from 'uuid';
+import useMediaQuery from '../../../hooks/useMediaQuery';
 
 /**
  * Takes care of instantiating a MapsIndoors Mapbox MapView.
@@ -28,6 +29,7 @@ function MapboxMap({ onMapView, onPositionControl }) {
     const primaryColor = useRecoilValue(primaryColorState);
     const bearing = useRecoilValue(bearingState);
     const pitch = useRecoilValue(pitchState);
+    const isDesktop = useMediaQuery('(min-width: 992px)');
 
     useEffect(() => {
         // Initialize MapboxV3View MapView
@@ -69,7 +71,7 @@ function MapboxMap({ onMapView, onPositionControl }) {
             onPositionControl(myPositionButtonElement);
         }
 
-        if (mapsIndoorsInstance && mapView && !hasZoomControl) {
+        if (mapsIndoorsInstance && mapView && !hasZoomControl && isDesktop) {
             mapView
                 .getMap()
                 .addControl(new mapboxgl.NavigationControl({ showCompass: false }), 'top-right');


### PR DESCRIPTION
# What 

- Hide zoom controls from mobile view

# How 

- Use the `isDesktop` media query to check if the zoom control should be displayed or not 