### PR TITLE
Add support for MapsIndoors Transition Level

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23181,7 +23181,7 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.34.0",
+      "version": "1.35.1",
       "devDependencies": {
         "@googlemaps/js-api-loader": "^1.15.1",
         "@mapsindoors/components": "*",

--- a/packages/map-template/.github/README.md
+++ b/packages/map-template/.github/README.md
@@ -83,6 +83,7 @@ When loading the MapsIndoors Map component for the first time, the map will resp
 |`kioskOriginLocationId`|`string`|If running the Map Template as a Kiosk, provide the Location ID that represents the location of the Kiosk. |
 |`timeout`|`number`|If you want the Map Template to reset the map position and the UI elements to the initial state after some time of inactivity, use this to specify the number of seconds of inactivity before resetting. This property is not dependent on the `kioskOriginLocationId`. |
 |`useKeyboard`|`bool`|If running the Map Template as a Kiosk, set this prop to `true` and it will display a virtual keyboard. This property is dependent on the `kioskOriginLocationId`. |
+|`miTransitionLevel`|`number`|The zoom level on which to transition from Mapbox to MapsIndoors data. Default value is 17. This feature is only available for Mapbox. |
 
 ## Using Query Parameters
 
@@ -111,6 +112,7 @@ The supported query parameters are the following:
 19. `kioskOriginLocationId` - If running the Map Template as a Kiosk, provide the Location ID that represents the location of the Kiosk.
 20. `timeout` - If you want the Map Template to reset the map position and the UI elements to the initial state after some time of inactivity, use this to specify the number of seconds of inactivity before resetting. This property is not dependent on the `kioskOriginLocationId`.
 21. `useKeyboard` -  If running the Map Template as a Kiosk, set this prop to `true` and it will display a virtual keyboard. This property is dependent on the `kioskOriginLocationId`.
+22. `miTransitionLevel` - The zoom level on which to transition from Mapbox to MapsIndoors data. Default value is 17. This feature is only available for Mapbox.
 
 **Note!** All the query parameters need to be separated with the `&` symbol, without any spaces in between.
 **Note!** When using parameters such as `directionsTo`, `directionsFrom`, `locationId`, `externalIDs`, and `tileStyle` make sure you are using the correct `apiKey` parameter to which they belong.

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.36.0] - 2024-02-13
+
+### Added
+
+- Added support for `miTransitionLevel` property.
+
 ## [1.35.1] - 2024-02-12
 
 ### Fixed

--- a/packages/map-template/README.md
+++ b/packages/map-template/README.md
@@ -134,6 +134,7 @@ Note that when using the React component, the properties should conform to JSX p
 |`kiosk-origin-location-id`|`kioskOriginLocationId`|`string`|If running the Map Template as a Kiosk, provide the Location ID that represents the location of the Kiosk. |
 |`timeout`|`timeout`|`number`|If you want the Map Template to reset the map position and the UI elements to the initial state after some time of inactivity, use this to specify the number of seconds of inactivity before resetting. This property is not dependent on the `kioskOriginLocationId`. |
 |`use-keyboard`|`useKeyboard`|`bool`|If running the Map Template as a Kiosk, set this prop to `true` and it will display a virtual keyboard. This property is dependent on the `kioskOriginLocationId`. |
+|`mi-transition-level`|`miTransitionLevel`|`number`|The zoom level on which to transition from Mapbox to MapsIndoors data. Default value is 17. This feature is only available for Mapbox. |
 
 ## Using Query Parameters
 
@@ -162,6 +163,7 @@ The supported query parameters are the following:
 19. `kioskOriginLocationId` - If running the Map Template as a Kiosk, provide the Location ID that represents the location of the Kiosk.
 20. `timeout` - If you want the Map Template to reset the map position and the UI elements to the initial state after some time of inactivity, use this to specify the number of seconds of inactivity before resetting. This property is not dependent on the `kioskOriginLocationId`.
 21. `useKeyboard` -  If running the Map Template as a Kiosk, set this prop to `true` and it will display a virtual keyboard. This property is dependent on the `kioskOriginLocationId`.
