### PR TITLE
Add current venue name when venue has changed on map

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23752,7 +23752,7 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.40.0",
+      "version": "1.43.0",
       "devDependencies": {
         "@googlemaps/js-api-loader": "^1.15.1",
         "@mapsindoors/components": "*",

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.43.1] - 2024-04-08
+
+### Fixed
+
+- Fix the venue not updating correctly on the map. 
+
 ## [1.43.0] - 2024-03-26
 
 ### Added

--- a/packages/map-template/src/components/Map/Map.jsx
+++ b/packages/map-template/src/components/Map/Map.jsx
@@ -129,6 +129,7 @@ function Map({ onLocationClick, onVenueChangedOnMap, useMapProviderModule, onMap
 
     /*
      * When venue is changed on the map, run callback.
+     * Set the current venue name whenever the venue is changed on the map.
      */
     useEffect(() => {
         if (venueOnMap) {

--- a/packages/map-template/src/components/Map/Map.jsx
+++ b/packages/map-template/src/components/Map/Map.jsx
@@ -20,6 +20,7 @@ import pitchState from '../../atoms/pitchState';
 import solutionState from '../../atoms/solutionState';
 import notificationMessageState from '../../atoms/notificationMessageState';
 import useMapBoundsDeterminer from '../../hooks/useMapBoundsDeterminer';
+import currentVenueNameState from "../../atoms/currentVenueNameState";
 
 /**
  * Private variable used for storing the tile style.
@@ -53,6 +54,7 @@ function Map({ onLocationClick, onVenueChangedOnMap, useMapProviderModule, onMap
     const [, setPositionControl] = useRecoilState(positionControlState);
     const solution = useRecoilValue(solutionState);
     const [, setErrorMessage] = useRecoilState(notificationMessageState);
+    const [, setCurrentVenueName] = useRecoilState(currentVenueNameState);
     useLiveData(apiKey);
 
     const [mapPositionKnown, venueOnMap] = useMapBoundsDeterminer();
@@ -130,6 +132,7 @@ function Map({ onLocationClick, onVenueChangedOnMap, useMapProviderModule, onMap
      */
     useEffect(() => {
         if (venueOnMap) {
+            setCurrentVenueName(venueOnMap.name);
             onVenueChangedOnMap(venueOnMap);
         }
     }, [venueOnMap]);

--- a/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
+++ b/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
@@ -48,7 +48,7 @@ function MapsIndoorsMap(props) {
 
         const defaultProps = {
             apiKey: 'mapspeople3d',
-            venue: 'AUSTIN',
+            venue: 'AUSTINOFFICE',
             logo: 'https://app.mapsindoors.com/mapsindoors/gfx/mapspeople-logo/mapspeople-pin.svg',
             primaryColor: '#005655', // --brand-colors-dark-pine-100 from MIDT
             useMapProviderModule: false,


### PR DESCRIPTION
# What 

- Fix the issue of current venue name not changing from the default venue 

# How 

- Changed the `AUSTIN` to the correct default venue `AUSTINOFFICE`
- Added the `setCurrentVenueName` when the venue is changed on the map