### PR TITLE
Add support for searching in the same venue by default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23752,7 +23752,7 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.39.0",
+      "version": "1.40.0",
       "devDependencies": {
         "@googlemaps/js-api-loader": "^1.15.1",
         "@mapsindoors/components": "*",

--- a/packages/map-template/.github/README.md
+++ b/packages/map-template/.github/README.md
@@ -84,6 +84,8 @@ When loading the MapsIndoors Map component for the first time, the map will resp
 |`timeout`|`number`|If you want the Map Template to reset the map position and the UI elements to the initial state after some time of inactivity, use this to specify the number of seconds of inactivity before resetting. This property is not dependent on the `kioskOriginLocationId`. |
 |`useKeyboard`|`bool`|If running the Map Template as a Kiosk, set this prop to `true` and it will display a virtual keyboard. This property is dependent on the `kioskOriginLocationId`. |
 |`miTransitionLevel`|`number`|The zoom level on which to transition from Mapbox to MapsIndoors data. Default value is 17. This feature is only available for Mapbox. |
+|`category`|`string`|If you want to indicate an active category on the map. The value should be the Key (Administrative ID). |
+|`searchAllVenues`|`bool`|If you want to perform search across all venues in the solution. |
 
 ## Using Query Parameters
 
@@ -114,6 +116,7 @@ The supported query parameters are the following:
 21. `useKeyboard` -  If running the Map Template as a Kiosk, set this prop to `true` and it will display a virtual keyboard. This property is dependent on the `kioskOriginLocationId`.
 22. `miTransitionLevel` - The zoom level on which to transition from Mapbox to MapsIndoors data. Default value is 17. This feature is only available for Mapbox.
 23. `category` - If you want to indicate an active category on the map. The value should be the Key (Administrative ID).
+24. `searchAllVenues` - If you want to perform search across all venues in the solution.
 
 **Note!** All the query parameters need to be separated with the `&` symbol, without any spaces in between.
 **Note!** When using parameters such as `directionsTo`, `directionsFrom`, `locationId`, `externalIDs`, and `tileStyle` make sure you are using the correct `apiKey` parameter to which they belong.

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.43.0] - 2024-03-26
+
+### Added
+
+- Add support for new parameter `searchAllVenues` which searches across all venues in one solution. 
+- Change the default behaviour to search in one venue.
+
 ## [1.42.0] - 2024-03-26
 
 ### Added

--- a/packages/map-template/README.md
+++ b/packages/map-template/README.md
@@ -136,6 +136,7 @@ Note that when using the React component, the properties should conform to JSX p
 |`use-keyboard`|`useKeyboard`|`bool`|If running the Map Template as a Kiosk, set this prop to `true` and it will display a virtual keyboard. This property is dependent on the `kioskOriginLocationId`. |
 |`mi-transition-level`|`miTransitionLevel`|`number`|The zoom level on which to transition from Mapbox to MapsIndoors data. Default value is 17. This feature is only available for Mapbox. |
 |`category`|`category`|`string`|If you want to indicate an active category on the map. The value should be the Key (Administrative ID). |
+|`search-all-venues`|`searchAllVenues`|`bool`|If you want to perform search across all venues in the solution. |
 
 ## Using Query Parameters
 
@@ -166,6 +167,7 @@ The supported query parameters are the following:
 21. `useKeyboard` -  If running the Map Template as a Kiosk, set this prop to `true` and it will display a virtual keyboard. This property is dependent on the `kioskOriginLocationId`.
 22. `miTransitionLevel` - The zoom level on which to transition from Mapbox to MapsIndoors data. Default value is 17. This feature is only available for Mapbox.
 23. `category` - If you want to indicate an active category on the map. The value should be the Key (Administrative ID).
+24. `searchAllVenues` - If you want to perform search across all venues in the solution.
 
 **Note!** All the query parameters need to be separated with the `&` symbol, without any spaces in between.
 **Note!** When using parameters such as `directionsTo`, `directionsFrom`, `locationId`, `externalIDs`, and `tileStyle` make sure you are using the correct `apiKey` parameter to which they belong.