+22. `miTransitionLevel` - The zoom level on which to transition from Mapbox to MapsIndoors data. Default value is 17. This feature is only available for Mapbox.
 
 **Note!** All the query parameters need to be separated with the `&` symbol, without any spaces in between.
 **Note!** When using parameters such as `directionsTo`, `directionsFrom`, `locationId`, `externalIDs`, and `tileStyle` make sure you are using the correct `apiKey` parameter to which they belong.

--- a/packages/map-template/releaseTools/webcomponent.js
+++ b/packages/map-template/releaseTools/webcomponent.js
@@ -28,7 +28,8 @@ MapsIndoorsMap.propTypes = {
     pitch: PropTypes.number,
     kioskOriginLocationId: PropTypes.string,
     useMapProviderModule: PropTypes.bool,
-    timeout: PropTypes.number
+    timeout: PropTypes.number, 
+    miTransitionLevel: PropTypes.number,
 };
 
 const WebMapsIndoorsMap = reactToWebComponent(MapsIndoorsMap, React, ReactDOM);

--- a/packages/map-template/src/atoms/miTransitionLevelState.js
+++ b/packages/map-template/src/atoms/miTransitionLevelState.js
@@ -1,0 +1,8 @@
+import { atom } from 'recoil';
+
+const miTransitionLevelState = atom({
+    key: 'miTransitionLevel',
+    default: null
+});
+
+export default miTransitionLevelState;

--- a/packages/map-template/src/atoms/miTransitionLevelState.js
+++ b/packages/map-template/src/atoms/miTransitionLevelState.js
@@ -2,7 +2,7 @@ import { atom } from 'recoil';
 
 const miTransitionLevelState = atom({
     key: 'miTransitionLevel',
-    default: null
+    default: undefined
 });
 
 export default miTransitionLevelState;

--- a/packages/map-template/src/components/Map/MapboxMap/MapboxMap.jsx
+++ b/packages/map-template/src/components/Map/MapboxMap/MapboxMap.jsx
@@ -41,8 +41,12 @@ function MapboxMap({ onMapView, onPositionControl }) {
             element: document.getElementById('map'),
             bearing: !isNaN(parseInt(bearing)) ? parseInt(bearing) : 0,
             pitch: !isNaN(parseInt(pitch)) ? parseInt(pitch) : 0,
-            mapsIndoorsTransitionLevel: !isNaN(parseInt(miTransitionLevel)) ? parseInt(miTransitionLevel) : 17,
         };
+
+        // If miTransitionLevel exists and it's a number, set it in the mapViewOptions
+        if (miTransitionLevel && !isNaN(parseInt(miTransitionLevel))) {
+            mapViewOptions.mapsIndoorsTransitionLevel = parseInt(miTransitionLevel);
+        }
 
         const mapViewInstance = new window.mapsindoors.mapView.MapboxV3View(mapViewOptions);
         setMapView(mapViewInstance);

