### PR TITLE
Fix QR code URL not working on the Google Cloud Storage buckets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23752,7 +23752,7 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.43.0",
+      "version": "1.43.1",
       "devDependencies": {
         "@googlemaps/js-api-loader": "^1.15.1",
         "@mapsindoors/components": "*",

--- a/packages/map-template/src/components/QRCodeDialog/QRCodeDialog.jsx
+++ b/packages/map-template/src/components/QRCodeDialog/QRCodeDialog.jsx
@@ -69,7 +69,7 @@ function QRCodeDialog() {
             const finalParams = newParams.toString();
 
             // Construct the QR code URL
-            let QRCodeURL = `${targetUrl}/?${finalParams}&directionsFrom=${directionsFrom.id}&directionsTo=${directionsTo.id}`;
+            let QRCodeURL = `${targetUrl}?${finalParams}&directionsFrom=${directionsFrom.id}&directionsTo=${directionsTo.id}`;
 
             const options = {
                 errorCorrectionLevel: 'L',


### PR DESCRIPTION
# What 

- Remove extra "/" character when building the QR code URL

# How 

- When building the `targetUrl`, remove the extra "/" as it is unnecessary 
- Tested with on 3 different environments: localhost, map.mapsindoors.com and also storage.googleapis.com/mi-map-latest/index.html 