--- a/packages/map-template/releaseTools/webcomponent.js
+++ b/packages/map-template/releaseTools/webcomponent.js
@@ -32,6 +32,7 @@ MapsIndoorsMap.propTypes = {
     miTransitionLevel: PropTypes.number,
     category: PropTypes.string,
     language: PropTypes.string,
+    searchAllVenues: PropTypes.bool,
 };
 
 const WebMapsIndoorsMap = reactToWebComponent(MapsIndoorsMap, React, ReactDOM);

--- a/packages/map-template/src/atoms/searchAllVenues.js
+++ b/packages/map-template/src/atoms/searchAllVenues.js
@@ -1,0 +1,8 @@
+import { atom } from 'recoil';
+
+const searchAllVenuesState = atom({
+    key: 'searchAllVenues',
+    default: false
+});
+
+export default searchAllVenuesState;

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -51,6 +51,7 @@ import selectedCategoryState from '../../atoms/selectedCategoryState.js';
 import LegendDialog from '../LegendDialog/LegendDialog.jsx';
 import isLegendDialogVisibleState from '../../atoms/isLegendDialogVisibleState.js';
 import searchAllVenuesState from '../../atoms/searchAllVenues.js';
+import currentVenueNameState from '../../atoms/currentVenueNameState.js';
 
 // Define the Custom Elements from our components package.
 defineCustomElements();
@@ -139,6 +140,7 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
     const isMobile = useMediaQuery('(max-width: 991px)');
     const resetState = useReset();
     const setCurrentVenueName = useSetCurrentVenueName();
+    const currentVenueName = useRecoilValue(currentVenueNameState);
     const [pushAppView, goBack, currentAppView, currentAppViewPayload, appStates, resetAppHistory] = useAppHistory();
 
     // Declare the reference to the disabled locations.
@@ -503,6 +505,16 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
         }
     }, [searchAllVenues, mapsindoorsSDKAvailable]);
 
+    /*
+     * React on changes to the currentVenueName prop.
+     * Get the venue categories based on the currentVenueName.
+     */
+    useEffect(() => {
+        if (mapsindoorsSDKAvailable && currentVenueName) {
+            getVenueCategories(currentVenueName)
+        }
+    }, [currentVenueName, mapsindoorsSDKAvailable]);
+
     /**
      * When venue is fitted while initializing the data,
      * set map to be ready and get the venue categories.
@@ -566,7 +578,7 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
 
             for (const key of keys) {
                 // Get the categories from the App Config that have a matching key.
-                const appConfigCategory = appConfig.menuInfo.mainmenu.find(category => category.categoryKey === key);
+                const appConfigCategory = appConfig?.menuInfo.mainmenu.find(category => category.categoryKey === key);
 
                 if (uniqueCategories.has(key)) {
                     let count = uniqueCategories.get(key).count;

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -109,7 +109,6 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
     const [, setSelectedCategory] = useRecoilState(selectedCategoryState);
     const [, setSearchAllVenues] = useRecoilState(searchAllVenuesState);
 
-
     const [showVenueSelector, setShowVenueSelector] = useState(true);
     const [showPositionControl, setShowPositionControl] = useState(true);
 

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -50,6 +50,7 @@ import miTransitionLevelState from '../../atoms/miTransitionLevelState.js';
 import selectedCategoryState from '../../atoms/selectedCategoryState.js';
 import LegendDialog from '../LegendDialog/LegendDialog.jsx';
 import isLegendDialogVisibleState from '../../atoms/isLegendDialogVisibleState.js';
+import searchAllVenuesState from '../../atoms/searchAllVenues.js';
 
 // Define the Custom Elements from our components package.
 defineCustomElements();
@@ -80,8 +81,9 @@ defineCustomElements();
  * @param {boolean} [props.useKeyboard] - If running the Map Template as a kiosk, set this prop to true and it will prompt a keyboard.
  * @param {number} [props.timeout] - If you want the Map Template to reset map position and UI elements to the initial state after some time of inactivity, use this to specify the number of seconds of inactivity before resetting.
  * @param {number} [props.miTransitionLevel] - The zoom level on which to transition from Mapbox to MapsIndoors data. Default value is 17. This feature is only available for Mapbox.
+ * @param {boolean} [props.searchAllVenues] - If you want to perform search across all venues in the solution.
  */
