### PR TITLE
Add support for category property

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23181,7 +23181,7 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.36.3",
+      "version": "1.36.4",
       "devDependencies": {
         "@googlemaps/js-api-loader": "^1.15.1",
         "@mapsindoors/components": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23181,7 +23181,7 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.34.0",
+      "version": "1.35.0",
       "devDependencies": {
         "@googlemaps/js-api-loader": "^1.15.1",
         "@mapsindoors/components": "*",

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.38.0] - 2024-02-28
+
+### Added 
+
+- Added support for `category` property.
+
 ## [1.37.1] - 2024-02-26
 
 ### Fixed 

--- a/packages/map-template/releaseTools/webcomponent.js
+++ b/packages/map-template/releaseTools/webcomponent.js
@@ -28,7 +28,8 @@ MapsIndoorsMap.propTypes = {
     pitch: PropTypes.number,
     kioskOriginLocationId: PropTypes.string,
     useMapProviderModule: PropTypes.bool,
-    timeout: PropTypes.number
+    timeout: PropTypes.number,
+    category: PropTypes.string,
 };
 
 const WebMapsIndoorsMap = reactToWebComponent(MapsIndoorsMap, React, ReactDOM);

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -76,7 +76,7 @@ defineCustomElements();
  * @param {boolean} [props.supportsUrlParameters] - Set to true if you want to support URL Parameters to configure the Map Template.
  * @param {boolean} [props.useKeyboard] - If running the Map Template as a kiosk, set this prop to true and it will prompt a keyboard.
  * @param {number} [props.timeout] - If you want the Map Template to reset map position and UI elements to the initial state after some time of inactivity, use this to specify the number of seconds of inactivity before resetting.
- * @param {string} [props.category] - If you want to indicate an active category on the map.
+ * @param {string} [props.category] - If you want to indicate an active category on the map. The value should be the Key (Administrative ID).
  */
 function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, primaryColor, logo, appUserRoles, directionsFrom, directionsTo, externalIDs, tileStyle, startZoomLevel, bearing, pitch, gmMapId, useMapProviderModule, kioskOriginLocationId, language, supportsUrlParameters, useKeyboard, timeout, category }) {
 

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -563,13 +563,8 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
      * Check if the category property matches with any of the existing categories.
      */
     useEffect(() => {
-        if (mapsindoorsSDKAvailable) {
-            if (category) {
-                const existingCategory = categories.find((matched) => matched[0] === category);
-                if (existingCategory !== undefined) {
-                    setSelectedCategory(category);
-                }
-            }
+        if (mapsindoorsSDKAvailable && category && categories.find((matched) => matched[0] === category)) {
+            setSelectedCategory(category);
         }
     }, [category, categories, mapsindoorsSDKAvailable]);
 

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -46,6 +46,7 @@ import venueState from '../../atoms/venueState.js';
 import useSetCurrentVenueName from '../../hooks/useSetCurrentVenueName.js';
 import useKeyboardState from '../../atoms/useKeyboardState';
 import { useIsDesktop } from '../../hooks/useIsDesktop.js';
+import selectedCategoryState from '../../atoms/selectedCategoryState.js';
 
 // Define the Custom Elements from our components package.
 defineCustomElements();
@@ -75,8 +76,9 @@ defineCustomElements();
  * @param {boolean} [props.supportsUrlParameters] - Set to true if you want to support URL Parameters to configure the Map Template.
  * @param {boolean} [props.useKeyboard] - If running the Map Template as a kiosk, set this prop to true and it will prompt a keyboard.
  * @param {number} [props.timeout] - If you want the Map Template to reset map position and UI elements to the initial state after some time of inactivity, use this to specify the number of seconds of inactivity before resetting.
+ * @param {string} [props.category] - If you want to indicate an active category on the map.
  */
-function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, primaryColor, logo, appUserRoles, directionsFrom, directionsTo, externalIDs, tileStyle, startZoomLevel, bearing, pitch, gmMapId, useMapProviderModule, kioskOriginLocationId, language, supportsUrlParameters, useKeyboard, timeout }) {
+function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, primaryColor, logo, appUserRoles, directionsFrom, directionsTo, externalIDs, tileStyle, startZoomLevel, bearing, pitch, gmMapId, useMapProviderModule, kioskOriginLocationId, language, supportsUrlParameters, useKeyboard, timeout, category }) {
 
     const [, setApiKey] = useRecoilState(apiKeyState);
     const [, setGmApiKey] = useRecoilState(gmApiKeyState);
@@ -98,6 +100,7 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
     const isInactive = useInactive(); // Hook to detect if user is inactive. Used in combination with timeout prop to reset the Map Template to initial values after a specified time.
     const [, setSupportsUrlParameters] = useRecoilState(supportsUrlParametersState);
     const [, setUseKeyboard] = useRecoilState(useKeyboardState);
+    const [, setSelectedCategory] = useRecoilState(selectedCategoryState);
 
     const [showVenueSelector, setShowVenueSelector] = useState(true);
     const [showPositionControl, setShowPositionControl] = useState(true);
@@ -396,6 +399,13 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
     useEffect(() => {
         setLogo(logo);
     }, [logo]);
+
+    /*
+     * React on changes in the category prop.
+     */
+    useEffect(() => {
+        setSelectedCategory(category);
+    }, [category]);
 
     /*
      * React on changes in the current location prop.

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -401,13 +401,6 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
     }, [logo]);
 
     /*
-     * React on changes in the category prop.
-     */
-    useEffect(() => {
-        setSelectedCategory(category);
-    }, [category]);
-
-    /*
      * React on changes in the current location prop.
      * Apply location selection if the current location exists and is not the same as the kioskOriginLocationId.
      */
@@ -553,6 +546,21 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
 
         setCategories(uniqueCategories);
     }