--- a/packages/map-template/src/components/Map/MapboxMap/MapboxMap.jsx
+++ b/packages/map-template/src/components/Map/MapboxMap/MapboxMap.jsx
@@ -33,7 +33,6 @@ function MapboxMap({ onMapView, onPositionControl }) {
     const isDesktop = useIsDesktop();
     const miTransitionLevel = useRecoilValue(miTransitionLevelState);
 
-
     useEffect(() => {
         // Initialize MapboxV3View MapView
         window.mapboxgl = mapboxgl;

--- a/packages/map-template/src/components/Map/MapboxMap/MapboxMap.jsx
+++ b/packages/map-template/src/components/Map/MapboxMap/MapboxMap.jsx
@@ -10,6 +10,7 @@ import bearingState from '../../../atoms/bearingState';
 import pitchState from '../../../atoms/pitchState';
 import { v4 as uuidv4 } from 'uuid';
 import { useIsDesktop } from '../../../hooks/useIsDesktop';
+import miTransitionLevelState from '../../../atoms/miTransitionLevelState';
 
 /**
  * Takes care of instantiating a MapsIndoors Mapbox MapView.
@@ -30,6 +31,8 @@ function MapboxMap({ onMapView, onPositionControl }) {
     const bearing = useRecoilValue(bearingState);
     const pitch = useRecoilValue(pitchState);
     const isDesktop = useIsDesktop();
+    const miTransitionLevel = useRecoilValue(miTransitionLevelState);
+
 
     useEffect(() => {
         // Initialize MapboxV3View MapView
@@ -39,6 +42,7 @@ function MapboxMap({ onMapView, onPositionControl }) {
             element: document.getElementById('map'),
             bearing: !isNaN(parseInt(bearing)) ? parseInt(bearing) : 0,
             pitch: !isNaN(parseInt(pitch)) ? parseInt(pitch) : 0,
+            mapsIndoorsTransitionLevel: !isNaN(parseInt(miTransitionLevel)) ? parseInt(miTransitionLevel) : 17,
         };
 
         const mapViewInstance = new window.mapsindoors.mapView.MapboxV3View(mapViewOptions);

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -102,7 +102,6 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
     const [, setUseKeyboard] = useRecoilState(useKeyboardState);
     const [, setMiTransitionLevel] = useRecoilState(miTransitionLevelState);
 
-
     const [showVenueSelector, setShowVenueSelector] = useState(true);
     const [showPositionControl, setShowPositionControl] = useState(true);
 

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -46,6 +46,7 @@ import venueState from '../../atoms/venueState.js';
 import useSetCurrentVenueName from '../../hooks/useSetCurrentVenueName.js';
 import useKeyboardState from '../../atoms/useKeyboardState';
 import { useIsDesktop } from '../../hooks/useIsDesktop.js';
+import miTransitionLevelState from '../../atoms/miTransitionLevelState.js';
 
 // Define the Custom Elements from our components package.
 defineCustomElements();
@@ -75,8 +76,9 @@ defineCustomElements();
  * @param {boolean} [props.supportsUrlParameters] - Set to true if you want to support URL Parameters to configure the Map Template.
  * @param {boolean} [props.useKeyboard] - If running the Map Template as a kiosk, set this prop to true and it will prompt a keyboard.
  * @param {number} [props.timeout] - If you want the Map Template to reset map position and UI elements to the initial state after some time of inactivity, use this to specify the number of seconds of inactivity before resetting.
+ * @param {number} [props.miTransitionLevel] - If you want to change the level at which we show the MapsIndoors locations - default value is 17.
  */
-function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, primaryColor, logo, appUserRoles, directionsFrom, directionsTo, externalIDs, tileStyle, startZoomLevel, bearing, pitch, gmMapId, useMapProviderModule, kioskOriginLocationId, language, supportsUrlParameters, useKeyboard, timeout }) {
+function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, primaryColor, logo, appUserRoles, directionsFrom, directionsTo, externalIDs, tileStyle, startZoomLevel, bearing, pitch, gmMapId, useMapProviderModule, kioskOriginLocationId, language, supportsUrlParameters, useKeyboard, timeout, miTransitionLevel }) {
 
     const [, setApiKey] = useRecoilState(apiKeyState);
     const [, setGmApiKey] = useRecoilState(gmApiKeyState);
@@ -98,6 +100,8 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
     const isInactive = useInactive(); // Hook to detect if user is inactive. Used in combination with timeout prop to reset the Map Template to initial values after a specified time.
     const [, setSupportsUrlParameters] = useRecoilState(supportsUrlParametersState);
     const [, setUseKeyboard] = useRecoilState(useKeyboardState);
+    const [, setMiTransitionLevel] = useRecoilState(miTransitionLevelState);
+
 
     const [showVenueSelector, setShowVenueSelector] = useState(true);
     const [showPositionControl, setShowPositionControl] = useState(true);
@@ -396,6 +400,13 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
     useEffect(() => {
         setLogo(logo);
     }, [logo]);
+
+    /*
+     * React on changes in the miTransitionLevel prop.
+     */
+    useEffect(() => {
+        setMiTransitionLevel(miTransitionLevel);
+    }, [miTransitionLevel]);
 
     /*
      * React on changes in the current location prop.

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -76,7 +76,7 @@ defineCustomElements();
  * @param {boolean} [props.supportsUrlParameters] - Set to true if you want to support URL Parameters to configure the Map Template.
  * @param {boolean} [props.useKeyboard] - If running the Map Template as a kiosk, set this prop to true and it will prompt a keyboard.
  * @param {number} [props.timeout] - If you want the Map Template to reset map position and UI elements to the initial state after some time of inactivity, use this to specify the number of seconds of inactivity before resetting.
- * @param {number} [props.miTransitionLevel] - If you want to change the level at which we show the MapsIndoors locations - default value is 17.
+ * @param {number} [props.miTransitionLevel] - The zoom level on which to transition from Mapbox to MapsIndoors data. Default value is 17.
  */
 function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, primaryColor, logo, appUserRoles, directionsFrom, directionsTo, externalIDs, tileStyle, startZoomLevel, bearing, pitch, gmMapId, useMapProviderModule, kioskOriginLocationId, language, supportsUrlParameters, useKeyboard, timeout, miTransitionLevel }) {
 

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -76,7 +76,7 @@ defineCustomElements();
  * @param {boolean} [props.supportsUrlParameters] - Set to true if you want to support URL Parameters to configure the Map Template.
  * @param {boolean} [props.useKeyboard] - If running the Map Template as a kiosk, set this prop to true and it will prompt a keyboard.
  * @param {number} [props.timeout] - If you want the Map Template to reset map position and UI elements to the initial state after some time of inactivity, use this to specify the number of seconds of inactivity before resetting.
- * @param {number} [props.miTransitionLevel] - The zoom level on which to transition from Mapbox to MapsIndoors data. Default value is 17.
+ * @param {number} [props.miTransitionLevel] - The zoom level on which to transition from Mapbox to MapsIndoors data. Default value is 17. This feature is only available for Mapbox.
  */
 function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, primaryColor, logo, appUserRoles, directionsFrom, directionsTo, externalIDs, tileStyle, startZoomLevel, bearing, pitch, gmMapId, useMapProviderModule, kioskOriginLocationId, language, supportsUrlParameters, useKeyboard, timeout, miTransitionLevel }) {
 

--- a/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
+++ b/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
@@ -27,6 +27,7 @@ import MapTemplate from '../MapTemplate/MapTemplate.jsx';
  * @param {number} [props.timeout] - If you want the Map Template to reset map position and UI elements to the initial state after some time of inactivity, use this to specify the number of seconds of inactivity before resetting.
  * @param {string} [props.language] - The language to show textual content in. Supported values are "en" for English, "da" for Danish, "de" for German and "fr" for French. If the prop is not set, the language of the browser will be used (if it is one of the four supported languages - otherwise it will default to English).
  * @param {boolean} [props.useKeyboard] - If running the Map Template as a kiosk, set this prop to true and it will prompt a keyboard. 
+ * @param {number} [props.miTransitionLevel] - If you want to change the level at which we show the MapsIndoors locations - default value is 17.
  */
 function MapsIndoorsMap(props) {
 
@@ -71,6 +72,7 @@ function MapsIndoorsMap(props) {
         const timeoutQueryParameter = queryStringParams.get('timeout');
         const languageQueryParameter = queryStringParams.get('language');
 		const useKeyboardQueryParameter = getBooleanQueryParameter(queryStringParams.get('useKeyboard'));
+        const miTransitionLevelQueryParameter = queryStringParams.get('miTransitionLevel');
 
         setMapTemplateProps({
             apiKey: props.supportsUrlParameters && apiKeyQueryParameter ? apiKeyQueryParameter : (props.apiKey || defaultProps.apiKey),
@@ -95,7 +97,7 @@ function MapsIndoorsMap(props) {
             language: props.supportsUrlParameters && languageQueryParameter ? languageQueryParameter : props.language,
             supportsUrlParameters: props.supportsUrlParameters,
 			useKeyboard: props.supportsUrlParameters && useKeyboardQueryParameter ? useKeyboardQueryParameter : (props.useKeyboard || defaultProps.useKeyboard),
-
+            miTransitionLevel: props.supportsUrlParameters && miTransitionLevelQueryParameter ? miTransitionLevelQueryParameter : props.miTransitionLevel,
         });
     }, [props]);
 

--- a/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
+++ b/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
@@ -27,7 +27,7 @@ import MapTemplate from '../MapTemplate/MapTemplate.jsx';
  * @param {number} [props.timeout] - If you want the Map Template to reset map position and UI elements to the initial state after some time of inactivity, use this to specify the number of seconds of inactivity before resetting.
  * @param {string} [props.language] - The language to show textual content in. Supported values are "en" for English, "da" for Danish, "de" for German and "fr" for French. If the prop is not set, the language of the browser will be used (if it is one of the four supported languages - otherwise it will default to English).
  * @param {boolean} [props.useKeyboard] - If running the Map Template as a kiosk, set this prop to true and it will prompt a keyboard. 
- * @param {number} [props.miTransitionLevel] - The zoom level on which to transition from Mapbox to MapsIndoors data. Default value is 17.
+ * @param {number} [props.miTransitionLevel] - The zoom level on which to transition from Mapbox to MapsIndoors data. Default value is 17. This feature is only available for Mapbox.
  */
 function MapsIndoorsMap(props) {
 

--- a/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
+++ b/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
@@ -27,7 +27,7 @@ import MapTemplate from '../MapTemplate/MapTemplate.jsx';
  * @param {number} [props.timeout] - If you want the Map Template to reset map position and UI elements to the initial state after some time of inactivity, use this to specify the number of seconds of inactivity before resetting.
  * @param {string} [props.language] - The language to show textual content in. Supported values are "en" for English, "da" for Danish, "de" for German and "fr" for French. If the prop is not set, the language of the browser will be used (if it is one of the four supported languages - otherwise it will default to English).
  * @param {boolean} [props.useKeyboard] - If running the Map Template as a kiosk, set this prop to true and it will prompt a keyboard. 
- * @param {number} [props.miTransitionLevel] - If you want to change the level at which we show the MapsIndoors locations - default value is 17.
+ * @param {number} [props.miTransitionLevel] - The zoom level on which to transition from Mapbox to MapsIndoors data. Default value is 17.
  */
 function MapsIndoorsMap(props) {
 
@@ -71,7 +71,7 @@ function MapsIndoorsMap(props) {
         const kioskOriginLocationId = queryStringParams.get('kioskOriginLocationId');
         const timeoutQueryParameter = queryStringParams.get('timeout');
         const languageQueryParameter = queryStringParams.get('language');
-		const useKeyboardQueryParameter = getBooleanQueryParameter(queryStringParams.get('useKeyboard'));
+        const useKeyboardQueryParameter = getBooleanQueryParameter(queryStringParams.get('useKeyboard'));
         const miTransitionLevelQueryParameter = queryStringParams.get('miTransitionLevel');
 
         setMapTemplateProps({
@@ -96,7 +96,7 @@ function MapsIndoorsMap(props) {
             timeout: props.supportsUrlParameters && timeoutQueryParameter ? timeoutQueryParameter : props.timeout,
             language: props.supportsUrlParameters && languageQueryParameter ? languageQueryParameter : props.language,
             supportsUrlParameters: props.supportsUrlParameters,
-			useKeyboard: props.supportsUrlParameters && useKeyboardQueryParameter ? useKeyboardQueryParameter : (props.useKeyboard || defaultProps.useKeyboard),
+            useKeyboard: props.supportsUrlParameters && useKeyboardQueryParameter ? useKeyboardQueryParameter : (props.useKeyboard || defaultProps.useKeyboard),
             miTransitionLevel: props.supportsUrlParameters && miTransitionLevelQueryParameter ? miTransitionLevelQueryParameter : props.miTransitionLevel,
         });
     }, [props]);


### PR DESCRIPTION
# What 

- Add support for `miTransitionLevel` on Mapbox

# How 

- Create a new parameter for `miTransitionLevel`
- Add the parameter to the `webcomponent.js`
- Handle the parameter and check if it's a number
- Default to 17 if it's not a number 