-function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, primaryColor, logo, appUserRoles, directionsFrom, directionsTo, externalIDs, tileStyle, startZoomLevel, bearing, pitch, gmMapId, useMapProviderModule, kioskOriginLocationId, language, supportsUrlParameters, useKeyboard, timeout, miTransitionLevel, category }) {
+function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, primaryColor, logo, appUserRoles, directionsFrom, directionsTo, externalIDs, tileStyle, startZoomLevel, bearing, pitch, gmMapId, useMapProviderModule, kioskOriginLocationId, language, supportsUrlParameters, useKeyboard, timeout, miTransitionLevel, category, searchAllVenues }) {
 
     const [, setApiKey] = useRecoilState(apiKeyState);
     const [, setGmApiKey] = useRecoilState(gmApiKeyState);
@@ -105,6 +107,8 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
     const [, setUseKeyboard] = useRecoilState(useKeyboardState);
     const [, setMiTransitionLevel] = useRecoilState(miTransitionLevelState);
     const [, setSelectedCategory] = useRecoilState(selectedCategoryState);
+    const [, setSearchAllVenues] = useRecoilState(searchAllVenuesState);
+
 
     const [showVenueSelector, setShowVenueSelector] = useState(true);
     const [showPositionControl, setShowPositionControl] = useState(true);
@@ -481,6 +485,25 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
         }
     }, [useKeyboard, kioskOriginLocationId, mapsindoorsSDKAvailable]);
 
+    /*
+     * React on changes in the category prop.
+     * Check if the category property matches with any of the existing categories.
+     */
+    useEffect(() => {
+        if (mapsindoorsSDKAvailable && category && categories.find((matched) => matched[0] === category)) {
+            setSelectedCategory(category);
+        }
+    }, [category, categories, mapsindoorsSDKAvailable]);
+
+    /*
+     * React on changes to the searchAllVenues prop.
+     */
+    useEffect(() => {
+        if (mapsindoorsSDKAvailable && searchAllVenues) {
+            setSearchAllVenues(searchAllVenues);
+        }
+    }, [searchAllVenues, mapsindoorsSDKAvailable]);
+
     /**
      * When venue is fitted while initializing the data,
      * set map to be ready and get the venue categories.
@@ -560,16 +583,6 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
 
         setCategories(uniqueCategories);
     }
-
-    /*
-     * React on changes in the category prop.
-     * Check if the category property matches with any of the existing categories.
-     */
-    useEffect(() => {
-        if (mapsindoorsSDKAvailable && category && categories.find((matched) => matched[0] === category)) {
-            setSelectedCategory(category);
-        }
-    }, [category, categories, mapsindoorsSDKAvailable]);
 
     return <div className={`mapsindoors-map ${locationsDisabledRef.current ? 'mapsindoors-map--hide-elements' : 'mapsindoors-map--show-elements'} ${showPositionControl ? 'mapsindoors-map--show-my-position' : 'mapsindoors-map--hide-my-position'}`}>
         <Notification />

--- a/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
+++ b/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
@@ -31,6 +31,7 @@ import MapTemplate from '../MapTemplate/MapTemplate.jsx';
  * @param {boolean} [props.useKeyboard] - If running the Map Template as a kiosk, set this prop to true and it will prompt a keyboard. 
  * @param {number} [props.miTransitionLevel] - The zoom level on which to transition from Mapbox to MapsIndoors data. Default value is 17. This feature is only available for Mapbox.
  * @param {string} [props.category] - If you want to indicate an active category on the map. The value should be the Key (Administrative ID).
