### PR TITLE
Remove hover from non-selectable locations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23181,7 +23181,7 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.36.3",
+      "version": "1.36.4",
       "devDependencies": {
         "@googlemaps/js-api-loader": "^1.15.1",
         "@mapsindoors/components": "*",

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.37.0] - 2024-02-22
+
+### Added 
+
+- Remove hover from non-selectable locations.
+
 ## [1.36.4] - 2024-02-20
 
 ### Fixed

--- a/packages/map-template/src/components/Map/Map.jsx
+++ b/packages/map-template/src/components/Map/Map.jsx
@@ -203,7 +203,8 @@ function Map({ onLocationClick, onVenueChangedOnMap, useMapProviderModule, onMap
             mapView
         });
 
-        // If the location where the mouse entered is non-selectable, do not hover it.
+        // Detect when the mouse hovers over a location and store the hovered location
+        // If the location is non-selectable, remove the hovering by calling the unhoverLocation() method.
         miInstance.on('mouseenter', () => {
             const hoveredLocation = miInstance.getHoveredLocation()
 

--- a/packages/map-template/src/components/Map/Map.jsx
+++ b/packages/map-template/src/components/Map/Map.jsx
@@ -203,6 +203,15 @@ function Map({ onLocationClick, onVenueChangedOnMap, useMapProviderModule, onMap
             mapView
         });
 
+        // If the location where the mouse entered is non-selectable, do not hover it.
+        miInstance.on('mouseenter', () => {
+            const hoveredLocation = miInstance.getHoveredLocation()
+
+            if (hoveredLocation?.properties.locationSettings?.selectable === false) {
+                miInstance.unhoverLocation();
+            }
+        });
+
         // TODO: Turn off visibility for building outline for demo purposes until the SDK supports Display Rules for Buildings too.
         miInstance.setDisplayRule(['MI_BUILDING_OUTLINE'], { visible: false });
 

--- a/packages/map-template/src/components/WebComponentWrappers/ListItemLocation/ListItemLocation.jsx
+++ b/packages/map-template/src/components/WebComponentWrappers/ListItemLocation/ListItemLocation.jsx
@@ -20,10 +20,14 @@ function ListItemLocation({ location, locationClicked, icon, isHovered }) {
     useEffect(() => {
         const clickHandler = customEvent => locationClicked(customEvent.detail);
         const hoverHandler = () => {
-            mapsIndoorsInstance.hoverLocation(location);
+            if (location.properties.locationSettings?.selectable !== false) {
+                mapsIndoorsInstance.hoverLocation(location);
+            }
         }
         const unhoverHandler = () => {
-            mapsIndoorsInstance.unhoverLocation(location);
+            if (!location.properties.locationSettings?.selectable !== false) {
+                mapsIndoorsInstance.unhoverLocation(location);
+            }
         }
 
         const { current } = elementRef;

--- a/packages/map-template/src/components/WebComponentWrappers/ListItemLocation/ListItemLocation.jsx
+++ b/packages/map-template/src/components/WebComponentWrappers/ListItemLocation/ListItemLocation.jsx
@@ -20,11 +20,13 @@ function ListItemLocation({ location, locationClicked, icon, isHovered }) {
     useEffect(() => {
         const clickHandler = customEvent => locationClicked(customEvent.detail);
         const hoverHandler = () => {
+            // Check if the location is no selectable before hovering it
             if (location.properties.locationSettings?.selectable !== false) {
                 mapsIndoorsInstance.hoverLocation(location);
             }
         }
         const unhoverHandler = () => {
+             // Check if the location is no selectable before unhovering it
             if (!location.properties.locationSettings?.selectable !== false) {
                 mapsIndoorsInstance.unhoverLocation(location);
             }

--- a/packages/map-template/src/components/WebComponentWrappers/ListItemLocation/ListItemLocation.jsx
+++ b/packages/map-template/src/components/WebComponentWrappers/ListItemLocation/ListItemLocation.jsx
@@ -20,13 +20,13 @@ function ListItemLocation({ location, locationClicked, icon, isHovered }) {
     useEffect(() => {
         const clickHandler = customEvent => locationClicked(customEvent.detail);
         const hoverHandler = () => {
-            // Check if the location is no selectable before hovering it
+            // Check if the location is non-selectable before hovering it
             if (location.properties.locationSettings?.selectable !== false) {
                 mapsIndoorsInstance.hoverLocation(location);
             }
         }
         const unhoverHandler = () => {
-             // Check if the location is no selectable before unhovering it
+             // Check if the location is non-selectable before unhovering it
             if (!location.properties.locationSettings?.selectable !== false) {
                 mapsIndoorsInstance.unhoverLocation(location);
             }


### PR DESCRIPTION
# What 

- Remove hover from non-selectable locations 

# How 

- Implement functionality for checking if the location is non-selectable before calling the `hoverLocation()` and `unhoverLocation()` on the `ListItemLocation.jsx` file
- Implement functionality for detecting the hovered locations on the map, and if the location is non-selectable, call the `unhoverLocation()`