### PR TITLE
Use jsDelivr as CDN for Map Template Web Component

### DIFF
--- a/.github/workflows/bump-version-release.yml
+++ b/.github/workflows/bump-version-release.yml
@@ -275,3 +275,16 @@ jobs:
       - name: Publish to npm
         if: steps.changed-files-map-template.outputs.any_changed == 'true'
         run: npm -w @mapsindoors/map-template publish --access public
+
+  # Using jsDelivr as the CDN, it will cache even @latest for up to 7 days. Specific versions are cached for up to a year, so we need to purge the CDN manually.
+  purge-jsdelivr-cache:
+    name: Purge jsDelivr cache
+    runs-on: ubuntu-latest
+    steps:
+      - name: Purge @latest version
+        run: |
+          curl -X PURGE "https://purge.jsdelivr.net/npm/@mapsindoors/map-template@latest"
+
+      - name: Purge @stable version
+        run: |
+          curl -X PURGE "https://purge.jsdelivr.net/npm/@mapsindoors/map-template@stable"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -10,6 +10,7 @@
     "collection": "dist/collection/collection-manifest.json",
     "collection:main": "dist/collection/index.js",
     "unpkg": "dist/mi-components/mi-components.js",
+    "jsdelivr": "dist/mi-components/mi-components.js",
     "files": [
         "dist/",
         "loader/"

--- a/packages/map-template/README.md
+++ b/packages/map-template/README.md
@@ -57,7 +57,7 @@ Use query parameters to configure the Web Component by setting the `supports-url
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MapsIndoors Map Template</title>
     <script type="module">
-        import MapsindoorsMap from 'https://cdn.jsdelivr.net/npm/@mapsindoors/map-template@stable/dist/mapsindoors-webcomponent.es.min.js';
+        import MapsindoorsMap from 'https://www.unpkg.com/@mapsindoors/map-template@stable/dist/mapsindoors-webcomponent.es.js';
         window.customElements.define('mapsindoors-map', MapsindoorsMap)
     </script>
     <style>

--- a/packages/map-template/README.md
+++ b/packages/map-template/README.md
@@ -57,7 +57,7 @@ Use query parameters to configure the Web Component by setting the `supports-url
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MapsIndoors Map Template</title>
     <script type="module">
-        import MapsindoorsMap from 'https://www.unpkg.com/@mapsindoors/map-template@stable/dist/mapsindoors-webcomponent.es.js';
+        import MapsindoorsMap from 'https://cdn.jsdelivr.net/npm/@mapsindoors/map-template@stable/dist/mapsindoors-webcomponent.es.min.js';
         window.customElements.define('mapsindoors-map', MapsindoorsMap)
     </script>
     <style>

--- a/packages/midt/package.json
+++ b/packages/midt/package.json
@@ -18,6 +18,7 @@
   "sass": "mixins/_index.scss",
   "style": "midt.css",
   "unpkg": "build/css/variables.css",
+  "jsdelivr": "build/css/variables.css",
   "scripts": {
     "build": "npm run clean && style-dictionary build",
     "clean": "style-dictionary clean",


### PR DESCRIPTION
We could just go ahead and use jsDelivr as the CDN, but it caches even the `@latest` version very hard, and that would be a problem for us (it can take up 7 days before it's updated).

Including a workflow step to purge the CDN, we should see better results than using unpkg as the CDN, and hopefully don't run into trouble with files that are cached for too long.