+ * @param {boolean} [props.searchAllVenues] - If you want to perform search across all venues in the solution.
  */
 function MapsIndoorsMap(props) {
 
@@ -51,7 +52,8 @@ function MapsIndoorsMap(props) {
             logo: 'https://app.mapsindoors.com/mapsindoors/gfx/mapspeople-logo/mapspeople-pin.svg',
             primaryColor: '#005655', // --brand-colors-dark-pine-100 from MIDT
             useMapProviderModule: false,
-            useKeyboard: false
+            useKeyboard: false, 
+            searchAllVenues: false,
         };
 
         const apiKeyQueryParameter = queryStringParams.get('apiKey');
@@ -77,6 +79,7 @@ function MapsIndoorsMap(props) {
         const useKeyboardQueryParameter = getBooleanQueryParameter(queryStringParams.get('useKeyboard'));
         const miTransitionLevelQueryParameter = queryStringParams.get('miTransitionLevel');
 		const categoryQueryParameter = queryStringParams.get('category');
+		const searchAllVenuesParameter = getBooleanQueryParameter(queryStringParams.get('searchAllVenues'));
 
         setMapTemplateProps({
             apiKey: props.supportsUrlParameters && apiKeyQueryParameter ? apiKeyQueryParameter : (props.apiKey || defaultProps.apiKey),
@@ -103,6 +106,7 @@ function MapsIndoorsMap(props) {
             useKeyboard: props.supportsUrlParameters && useKeyboardQueryParameter ? useKeyboardQueryParameter : (props.useKeyboard || defaultProps.useKeyboard),
             miTransitionLevel: props.supportsUrlParameters && miTransitionLevelQueryParameter ? miTransitionLevelQueryParameter : props.miTransitionLevel,
 			category: props.supportsUrlParameters && categoryQueryParameter ? categoryQueryParameter : props.category,
+            searchAllVenues: props.supportsUrlParameters && searchAllVenuesParameter ? searchAllVenuesParameter : (props.searchAllVenues || defaultProps.searchAllVenues),
         });
     }, [props]);
 

--- a/packages/map-template/src/components/Search/Search.jsx
+++ b/packages/map-template/src/components/Search/Search.jsx
@@ -29,6 +29,7 @@ import { useIsDesktop } from '../../hooks/useIsDesktop';
 import { ReactComponent as Legend } from '../../assets/legend.svg';
 import isLegendDialogVisibleState from '../../atoms/isLegendDialogVisibleState';
 import legendSortedFieldsSelector from '../../selectors/legendSortedFieldsSelector';
+import searchAllVenuesState from '../../atoms/searchAllVenues';
 
 /**
  * Show the search results.
@@ -75,7 +76,7 @@ function Search({ onSetSize, isOpen }) {
 
     const [, setIsLocationClicked] = useRecoilState(isLocationClickedState);
 
-    const [currentVenueId, setCurrentVenueId] = useRecoilState(currentVenueNameState);
+    const [currentVenueName, setCurrentVenueName] = useRecoilState(currentVenueNameState);
 
     const currentLanguage = useRecoilValue(languageState);
 
@@ -95,6 +96,8 @@ function Search({ onSetSize, isOpen }) {
 
     const legendSections = useRecoilValue(legendSortedFieldsSelector);
 
+    const searchAllVenues = useRecoilValue(searchAllVenuesState);
+
     /**
      * 
      * Get the locations and filter through them based on categories selected.
@@ -104,7 +107,7 @@ function Search({ onSetSize, isOpen }) {
     function getFilteredLocations(category) {
         window.mapsindoors.services.LocationsService.getLocations({
             categories: category,
-            venue: kioskLocation && isKioskContext ? kioskLocation.properties.venueId : undefined,
+            venue: searchAllVenues ? undefined : currentVenueName,
         }).then(onResults);
     }
 
@@ -186,8 +189,8 @@ function Search({ onSetSize, isOpen }) {
         setCurrentLocation(location);
 
         // Set the current venue to be the selected location venue.
-        if (location.properties.venueId !== currentVenueId) {
-            setCurrentVenueId(location.properties.venueId);
+        if (location.properties.venueId !== currentVenueName) {
+            setCurrentVenueName(location.properties.venueId);
             setIsLocationClicked(true);
         }
 
@@ -269,7 +272,7 @@ function Search({ onSetSize, isOpen }) {
             setSearchResults([]);
             setSelectedCategory(null);
         }
-    }, [currentVenueId]);
+    }, [currentVenueName]);
 
     /*
      * React on changes in the app language. Any existing category search needs to update with translated Locations.

--- a/packages/map-template/src/components/WebComponentWrappers/Search/Search.jsx
+++ b/packages/map-template/src/components/WebComponentWrappers/Search/Search.jsx
@@ -4,8 +4,6 @@ import { useRecoilValue, useRecoilState } from 'recoil';
 import userPositionState from '../../../atoms/userPositionState';
 import languageState from '../../../atoms/languageState';
 import searchInputState from '../../../atoms/searchInputState';
-import kioskLocationState from '../../../atoms/kioskLocationState';
-import { useIsKioskContext } from '../../../hooks/useIsKioskContext';
 import currentVenueNameState from '../../../atoms/currentVenueNameState';
 import searchAllVenuesState from '../../../atoms/searchAllVenues';
 
@@ -32,8 +30,6 @@ const SearchField = forwardRef(({ placeholder, mapsindoors, results, clicked, cl
 
     const [, setSearchInput] = useRecoilState(searchInputState)
 
-    const kioskLocation = useRecoilValue(kioskLocationState);
-
     const mapboxPlacesSessionToken = sessionStorage.getItem('mapboxPlacesSessionToken');
 
     const userPositionCoordinates = {
@@ -44,7 +40,7 @@ const SearchField = forwardRef(({ placeholder, mapsindoors, results, clicked, cl
     /** Instruct the search field to search for Locations near the map center. */
     const searchNear = useNear();
 
-    const currentVenue = useRecoilValue(currentVenueNameState);
+    const currentVenueName = useRecoilValue(currentVenueNameState);
 
     const searchAllVenues = useRecoilValue(searchAllVenuesState);
 
@@ -122,7 +118,7 @@ const SearchField = forwardRef(({ placeholder, mapsindoors, results, clicked, cl
         disabled={disabled}
         mapbox={mapbox}
         google={google}
-        mi-venue={searchAllVenues ? undefined : currentVenue}
+        mi-venue={searchAllVenues ? undefined : currentVenueName}
         language={language} />
 });
 

--- a/packages/map-template/src/components/WebComponentWrappers/Search/Search.jsx
+++ b/packages/map-template/src/components/WebComponentWrappers/Search/Search.jsx
@@ -6,6 +6,8 @@ import languageState from '../../../atoms/languageState';
 import searchInputState from '../../../atoms/searchInputState';
 import kioskLocationState from '../../../atoms/kioskLocationState';
 import { useIsKioskContext } from '../../../hooks/useIsKioskContext';
+import currentVenueNameState from '../../../atoms/currentVenueNameState';
+import searchAllVenuesState from '../../../atoms/searchAllVenues';
 
 /**
  * React wrapper around the custom element <mi-search>.
@@ -32,8 +34,6 @@ const SearchField = forwardRef(({ placeholder, mapsindoors, results, clicked, cl
 
     const kioskLocation = useRecoilValue(kioskLocationState);
 
-    const isKioskContext = useIsKioskContext();
-
     const mapboxPlacesSessionToken = sessionStorage.getItem('mapboxPlacesSessionToken');
 
     const userPositionCoordinates = {
@@ -43,6 +43,10 @@ const SearchField = forwardRef(({ placeholder, mapsindoors, results, clicked, cl
 
     /** Instruct the search field to search for Locations near the map center. */
     const searchNear = useNear();
+
+    const currentVenue = useRecoilValue(currentVenueNameState);
+
+    const searchAllVenues = useRecoilValue(searchAllVenuesState);
 
     /**
      * Methods that can be triggered on the mi-search element.
@@ -118,7 +122,7 @@ const SearchField = forwardRef(({ placeholder, mapsindoors, results, clicked, cl
         disabled={disabled}
         mapbox={mapbox}
         google={google}
-        mi-venue={kioskLocation && isKioskContext ? kioskLocation.properties.venueId : undefined} // Restrict the search to the kiosk location venue when in kiosk mode.
+        mi-venue={searchAllVenues ? undefined : currentVenue}
         language={language} />
 });
 


### PR DESCRIPTION
# What 

- Add support for searching in the same venue by default 
- Add new parameter called `searchAllVenues` which is a boolean that can be set in order to perform search across all venues in a solution 
- Fix issue with categories not updating when changing the venue

# How 

- Add new boolean parameter `searchAllVenues` and create an atom for storing the value
- Rename the `currentVenueName` for consistency reasons 
- In the `Search.jsx` file in the wrapper component, add a check if the `searchAllVenues` prop is true in the `mi-venue`
- In the `Search.jsx` file, add the venue attribute when searching for selecting a category in order to get the filtered locations 
- Add a new `useEffect()` on the `MapTemplate.jsx` file which handles the changes in the `currentVenueName` atom, and gets the current categories based on that 