### PR TITLE
Disable Sentry replays

### DIFF
--- a/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
+++ b/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
@@ -139,9 +139,9 @@ Sentry.init({
     // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
     tracePropagationTargets: ["localhost", /^https:\/\/api\.mapsindoors\.com/],
 
-    // Capture Replay for 10% of all sessions,
-    // plus for 100% of sessions with an error
-    replaysSessionSampleRate: 0.1,
+    // Disable capture Replay for sessions.
+    // Set to 100% of sessions with an error
+    replaysSessionSampleRate: 0,
     replaysOnErrorSampleRate: 1.0,
 });
 


### PR DESCRIPTION
We're hitting the rate limit, and don't use it much at this moment anyway.