### PR TITLE
Fix issue of Map Template height when running it in a web view 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23181,7 +23181,7 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.36.1",
+      "version": "1.36.3",
       "devDependencies": {
         "@googlemaps/js-api-loader": "^1.15.1",
         "@mapsindoors/components": "*",

--- a/packages/map-template/README.md
+++ b/packages/map-template/README.md
@@ -21,7 +21,7 @@ In your styles make sure to give it a size. For example:
 mapsindoors-map {
     display: block;
     width: 100vw;
-    height: 100svh;
+    height: 100dvh;
 }
 ```
 
@@ -67,7 +67,7 @@ Use query parameters to configure the Web Component by setting the `supports-url
         mapsindoors-map {
             display: block;
             width: 100vw;
-            height: 100svh;
+            height: 100dvh;
         }
     </style>
 </head>
@@ -97,7 +97,7 @@ import MapsIndoorsMap from '@mapsindoors/map-template/dist/mapsindoors-react.es.
 <div style={{
       display: 'block',
       width: '100vw',
-      height: '100svh'
+      height: '100dvh'
 }}>
       <MapsIndoorsMap></MapsIndoorsMap>
 </div>

--- a/packages/map-template/src/index.css
+++ b/packages/map-template/src/index.css
@@ -21,5 +21,5 @@ code {
 
 #root {
   width: 100%;
-  height: 100svh;
+  height: 100dvh;
 }

--- a/packages/tests/web-component/index.html
+++ b/packages/tests/web-component/index.html
@@ -16,7 +16,7 @@
         mapsindoors-map {
             display: block;
             width: 100vw;
-            height: 100svh;
+            height: 100dvh;
         }
     </style>
 </head>


### PR DESCRIPTION
# What

- Fix issue of Map Template height when running it in a web view

# How

- Replace the `svh` units to `dvh`, which stands for Dynamic viewport height 
- Read more about it here: https://blog.stackademic.com/exploring-css-units-unleashing-the-power-of-dvh-over-vh-1ff61b9c87ae

Tested:
- Firefox
- Chrome 
- Safari
- Web component 
- React component 
- Updated the bucket and tested in in web view 
- Android browsers