### PR TITLE
MICMS-3678: Add 'disabled' option to the 'mi-dropdown-item'

### DIFF
--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -17,6 +17,8 @@ import { RouteTravelMode } from "./enums/route-travel-mode.enum";
 import { DirectionsTranslations } from "./types/directions-translations.interface";
 export namespace Components {
     interface ComboBoxItem {
+        "disabled": boolean;
+        "excludeFromAll": boolean;
         "selected": boolean;
         "text": string;
         "value": string;
@@ -235,6 +237,8 @@ export namespace Components {
         "selected": Array<HTMLMiDropdownItemElement>;
     }
     interface MiDropdownItem {
+        "disabled": boolean;
+        "excludeFromAll": boolean;
         "selected": boolean;
         "text": string;
         "value": string;
@@ -1374,6 +1378,8 @@ declare global {
 }
 declare namespace LocalJSX {
     interface ComboBoxItem {
+        "disabled"?: boolean;
+        "excludeFromAll"?: boolean;
         "selected"?: boolean;
         "text"?: string;
         "value"?: string;
@@ -1613,6 +1619,8 @@ declare namespace LocalJSX {
         "selected"?: Array<HTMLMiDropdownItemElement>;
     }
     interface MiDropdownItem {
+        "disabled"?: boolean;
+        "excludeFromAll"?: boolean;
         "selected"?: boolean;
         "text"?: string;
         "value"?: string;

--- a/packages/components/src/components/combo-box-item/combo-box-item.tsx
+++ b/packages/components/src/components/combo-box-item/combo-box-item.tsx
@@ -8,6 +8,8 @@ import { Component, Element, Prop  } from "@stencil/core";
 export class ComboItem {
     @Element() el: HTMLDivElement;
     @Prop() selected: boolean = false;
+    @Prop() disabled: boolean = false;
+    @Prop() excludeFromAll: boolean = false;
     @Prop() value: string;
     @Prop() text: string;
 }

--- a/packages/components/src/components/combo-box-item/readme.md
+++ b/packages/components/src/components/combo-box-item/readme.md
@@ -12,11 +12,13 @@ Set the `title` attribute to add extra information about an item.
 
 ## Properties
 
-| Property   | Attribute  | Description | Type      | Default     |
-| ---------- | ---------- | ----------- | --------- | ----------- |
-| `selected` | `selected` |             | `boolean` | `false`     |
-| `text`     | `text`     |             | `string`  | `undefined` |
-| `value`    | `value`    |             | `string`  | `undefined` |
+| Property         | Attribute          | Description | Type      | Default     |
+| ---------------- | ------------------ | ----------- | --------- | ----------- |
+| `disabled`       | `disabled`         |             | `boolean` | `false`     |
+| `excludeFromAll` | `exclude-from-all` |             | `boolean` | `false`     |
+| `selected`       | `selected`         |             | `boolean` | `false`     |
+| `text`           | `text`             |             | `string`  | `undefined` |
+| `value`          | `value`            |             | `string`  | `undefined` |
 
 
 ----------------------------------------------

--- a/packages/components/src/components/dropdown-item/dropdown-item.tsx
+++ b/packages/components/src/components/dropdown-item/dropdown-item.tsx
@@ -7,6 +7,8 @@ import { Component, Element, Prop } from '@stencil/core';
 export class DropdownItem {
     @Element() el: HTMLDivElement;
     @Prop() selected: boolean = false;
+    @Prop() disabled: boolean = false;
+    @Prop() excludeFromAll: boolean = false;
     @Prop() value: string;
     @Prop() text: string;
 }

--- a/packages/components/src/components/dropdown-item/readme.md
+++ b/packages/components/src/components/dropdown-item/readme.md
@@ -10,11 +10,13 @@ Set the `title` attribute to add extra information about an item.
 
 ## Properties
 
-| Property   | Attribute  | Description | Type      | Default     |
-| ---------- | ---------- | ----------- | --------- | ----------- |
-| `selected` | `selected` |             | `boolean` | `false`     |
-| `text`     | `text`     |             | `string`  | `undefined` |
-| `value`    | `value`    |             | `string`  | `undefined` |
+| Property         | Attribute          | Description | Type      | Default     |
+| ---------------- | ------------------ | ----------- | --------- | ----------- |
+| `disabled`       | `disabled`         |             | `boolean` | `false`     |
+| `excludeFromAll` | `exclude-from-all` |             | `boolean` | `false`     |
+| `selected`       | `selected`         |             | `boolean` | `false`     |
+| `text`           | `text`             |             | `string`  | `undefined` |
+| `value`          | `value`            |             | `string`  | `undefined` |
 
 
 ----------------------------------------------

--- a/packages/components/src/components/dropdown/dropdown.tsx
+++ b/packages/components/src/components/dropdown/dropdown.tsx
@@ -170,17 +170,17 @@ export class Dropdown {
         }
     }
 
-     /**
-     * Outside the dropdown listener. It will close the dropdown when a click is outside a dropdown and dropdown list.
-     *
-     * @param ev
-     */
-      @Listen('click', {target: 'window'})
-      checkForClickOutside(ev) {
-          if (!this.hostElement.contains(ev.target)) {
-              this.open = false;
-          }
-      }
+    /**
+    * Outside the dropdown listener. It will close the dropdown when a click is outside a dropdown and dropdown list.
+    *
+    * @param ev
+    */
+    @Listen('click', { target: 'window' })
+    checkForClickOutside(ev) {
+        if (!this.hostElement.contains(ev.target)) {
+            this.open = false;
+        }
+    }
 
     /**
      * Mousemove event handler.
@@ -382,7 +382,7 @@ export class Dropdown {
         const items = Array.from(this.currentItems) as Array<HTMLMiDropdownItemElement>;
 
         for (const item of items) {
-            item.selected = true;
+            item.selected = !item.excludeFromAll;
         }
 
         this.onChangedHandler();
@@ -618,6 +618,7 @@ export class Dropdown {
                         type="checkbox"
                         value={index}
                         checked={item.selected}
+                        disabled={item.disabled}
                         onChange={() => this.onSelect(item)}
                     />
                     {itemText}


### PR DESCRIPTION
### What

The dropdown items need to be extended with addition properties: `disabled` (to mark input field disabled) and `excludeFromAll` (to make a dropdown item excluded from the `selectAll` function)

### How

1. `disabled` - new `@Prop` with a default value set to `false`. This value will be used when generating input elements inside the dropdown element to mark the input fields as disabled.
2. `excludeFromAll` - new `@Prop` with a default value set to `false`. This value will be used when calling the `selectAll` function where only items with `false` `excludeFromAll` will be selected.