### PR TITLE
Fix error when scanning the QR code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23141,7 +23141,7 @@
     },
     "packages/components": {
       "name": "@mapsindoors/components",
-      "version": "13.17.0",
+      "version": "13.17.1",
       "license": "MIT",
       "dependencies": {
         "@11ty/eleventy": "^2.0.0",
@@ -23181,7 +23181,7 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.33.0",
+      "version": "1.33.1",
       "devDependencies": {
         "@googlemaps/js-api-loader": "^1.15.1",
         "@mapsindoors/components": "*",

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.33.2] - 2024-02-07
+
+### Fixed
+
+- Fixed error when scanning the QR code.
+
 ## [1.33.1] - 2024-02-02
 
 ### Added

--- a/packages/map-template/src/components/QRCodeDialog/QRCodeDialog.jsx
+++ b/packages/map-template/src/components/QRCodeDialog/QRCodeDialog.jsx
@@ -33,7 +33,8 @@ function QRCodeDialog() {
     useEffect(() => {
         if (directionsFrom && directionsTo) {
             // The target URL when the user opens the QR code dialog
-            let targetUrl = window.location.origin;
+            // Create the URL by combining the origin and the pathname
+            let targetUrl = window.location.origin + window.location.pathname;
 
             // The interface for the existing URL search params
             const currentParams = new URLSearchParams(window.location.search);


### PR DESCRIPTION
# What 

- Fix the issue of having incomplete URL when scanning the QR code

# How 

- Combine the `origin` and `pathname` when creating the targetURL 