### PR TITLE
Add Sentry performance monitoring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5092,6 +5092,489 @@
         "node": ">=6"
       }
     },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "7.105.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.105.0.tgz",
+      "integrity": "sha512-17doUQFKYgLfG7EmZXjZQ7HR/aBzuLDd+GVaCNthUPyiz/tltV7EFECDWwHpXqzQgYRgroSbY8PruMVujFGUUw==",
+      "dev": true,
+      "dependencies": {
+        "@sentry/core": "7.105.0",
+        "@sentry/types": "7.105.0",
+        "@sentry/utils": "7.105.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "7.105.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.105.0.tgz",
+      "integrity": "sha512-XMBdkjIDhap5Gwrub5wlUJhuUVJM4aL4lZV8KcxJZZSXgXsnyGYbEh9SPZOHO05jtbxTxVeL3Pik5qtYjdGnPA==",
+      "dev": true,
+      "dependencies": {
+        "@sentry/core": "7.105.0",
+        "@sentry/replay": "7.105.0",
+        "@sentry/types": "7.105.0",
+        "@sentry/utils": "7.105.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sentry-internal/tracing": {
+      "version": "7.105.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.105.0.tgz",
+      "integrity": "sha512-b+AFYB7Bc9vmyxl2jbmuT4esX5G0oPfpz35A0sxFzmJIhvMg1YMDNio2c81BtKN+VSPORCnKMLhfk3kyKKvWMQ==",
+      "dev": true,
+      "dependencies": {
+        "@sentry/core": "7.105.0",
+        "@sentry/types": "7.105.0",
+        "@sentry/utils": "7.105.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/babel-plugin-component-annotate": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-2.14.2.tgz",
+      "integrity": "sha512-mFBVnIZmdMrpxo61rG5yf0WFt5VrRpy8cpIpJtT3mYkX9vDmcUZaZaD1ctv73iZF3QwaieVdn05Na5mWzZ8h/A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "7.105.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.105.0.tgz",
+      "integrity": "sha512-OlYJzsZG109T1VpZ7O7KXf9IXCUUpp41lkkQM7ICBOBsfiHRUKmV5piTGCG5UgAvyb/gI/I1uQQtO4jthcHKEA==",
+      "dev": true,
+      "dependencies": {
+        "@sentry-internal/feedback": "7.105.0",
+        "@sentry-internal/replay-canvas": "7.105.0",
+        "@sentry-internal/tracing": "7.105.0",
+        "@sentry/core": "7.105.0",
+        "@sentry/replay": "7.105.0",
+        "@sentry/types": "7.105.0",
+        "@sentry/utils": "7.105.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@sentry/bundler-plugin-core/-/bundler-plugin-core-2.14.2.tgz",
+      "integrity": "sha512-HgOFWYdq87lSmeVW1w8K2Vf2DGzRPvKzHTajZYLTPlrZ1jbajq9vwuqhrJ9AnDkjl0mjyzSPEy3ZTeG1Z7uRNA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "7.18.5",
+        "@sentry/babel-plugin-component-annotate": "2.14.2",
+        "@sentry/cli": "^2.22.3",
+        "dotenv": "^16.3.1",
+        "find-up": "5.0.0",
+        "glob": "9.3.2",
+        "magic-string": "0.27.0",
+        "unplugin": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/@babel/core": {
+      "version": "7.18.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.5.tgz",
+      "integrity": "sha512-MGY8vg3DxMnctw0LdvSEojOsumc70g0t18gNyUdAZqB1Rpd1Bqo/svHGvt+UJ6JcGX+DIekGFDxxIWofBxLCnQ==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.1.0",
+        "@babel/code-frame": "^7.16.7",
+        "@babel/generator": "^7.18.2",
+        "@babel/helper-compilation-targets": "^7.18.2",
+        "@babel/helper-module-transforms": "^7.18.0",
+        "@babel/helpers": "^7.18.2",
+        "@babel/parser": "^7.18.5",
+        "@babel/template": "^7.16.7",
+        "@babel/traverse": "^7.18.5",
+        "@babel/types": "^7.18.4",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.1",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/glob": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.2.tgz",
+      "integrity": "sha512-BTv/JhKXFEHsErMte/AnfiSv8yYOLLiyH2lTg8vn02O21zWFgHPTfxtgn1QRe7NRgggUhC8hacR2Re94svHqeA==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "minimatch": "^7.4.1",
+        "minipass": "^4.2.4",
+        "path-scurry": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/minimatch": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
+      "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/minipass": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@sentry/cli": {
+      "version": "2.28.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.28.6.tgz",
+      "integrity": "sha512-o2Ngz7xXuhwHxMi+4BFgZ4qjkX0tdZeOSIZkFAGnTbRhQe5T8bxq6CcQRLdPhqMgqvDn7XuJ3YlFtD3ZjHvD7g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "sentry-cli": "bin/sentry-cli"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@sentry/cli-darwin": "2.28.6",
+        "@sentry/cli-linux-arm": "2.28.6",
+        "@sentry/cli-linux-arm64": "2.28.6",
+        "@sentry/cli-linux-i686": "2.28.6",
+        "@sentry/cli-linux-x64": "2.28.6",
+        "@sentry/cli-win32-i686": "2.28.6",
+        "@sentry/cli-win32-x64": "2.28.6"
+      }
+    },
+    "node_modules/@sentry/cli-darwin": {
+      "version": "2.28.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.28.6.tgz",
+      "integrity": "sha512-KRf0VvTltHQ5gA7CdbUkaIp222LAk/f1+KqpDzO6nB/jC/tL4sfiy6YyM4uiH6IbVEudB8WpHCECiatmyAqMBA==",
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm": {
+      "version": "2.28.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.28.6.tgz",
+      "integrity": "sha512-ANG7U47yEHD1g3JrfhpT4/MclEvmDZhctWgSP5gVw5X4AlcI87E6dTqccnLgvZjiIAQTaJJAZuSHVVF3Jk403w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm64": {
+      "version": "2.28.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.28.6.tgz",
+      "integrity": "sha512-caMDt37FI752n4/3pVltDjlrRlPFCOxK4PHvoZGQ3KFMsai0ZhE/0CLBUMQqfZf0M0r8KB2x7wqLm7xSELjefQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-i686": {
+      "version": "2.28.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.28.6.tgz",
+      "integrity": "sha512-Tj1+GMc6lFsDRquOqaGKXFpW9QbmNK4TSfynkWKiJxdTEn5jSMlXXfr0r9OQrxu3dCCqEHkhEyU63NYVpgxIPw==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-x64": {
+      "version": "2.28.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.28.6.tgz",
+      "integrity": "sha512-Dt/Xz784w/z3tEObfyJEMmRIzn0D5qoK53H9kZ6e0yNvJOSKNCSOq5cQk4n1/qeG0K/6SU9dirmvHwFUiVNyYg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-i686": {
+      "version": "2.28.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.28.6.tgz",
+      "integrity": "sha512-zkpWtvY3kt+ogVaAbfFr2MEkgMMHJNJUnNMO8Ixce9gh38sybIkDkZNFnVPBXMClJV0APa4QH0EwumYBFZUMuQ==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-x64": {
+      "version": "2.28.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.28.6.tgz",
+      "integrity": "sha512-TG2YzZ9JMeNFzbicdr5fbtsusVGACbrEfHmPgzWGDeLUP90mZxiMTjkXsE1X/5jQEQjB2+fyfXloba/Ugo51hA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "7.105.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.105.0.tgz",
+      "integrity": "sha512-5xsaTG6jZincTeJUmZomlv20mVRZUEF1U/g89lmrSOybyk2+opEnB1JeBn4ODwnvmSik8r2QLr6/RiYlaxRJCg==",
+      "dev": true,
+      "dependencies": {
+        "@sentry/types": "7.105.0",
+        "@sentry/utils": "7.105.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "7.105.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.105.0.tgz",
+      "integrity": "sha512-t9MXmMC6lNv8Hj+eng6ZQg9UdrmOeds8yh2382d/yOcdLR3yFA/JVga1BiR/P9D/26Y6YVE8DgTcn8gz4xKngg==",
+      "dev": true,
+      "dependencies": {
+        "@sentry/browser": "7.105.0",
+        "@sentry/core": "7.105.0",
+        "@sentry/types": "7.105.0",
+        "@sentry/utils": "7.105.0",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "react": "15.x || 16.x || 17.x || 18.x"
+      }
+    },
+    "node_modules/@sentry/replay": {
+      "version": "7.105.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.105.0.tgz",
+      "integrity": "sha512-hZD2m6fNL9gorUOaaEpqxeH7zNP4y2Ej0TdieM1HMQ2q9Zrm9yOzk9/7ALfbRLIZFRMFTqo9vvVztLs3E+Hx+g==",
+      "dev": true,
+      "dependencies": {
+        "@sentry-internal/tracing": "7.105.0",
+        "@sentry/core": "7.105.0",
+        "@sentry/types": "7.105.0",
+        "@sentry/utils": "7.105.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sentry/types": {
+      "version": "7.105.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.105.0.tgz",
+      "integrity": "sha512-80o0KMVM+X2Ym9hoQxvJetkJJwkpCg7o6tHHFXI+Rp7fawc2iCMTa0IRQMUiSkFvntQLYIdDoNNuKdzz2PbQGA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/utils": {
+      "version": "7.105.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.105.0.tgz",
+      "integrity": "sha512-YVAV0c2KLM8+VZCicQ/E/P2+J9Vs0hGhrXwV7w6ZEAtvxrg4oF270toL1WRhvcaf8JO4J1v4V+LuU6Txs4uEeQ==",
+      "dev": true,
+      "dependencies": {
+        "@sentry/types": "7.105.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/vite-plugin": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/@sentry/vite-plugin/-/vite-plugin-2.14.2.tgz",
+      "integrity": "sha512-t8IiRZGxivtODgabjgHlgUhOBEIJdOclJGUKLAJjJqPtYeKjPzxYOo/Z5yt7k1rhBAaMhFk3whW5o7SOq4KVOA==",
+      "dev": true,
+      "dependencies": {
+        "@sentry/bundler-plugin-core": "2.14.2",
+        "unplugin": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.25.21",
       "license": "MIT"
@@ -12879,6 +13362,21 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dev": true,
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
+    },
     "node_modules/hosted-git-info": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
@@ -16147,6 +16645,18 @@
         "lz-string": "bin/bin.js"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+      "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "license": "MIT",
@@ -18633,6 +19143,40 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
+      "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^9.1.1 || ^10.0.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+      "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
+      "dev": true,
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/path-scurry/node_modules/minipass": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
+      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
     },
     "node_modules/path-to-regexp": {
       "version": "6.2.1",
@@ -22006,6 +22550,18 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/unplugin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.0.1.tgz",
+      "integrity": "sha512-aqrHaVBWW1JVKBHmGo33T5TxeL0qWzfvjWokObHA9bYmN7eNDkwOxmLjhioHl9878qDFMAaT51XNroRyuz7WxA==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.8.1",
+        "chokidar": "^3.5.3",
+        "webpack-sources": "^3.2.3",
+        "webpack-virtual-modules": "^0.5.0"
+      }
+    },
     "node_modules/upath": {
       "version": "2.0.1",
       "dev": true,
@@ -22738,6 +23294,21 @@
       "version": "3.0.1",
       "license": "BSD-2-Clause"
     },
+    "node_modules/webpack-sources": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+      "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webpack-virtual-modules": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.5.0.tgz",
+      "integrity": "sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==",
+      "dev": true
+    },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "license": "MIT",
@@ -23141,7 +23712,7 @@
     },
     "packages/components": {
       "name": "@mapsindoors/components",
-      "version": "13.17.1",
+      "version": "13.18.0",
       "license": "MIT",
       "dependencies": {
         "@11ty/eleventy": "^2.0.0",
@@ -23181,12 +23752,14 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.36.4",
+      "version": "1.39.0",
       "devDependencies": {
         "@googlemaps/js-api-loader": "^1.15.1",
         "@mapsindoors/components": "*",
         "@mapsindoors/css": "^3.0.0",
         "@mapsindoors/midt": "*",
+        "@sentry/react": "^7.105.0",
+        "@sentry/vite-plugin": "^2.14.2",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",

--- a/packages/map-template/.gitignore
+++ b/packages/map-template/.gitignore
@@ -21,3 +21,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# Sentry Config File
+.env.sentry-build-plugin

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.40.0] - 2024-03-06
+
+### Added 
+
+- Added Sentry for Error Logging and Performance Metrics
+
 ## [1.39.1] - 2024-03-04
 
 ### Added 

--- a/packages/map-template/package.json
+++ b/packages/map-template/package.json
@@ -12,6 +12,8 @@
     "@mapsindoors/components": "*",
     "@mapsindoors/css": "^3.0.0",
     "@mapsindoors/midt": "*",
+    "@sentry/react": "^7.105.0",
+    "@sentry/vite-plugin": "^2.14.2",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/packages/map-template/src/App.jsx
+++ b/packages/map-template/src/App.jsx
@@ -14,5 +14,4 @@ function App() {
     );
 }
 
-export default Sentry.withProfiler(App, { name: "MapsIndoorsMap" });
-
+export default Sentry.withProfiler(App, { name: "App" });

--- a/packages/map-template/src/App.jsx
+++ b/packages/map-template/src/App.jsx
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/react";
 import './App.css';
 import MapsIndoorsMap from './components/MapsIndoorsMap/MapsIndoorsMap';
 
@@ -13,5 +14,5 @@ function App() {
     );
 }
 
-export default App;
+export default Sentry.withProfiler(App, { name: "MapsIndoorsMap" });
 

--- a/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
+++ b/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
@@ -1,4 +1,6 @@
-import { useEffect, useState } from 'react';
+import * as Sentry from "@sentry/react";
+import React, { useEffect, useState } from 'react';
+import { createRoutesFromChildren, matchRoutes, useLocation, useNavigationType } from 'react-dom/client';
 import { RecoilRoot } from 'recoil';
 import MapTemplate from '../MapTemplate/MapTemplate.jsx';
 
@@ -110,6 +112,36 @@ function MapsIndoorsMap(props) {
         </RecoilRoot>
     )
 }
+
+Sentry.init({
+    dsn: "https://0ee7fa162023d958c96db25e99c8ff6c@o351128.ingest.sentry.io/4506851619831808",
+    // Set environment to localhost if the url includes it. Otherwise, set to production.
+    environment: window.location.hostname === 'localhost' ? 'localhost' : 'production',
+    integrations: [
+        // See docs for support of different versions of variation of react router
+        // https://docs.sentry.io/platforms/javascript/guides/react/configuration/integrations/react-router/
+        Sentry.reactRouterV6BrowserTracingIntegration({
+            useEffect: React.useEffect,
+            useLocation,
+            useNavigationType,
+            createRoutesFromChildren,
+            matchRoutes
+        }),
+        Sentry.replayIntegration()
+    ],
+
+    // Set tracesSampleRate to 1.0 to capture 100%
+    // of transactions for performance monitoring.
+    tracesSampleRate: 1.0,
+
+    // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+    tracePropagationTargets: ["localhost", /^https:\/\/api\.mapsindoors\.com/],
+
+    // Capture Replay for 10% of all sessions,
+    // plus for 100% of sessions with an error
+    replaysSessionSampleRate: 0.1,
+    replaysOnErrorSampleRate: 1.0,
+});
 
 export default MapsIndoorsMap;
 

--- a/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
+++ b/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
@@ -120,6 +120,8 @@ Sentry.init({
     integrations: [
         // See docs for support of different versions of variation of react router
         // https://docs.sentry.io/platforms/javascript/guides/react/configuration/integrations/react-router/
+        // Note: While we don't use React Router in the Map Template project, this is needed to instrument
+        // the `/` route properly. Without this, Sentry will not log anything on the main page of this app.
         Sentry.reactRouterV6BrowserTracingIntegration({
             useEffect: React.useEffect,
             useLocation,

--- a/packages/map-template/src/components/SplashScreen/SplashScreen.jsx
+++ b/packages/map-template/src/components/SplashScreen/SplashScreen.jsx
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/react";
 import React from "react";
 import { useRecoilValue } from "recoil";
 import primaryColorState from "../../atoms/primaryColorState";
@@ -32,4 +33,4 @@ function SplashScreen() {
     )
 }
 
-export default SplashScreen;
+export default Sentry.withProfiler(SplashScreen, { name: "SplashScreen" });

--- a/packages/map-template/src/index.jsx
+++ b/packages/map-template/src/index.jsx
@@ -1,24 +1,26 @@
 import * as Sentry from "@sentry/react";
 import React from 'react';
-import ReactDOM, { createRoutesFromChildren, matchRoutes, useLocation, useNavigationType } from 'react-dom/client';
+import ReactDOM from 'react-dom/client';
+// import { createRoutesFromChildren, matchRoutes, useLocation, useNavigationType } from 'react-dom/client';
 import App from './App';
 import './index.css';
 import reportWebVitals from './reportWebVitals';
 
 Sentry.init({
 dsn: "https://0ee7fa162023d958c96db25e99c8ff6c@o351128.ingest.sentry.io/4506851619831808",
+// Set environment to localhost if the url includes it. Otherwise, set to production.
 environment: window.location.hostname === 'localhost' ? 'localhost' : 'production',
 integrations: [
-        // See docs for support of different versions of variation of react router
-        // https://docs.sentry.io/platforms/javascript/guides/react/configuration/integrations/react-router/
-        Sentry.reactRouterV6BrowserTracingIntegration({
-                useEffect: React.useEffect,
-                useLocation,
-                useNavigationType,
-                createRoutesFromChildren,
-                matchRoutes
-        }),
-        Sentry.replayIntegration()
+    // See docs for support of different versions of variation of react router
+    // https://docs.sentry.io/platforms/javascript/guides/react/configuration/integrations/react-router/
+    // Sentry.reactRouterV6BrowserTracingIntegration({
+    //         useEffect: React.useEffect,
+    //         useLocation,
+    //         useNavigationType,
+    //         createRoutesFromChildren,
+    //         matchRoutes
+    // }),
+    Sentry.replayIntegration()
 ],
 
 // Set tracesSampleRate to 1.0 to capture 100%

--- a/packages/map-template/src/index.jsx
+++ b/packages/map-template/src/index.jsx
@@ -7,38 +7,38 @@ import './index.css';
 import reportWebVitals from './reportWebVitals';
 
 Sentry.init({
-dsn: "https://0ee7fa162023d958c96db25e99c8ff6c@o351128.ingest.sentry.io/4506851619831808",
-// Set environment to localhost if the url includes it. Otherwise, set to production.
-environment: window.location.hostname === 'localhost' ? 'localhost' : 'production',
-integrations: [
-    // See docs for support of different versions of variation of react router
-    // https://docs.sentry.io/platforms/javascript/guides/react/configuration/integrations/react-router/
-    // Sentry.reactRouterV6BrowserTracingIntegration({
-    //         useEffect: React.useEffect,
-    //         useLocation,
-    //         useNavigationType,
-    //         createRoutesFromChildren,
-    //         matchRoutes
-    // }),
-    Sentry.replayIntegration()
-],
+    dsn: "https://0ee7fa162023d958c96db25e99c8ff6c@o351128.ingest.sentry.io/4506851619831808",
+    // Set environment to localhost if the url includes it. Otherwise, set to production.
+    environment: window.location.hostname === 'localhost' ? 'localhost' : 'production',
+    integrations: [
+        // See docs for support of different versions of variation of react router
+        // https://docs.sentry.io/platforms/javascript/guides/react/configuration/integrations/react-router/
+        // Sentry.reactRouterV6BrowserTracingIntegration({
+        //     useEffect: React.useEffect,
+        //     useLocation,
+        //     useNavigationType,
+        //     createRoutesFromChildren,
+        //     matchRoutes
+        // }),
+        Sentry.replayIntegration()
+    ],
 
-// Set tracesSampleRate to 1.0 to capture 100%
-// of transactions for performance monitoring.
-tracesSampleRate: 1.0,
+    // Set tracesSampleRate to 1.0 to capture 100%
+    // of transactions for performance monitoring.
+    tracesSampleRate: 1.0,
 
-// Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
-tracePropagationTargets: ["localhost", /^https:\/\/api\.mapsindoors\.com/],
+    // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+    tracePropagationTargets: ["localhost", /^https:\/\/api\.mapsindoors\.com/],
 
-// Capture Replay for 10% of all sessions,
-// plus for 100% of sessions with an error
-replaysSessionSampleRate: 0.1,
-replaysOnErrorSampleRate: 1.0,
+    // Capture Replay for 10% of all sessions,
+    // plus for 100% of sessions with an error
+    replaysSessionSampleRate: 0.1,
+    replaysOnErrorSampleRate: 1.0,
 });
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
-        <App />
+    <App />
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/packages/map-template/src/index.jsx
+++ b/packages/map-template/src/index.jsx
@@ -1,7 +1,6 @@
 import * as Sentry from "@sentry/react";
 import React from 'react';
-import ReactDOM from 'react-dom/client';
-// import { createRoutesFromChildren, matchRoutes, useLocation, useNavigationType } from 'react-dom/client';
+import ReactDOM, { createRoutesFromChildren, matchRoutes, useLocation, useNavigationType } from 'react-dom/client';
 import App from './App';
 import './index.css';
 import reportWebVitals from './reportWebVitals';
@@ -13,13 +12,13 @@ Sentry.init({
     integrations: [
         // See docs for support of different versions of variation of react router
         // https://docs.sentry.io/platforms/javascript/guides/react/configuration/integrations/react-router/
-        // Sentry.reactRouterV6BrowserTracingIntegration({
-        //     useEffect: React.useEffect,
-        //     useLocation,
-        //     useNavigationType,
-        //     createRoutesFromChildren,
-        //     matchRoutes
-        // }),
+        Sentry.reactRouterV6BrowserTracingIntegration({
+            useEffect: React.useEffect,
+            useLocation,
+            useNavigationType,
+            createRoutesFromChildren,
+            matchRoutes
+        }),
         Sentry.replayIntegration()
     ],
 

--- a/packages/map-template/src/index.jsx
+++ b/packages/map-template/src/index.jsx
@@ -1,8 +1,38 @@
+import * as Sentry from "@sentry/react";
 import React from 'react';
-import ReactDOM from 'react-dom/client';
+import ReactDOM, { createRoutesFromChildren, matchRoutes, useLocation, useNavigationType } from 'react-dom/client';
 import App from './App';
 import './index.css';
 import reportWebVitals from './reportWebVitals';
+
+Sentry.init({
+dsn: "https://0ee7fa162023d958c96db25e99c8ff6c@o351128.ingest.sentry.io/4506851619831808",
+environment: window.location.hostname === 'localhost' ? 'localhost' : 'production',
+integrations: [
+        // See docs for support of different versions of variation of react router
+        // https://docs.sentry.io/platforms/javascript/guides/react/configuration/integrations/react-router/
+        Sentry.reactRouterV6BrowserTracingIntegration({
+                useEffect: React.useEffect,
+                useLocation,
+                useNavigationType,
+                createRoutesFromChildren,
+                matchRoutes
+        }),
+        Sentry.replayIntegration()
+],
+
+// Set tracesSampleRate to 1.0 to capture 100%
+// of transactions for performance monitoring.
+tracesSampleRate: 1.0,
+
+// Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+tracePropagationTargets: ["localhost", /^https:\/\/api\.mapsindoors\.com/],
+
+// Capture Replay for 10% of all sessions,
+// plus for 100% of sessions with an error
+replaysSessionSampleRate: 0.1,
+replaysOnErrorSampleRate: 1.0,
+});
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(

--- a/packages/map-template/src/index.jsx
+++ b/packages/map-template/src/index.jsx
@@ -1,39 +1,8 @@
-import * as Sentry from "@sentry/react";
 import React from 'react';
-import ReactDOM, { createRoutesFromChildren, matchRoutes, useLocation, useNavigationType } from 'react-dom/client';
+import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
 import reportWebVitals from './reportWebVitals';
-
-Sentry.init({
-    dsn: "https://0ee7fa162023d958c96db25e99c8ff6c@o351128.ingest.sentry.io/4506851619831808",
-    // Set environment to localhost if the url includes it. Otherwise, set to production.
-    environment: window.location.hostname === 'localhost' ? 'localhost' : 'production',
-    integrations: [
-        // See docs for support of different versions of variation of react router
-        // https://docs.sentry.io/platforms/javascript/guides/react/configuration/integrations/react-router/
-        Sentry.reactRouterV6BrowserTracingIntegration({
-            useEffect: React.useEffect,
-            useLocation,
-            useNavigationType,
-            createRoutesFromChildren,
-            matchRoutes
-        }),
-        Sentry.replayIntegration()
-    ],
-
-    // Set tracesSampleRate to 1.0 to capture 100%
-    // of transactions for performance monitoring.
-    tracesSampleRate: 1.0,
-
-    // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
-    tracePropagationTargets: ["localhost", /^https:\/\/api\.mapsindoors\.com/],
-
-    // Capture Replay for 10% of all sessions,
-    // plus for 100% of sessions with an error
-    replaysSessionSampleRate: 0.1,
-    replaysOnErrorSampleRate: 1.0,
-});
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(

--- a/packages/map-template/vite.config.js
+++ b/packages/map-template/vite.config.js
@@ -21,11 +21,11 @@ export default defineConfig(() => {
             ViteFaviconsPlugin('./public/favicon.png'),
             eslint(),
             sentryVitePlugin({
-                org: 'mapspeople-gx',
-                project: 'map-mapsindoors',
+                org: process.env.SENTRY_ORG,
+                project: process.env.SENTRY_PROJECT,
           
                 // Auth tokens can be obtained from https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/
-                authToken: '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',
+                authToken: process.env.SENTRY_AUTH_TOKEN,
                 reactComponentAnnotation: { enabled: true },
             }),
         ]

--- a/packages/map-template/vite.config.js
+++ b/packages/map-template/vite.config.js
@@ -1,8 +1,9 @@
-import { defineConfig } from 'vite';
+import { sentryVitePlugin } from "@sentry/vite-plugin";
 import react from '@vitejs/plugin-react';
-import svgr from 'vite-plugin-svgr';
+import { defineConfig } from 'vite';
 import eslint from 'vite-plugin-eslint';
 import { ViteFaviconsPlugin } from 'vite-plugin-favicon2';
+import svgr from 'vite-plugin-svgr';
 
 
 export default defineConfig(() => {
@@ -11,13 +12,22 @@ export default defineConfig(() => {
             port: 3000
         },
         build: {
-            outDir: 'build'
+            outDir: 'build',
+            sourcemap: true,
         },
         plugins: [
             react(),
             svgr(),
             ViteFaviconsPlugin('./public/favicon.png'),
-            eslint()
+            eslint(),
+            sentryVitePlugin({
+                org: 'mapspeople-gx',
+                project: 'map-mapsindoors',
+          
+                // Auth tokens can be obtained from https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/
+                authToken: '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',
+                reactComponentAnnotation: { enabled: true },
+            }),
         ]
     }
 });


### PR DESCRIPTION
Adding support for Sentry Error Logging, Release Tracking, and Application Performance Monitoring.

One big thing that makes the Map Template deviate from the standard Sentry docs is that we don't use React Routes, but keep everything on `/` as a single-page app. We can do profiling of individual components, and that might give us more insight into which ones are heavy/slow, or other bottlenecks they might create. Docs here: https://docs.sentry.io/platforms/javascript/guides/react/features/component-tracking/. I haven't seen a named Component automatically tracked, besides the one [I made myself](https://github.com/MapsPeople/web-ui/pull/343#pullrequestreview-1914170685), so we need to go in and name all of the components.