### PR TITLE
Search results state is not reset when using the timeout property

### DIFF
--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.33.3] - 2024-02-07
+
+### Fixed
+
+- Fixed search results state not resetting when using the timeout property.
+
 ## [1.33.2] - 2024-02-07
 
 ### Fixed

--- a/packages/map-template/src/hooks/useReset.js
+++ b/packages/map-template/src/hooks/useReset.js
@@ -8,6 +8,7 @@ import notificationMessageState from '../atoms/notificationMessageState';
 import showQRCodeDialogState from '../atoms/showQRCodeDialogState';
 import substepsToggledState from '../atoms/substepsToggledState';
 import travelModeState from '../atoms/travelModeState';
+import searchResultsState from '../atoms/searchResultsState';
 
 /**
  * Reset a number of Recoil atoms to initial values.
@@ -25,6 +26,7 @@ export function useReset() {
     const showQRCodeDialog = useResetRecoilState(showQRCodeDialogState);
     const substepsToggled = useResetRecoilState(substepsToggledState);
     const travelMode = useResetRecoilState(travelModeState);
+    const searchResults = useResetRecoilState(searchResultsState);
 
     return () => {
         activeStep();
@@ -36,5 +38,6 @@ export function useReset() {
         showQRCodeDialog();
         substepsToggled();
         travelMode();
+        searchResults();
     };
 }


### PR DESCRIPTION
# What 

- Fixed search results not being reset when using the timeout property 

# How

- Add the `searchResults` to the `useReset` hook