+
+    /*
+     * React on changes in the category prop.
+     * Check if the category property matches with any of the existing categories.
+     */
+    useEffect(() => {
+        if (mapsindoorsSDKAvailable) {
+            if (category) {
+                const existingCategory = categories.find((matched) => matched[0] === category)
+                if (existingCategory !== undefined) {
+                    setSelectedCategory(category);
+                }
+            }
+        }
+    }, [category, categories, mapsindoorsSDKAvailable]);
 
     return <div className={`mapsindoors-map ${locationsDisabledRef.current ? 'mapsindoors-map--hide-elements' : 'mapsindoors-map--show-elements'} ${showPositionControl ? 'mapsindoors-map--show-my-position' : 'mapsindoors-map--hide-my-position'}`}>
         <Notification />

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -553,8 +553,7 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
      */
     useEffect(() => {
         if (mapsindoorsSDKAvailable) {
-            if (category) {
-                const existingCategory = categories.find((matched) => matched[0] === category)
+            if (category && categories.includes(matched => matched[0] === category) {
                 if (existingCategory !== undefined) {
                     setSelectedCategory(category);
                 }

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -553,7 +553,8 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
      */
     useEffect(() => {
         if (mapsindoorsSDKAvailable) {
-            if (category && categories.includes(matched => matched[0] === category) {
+            if (category) {
+                const existingCategory = categories.find((matched) => matched[0] === category);
                 if (existingCategory !== undefined) {
                     setSelectedCategory(category);
                 }

--- a/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
+++ b/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
@@ -27,7 +27,7 @@ import MapTemplate from '../MapTemplate/MapTemplate.jsx';
  * @param {number} [props.timeout] - If you want the Map Template to reset map position and UI elements to the initial state after some time of inactivity, use this to specify the number of seconds of inactivity before resetting.
  * @param {string} [props.language] - The language to show textual content in. Supported values are "en" for English, "da" for Danish, "de" for German and "fr" for French. If the prop is not set, the language of the browser will be used (if it is one of the four supported languages - otherwise it will default to English).
  * @param {boolean} [props.useKeyboard] - If running the Map Template as a kiosk, set this prop to true and it will prompt a keyboard. 
- * @param {string} [props.category] - If you want to indicate an active category on the map.
+ * @param {string} [props.category] - If you want to indicate an active category on the map. The value should be the Key (Administrative ID).
  */
 function MapsIndoorsMap(props) {
 

--- a/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
+++ b/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
@@ -27,6 +27,7 @@ import MapTemplate from '../MapTemplate/MapTemplate.jsx';
  * @param {number} [props.timeout] - If you want the Map Template to reset map position and UI elements to the initial state after some time of inactivity, use this to specify the number of seconds of inactivity before resetting.
  * @param {string} [props.language] - The language to show textual content in. Supported values are "en" for English, "da" for Danish, "de" for German and "fr" for French. If the prop is not set, the language of the browser will be used (if it is one of the four supported languages - otherwise it will default to English).
  * @param {boolean} [props.useKeyboard] - If running the Map Template as a kiosk, set this prop to true and it will prompt a keyboard. 
+ * @param {string} [props.category] - If you want to indicate an active category on the map.
  */
 function MapsIndoorsMap(props) {
 
@@ -67,10 +68,12 @@ function MapsIndoorsMap(props) {
         const externalIDsQueryParameter = queryStringParams.get('externalIDs')?.split(',');
         const gmMapIdQueryParameter = queryStringParams.get('gmMapId');
         const useMapProviderModuleParameter = getBooleanQueryParameter(queryStringParams.get('useMapProviderModule'));
-        const kioskOriginLocationId = queryStringParams.get('kioskOriginLocationId');
+        const kioskOriginLocationIdQueryParameter = queryStringParams.get('kioskOriginLocationId');
         const timeoutQueryParameter = queryStringParams.get('timeout');
         const languageQueryParameter = queryStringParams.get('language');
 		const useKeyboardQueryParameter = getBooleanQueryParameter(queryStringParams.get('useKeyboard'));
+        const categoryQueryParameter = queryStringParams.get('category');
+
 
         setMapTemplateProps({
             apiKey: props.supportsUrlParameters && apiKeyQueryParameter ? apiKeyQueryParameter : (props.apiKey || defaultProps.apiKey),
@@ -90,11 +93,12 @@ function MapsIndoorsMap(props) {
             externalIDs: props.supportsUrlParameters && externalIDsQueryParameter ? externalIDsQueryParameter : props.externalIDs,
             gmMapId: props.supportsUrlParameters && gmMapIdQueryParameter ? gmMapIdQueryParameter : props.gmMapId,
             useMapProviderModule: props.supportsUrlParameters && useMapProviderModuleParameter ? useMapProviderModuleParameter : (props.useMapProviderModule || defaultProps.useMapProviderModule),
-            kioskOriginLocationId: props.supportsUrlParameters && kioskOriginLocationId ? kioskOriginLocationId : props.kioskOriginLocationId,
+            kioskOriginLocationId: props.supportsUrlParameters && kioskOriginLocationIdQueryParameter ? kioskOriginLocationIdQueryParameter : props.kioskOriginLocationId,
             timeout: props.supportsUrlParameters && timeoutQueryParameter ? timeoutQueryParameter : props.timeout,
             language: props.supportsUrlParameters && languageQueryParameter ? languageQueryParameter : props.language,
             supportsUrlParameters: props.supportsUrlParameters,
 			useKeyboard: props.supportsUrlParameters && useKeyboardQueryParameter ? useKeyboardQueryParameter : (props.useKeyboard || defaultProps.useKeyboard),
+            category: props.supportsUrlParameters && categoryQueryParameter ? categoryQueryParameter : props.category,
 
         });
     }, [props]);

--- a/packages/map-template/src/components/Search/Categories/Categories.jsx
+++ b/packages/map-template/src/components/Search/Categories/Categories.jsx
@@ -126,7 +126,7 @@ function Categories({ onSetSize, getFilteredLocations, searchFieldRef }) {
         });
     }
 
-    /**
+    /*
      * Get the active category element.
      */
     useEffect(() => {

--- a/packages/map-template/src/components/Search/Categories/Categories.jsx
+++ b/packages/map-template/src/components/Search/Categories/Categories.jsx
@@ -135,7 +135,7 @@ function Categories({ onSetSize, getFilteredLocations, searchFieldRef }) {
         }
     }, [selectedCategory]);
 
-    /**
+    /*
      * Use the active category state to scroll into view
      * and center the category.
      */

--- a/packages/map-template/src/components/Search/Categories/Categories.jsx
+++ b/packages/map-template/src/components/Search/Categories/Categories.jsx
@@ -24,7 +24,7 @@ import getActiveCategory from "../../../helpers/GetActiveCategory";
 function Categories({ onSetSize, getFilteredLocations, searchFieldRef }) {
     /** Referencing the categories results container DOM element */
     const categoriesListRef = useRef();
-    
+
     const categories = useRecoilValue(categoriesState);
 
     const isDesktop = useIsDesktop();
@@ -43,7 +43,7 @@ function Categories({ onSetSize, getFilteredLocations, searchFieldRef }) {
 
     const scrollableContentSwipePrevent = usePreventSwipe();
 
-    const [activeChip, setActiveChip] = useState();
+    const [activeCategory, setActiveCategory] = useState();
 
     /**
      * Communicate size change to parent component.
@@ -127,22 +127,23 @@ function Categories({ onSetSize, getFilteredLocations, searchFieldRef }) {
     }
 
     /**
-     * Get the active chip element.
+     * Get the active category element.
      */
     useEffect(() => {
         if (selectedCategory) {
-            getActiveCategory().then(chip => setActiveChip(chip));
+            getActiveCategory().then(activeCategory => setActiveCategory(activeCategory));
         }
     }, [selectedCategory]);
 
     /**
-     * Use the active chip to scroll into view.
+     * Use the active category state to scroll into view
+     * and center the category.
      */
     useEffect(() => {
-        if (activeChip) {
-            activeChip.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'center' })
+        if (activeCategory) {
+            activeCategory.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'center' })
         }
-    }, [activeChip]);
+    }, [activeCategory]);
 
     return (
         <div className="categories prevent-scroll" {...scrollableContentSwipePrevent}>

--- a/packages/map-template/src/components/Search/Categories/Categories.jsx
+++ b/packages/map-template/src/components/Search/Categories/Categories.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useRecoilState, useRecoilValue } from "recoil";
 import './Categories.scss';
 import { ReactComponent as ChevronRight } from '../../../assets/chevron-right.svg';
@@ -11,6 +11,7 @@ import filteredLocationsState from "../../../atoms/filteredLocationsState";
 import selectedCategoryState from "../../../atoms/selectedCategoryState";
 import { usePreventSwipe } from '../../../hooks/usePreventSwipe';
 import { useIsDesktop } from "../../../hooks/useIsDesktop";
+import getActiveCategory from "../../../helpers/GetActiveCategory";
 
 /**
  * Show the categories list.
@@ -23,7 +24,7 @@ import { useIsDesktop } from "../../../hooks/useIsDesktop";
 function Categories({ onSetSize, getFilteredLocations, searchFieldRef }) {
     /** Referencing the categories results container DOM element */
     const categoriesListRef = useRef();
-
+    
     const categories = useRecoilValue(categoriesState);
 
     const isDesktop = useIsDesktop();
@@ -41,6 +42,8 @@ function Categories({ onSetSize, getFilteredLocations, searchFieldRef }) {
     const [, setFilteredLocations] = useRecoilState(filteredLocationsState);
 
     const scrollableContentSwipePrevent = usePreventSwipe();
+
+    const [activeChip, setActiveChip] = useState();
 
     /**
      * Communicate size change to parent component.
@@ -83,7 +86,6 @@ function Categories({ onSetSize, getFilteredLocations, searchFieldRef }) {
         }
     }
 
-
     /**
      * Update the state of the left and right scroll buttons
      */
@@ -123,6 +125,24 @@ function Categories({ onSetSize, getFilteredLocations, searchFieldRef }) {
             updateScrollButtonsState();
         });
     }
+
+    /**
+     * Get the active chip element.
+     */
+    useEffect(() => {
+        if (selectedCategory) {
+            getActiveCategory().then(chip => setActiveChip(chip));
+        }
+    }, [selectedCategory]);
+
+    /**
+     * Use the active chip to scroll into view.
+     */
+    useEffect(() => {
+        if (activeChip) {
+            activeChip.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'center' })
+        }
+    }, [activeChip]);
 
     return (
         <div className="categories prevent-scroll" {...scrollableContentSwipePrevent}>

--- a/packages/map-template/src/components/Search/Search.jsx
+++ b/packages/map-template/src/components/Search/Search.jsx
@@ -318,15 +318,14 @@ function Search({ onSetSize, isOpen }) {
     }, [useKeyboard]);
 
     /*
-   * React on changes in the app language. Any existing category search needs to update with translated Locations.
-   */
+     * React on changes in the selected category state. 
+     * If the selected category is present, get the filtered locations based on the selected category.
+     */
     useEffect(() => {
         if (selectedCategory) {
-            setSelectedCategory(selectedCategory);
             getFilteredLocations(selectedCategory);
         }
     }, [selectedCategory]);
-
 
     return (
         <div className="search"

--- a/packages/map-template/src/components/Search/Search.jsx
+++ b/packages/map-template/src/components/Search/Search.jsx
@@ -317,6 +317,17 @@ function Search({ onSetSize, isOpen }) {
         }
     }, [useKeyboard]);
 
+    /*
+   * React on changes in the app language. Any existing category search needs to update with translated Locations.
+   */
+    useEffect(() => {
+        if (selectedCategory) {
+            setSelectedCategory(selectedCategory);
+            getFilteredLocations(selectedCategory);
+        }
+    }, [selectedCategory]);
+
+
     return (
         <div className="search"
             ref={searchRef}

--- a/packages/map-template/src/helpers/GetActiveCategory.js
+++ b/packages/map-template/src/helpers/GetActiveCategory.js
@@ -1,0 +1,26 @@
+/**
+ * Get the active chip element.
+ *
+ * @returns {Promise}
+ */
+export default function getActiveCategory() {
+    return new Promise(resolve => {
+        const activeChip = document.querySelector('.chip--active');
+
+        // If there is no active chip element (yet), setup a MutationObserver that listens for the appearance of it.
+        if (!activeChip) {
+            const observer = new MutationObserver(() => {
+                const activeChip = document.querySelector('.chip--active');
+                if (activeChip) {
+                    observer.disconnect();
+                    resolve(activeChip);
+                }
+            });
+
+            // Observe changes in the DOM (see https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver/observe#options)
+            observer.observe(document, { attributes: false, childList: true, characterData: false, subtree: true });
+        } else {
+            resolve(activeChip); 
+        }
+    });
+}

--- a/packages/map-template/src/helpers/GetActiveCategory.js
+++ b/packages/map-template/src/helpers/GetActiveCategory.js
@@ -1,26 +1,26 @@
 /**
- * Get the active chip element.
+ * Get the active category element.
  *
  * @returns {Promise}
  */
 export default function getActiveCategory() {
     return new Promise(resolve => {
-        const activeChip = document.querySelector('.chip--active');
+        const activeCategory = document.querySelector('.chip--active');
 
         // If there is no active chip element (yet), setup a MutationObserver that listens for the appearance of it.
-        if (!activeChip) {
+        if (!activeCategory) {
             const observer = new MutationObserver(() => {
-                const activeChip = document.querySelector('.chip--active');
-                if (activeChip) {
+                const activeCategory = document.querySelector('.chip--active');
+                if (activeCategory) {
                     observer.disconnect();
-                    resolve(activeChip);
+                    resolve(activeCategory);
                 }
             });
 
             // Observe changes in the DOM (see https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver/observe#options)
             observer.observe(document, { attributes: false, childList: true, characterData: false, subtree: true });
         } else {
-            resolve(activeChip); 
+            resolve(activeCategory); 
         }
     });
 }


### PR DESCRIPTION
# What 

- Add support for category property 

# How 

- Add new property called `category`
- Check if the category prop exists in the list of sorted categories -> if it exists, then set the `selectedCategory` atom 
- Use `MutationObserver` to detect when the active chip element appears on the map 
- Scroll into the view of the active category 

**Note!** Remember that the category property should be the Key (Administrative ID) and not the Display name. 