### PR TITLE
Fix size of the images on the Location Details page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23181,7 +23181,7 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.36.3",
+      "version": "1.36.4",
       "devDependencies": {
         "@googlemaps/js-api-loader": "^1.15.1",
         "@mapsindoors/components": "*",

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.37.1] - 2024-02-26
+
+### Fixed 
+
+- Fix size of the images on the Location Details page.
+
 ## [1.37.0] - 2024-02-22
 
 ### Added 

--- a/packages/map-template/src/components/LocationDetails/LocationDetails.scss
+++ b/packages/map-template/src/components/LocationDetails/LocationDetails.scss
@@ -51,7 +51,7 @@
         width: 100%;
         border-radius: var(--rounding-large);
         object-fit: contain;
-        padding: var(--spacing-medium) 0;
+        margin: var(--spacing-medium) 0;
     }
 
     &__categories {

--- a/packages/map-template/src/components/LocationDetails/LocationDetails.scss
+++ b/packages/map-template/src/components/LocationDetails/LocationDetails.scss
@@ -48,11 +48,10 @@
     }
 
     &__image {
-        max-width: 400px;
         width: 100%;
         border-radius: var(--rounding-large);
-        aspect-ratio: 16 / 9;
-        object-fit: cover;
+        object-fit: contain;
+        padding: 16px 0;
     }
 
     &__categories {

--- a/packages/map-template/src/components/LocationDetails/LocationDetails.scss
+++ b/packages/map-template/src/components/LocationDetails/LocationDetails.scss
@@ -51,7 +51,7 @@
         width: 100%;
         border-radius: var(--rounding-large);
         object-fit: contain;
-        padding: 16px 0;
+        padding: var(--spacing-medium) 0;
     }
 
     &__categories {


### PR DESCRIPTION
# What 

- Fix size of the images on the Location Details prop

# How 

- Based on UX considerations, removed the `aspect-ratio`, changed the `object-fit` to `contain` and added a padding of `16px` at the top and bottom of the image.