### PR TITLE
Hide external ids by default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23769,7 +23769,7 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.44.2",
+      "version": "1.44.3",
       "devDependencies": {
         "@googlemaps/js-api-loader": "^1.15.1",
         "@mapsindoors/components": "*",

--- a/packages/map-template/src/components/WebComponentWrappers/ListItemLocation/ListItemLocation.jsx
+++ b/packages/map-template/src/components/WebComponentWrappers/ListItemLocation/ListItemLocation.jsx
@@ -62,7 +62,7 @@ function ListItemLocation({ location, locationClicked, icon, isHovered }) {
     }, [location, locationClicked, isHovered]);
 
 
-    return <mi-list-item-location level={t('Level')} ref={elementRef} />
+    return <mi-list-item-location level={t('Level')} ref={elementRef} show-external-id={false} />
 }
 
 export default ListItemLocation;


### PR DESCRIPTION
# What 

- Hide external IDs by default when performing a search in the Map Template

# How 

- Set the `show-external-ids` property to be false by default