### PR TITLE
Remove hover effect on "inherit from type" non-selectable locations if the type has "non-selectable" set

### DIFF
--- a/packages/map-template/src/components/Map/Map.jsx
+++ b/packages/map-template/src/components/Map/Map.jsx
@@ -208,11 +208,11 @@ function Map({ onLocationClick, onVenueChangedOnMap, useMapProviderModule, onMap
         });
 
         // Detect when the mouse hovers over a location and store the hovered location
-        // If the location is non-selectable, remove the hovering by calling the unhoverLocation() method.
+        // If the location is non-selectable/inherited from type, remove the hovering by calling the unhoverLocation() method.
         miInstance.on('mouseenter', () => {
             const hoveredLocation = miInstance.getHoveredLocation()
 
-            if (hoveredLocation?.properties.locationSettings?.selectable === false) {
+            if (hoveredLocation?.properties.locationSettings?.selectable === false || hoveredLocation?.properties.locationSettings?.selectable === null) {
                 miInstance.unhoverLocation();
             }
         });

--- a/packages/map-template/src/components/Map/Map.jsx
+++ b/packages/map-template/src/components/Map/Map.jsx
@@ -208,7 +208,7 @@ function Map({ onLocationClick, onVenueChangedOnMap, useMapProviderModule, onMap
         });
 
         // Detect when the mouse hovers over a location and store the hovered location
-        // If the location is non-selectable/inherited from type, remove the hovering by calling the unhoverLocation() method.
+        // If the location is non-selectable (either set on the Location or inherited from the type), remove the hovering by calling the unhoverLocation() method.
         miInstance.on('mouseenter', () => {
             const hoveredLocation = miInstance.getHoveredLocation()
 

--- a/packages/map-template/src/components/WebComponentWrappers/ListItemLocation/ListItemLocation.jsx
+++ b/packages/map-template/src/components/WebComponentWrappers/ListItemLocation/ListItemLocation.jsx
@@ -21,7 +21,7 @@ function ListItemLocation({ location, locationClicked, icon, isHovered }) {
     useEffect(() => {
         const clickHandler = customEvent => locationClicked(customEvent.detail);
         const hoverHandler = () => {
-            // Check if the location is non-selectable(either set on the Location or inherited from the type) from type before hovering it.
+            // Check if the location is non-selectable (either set on the Location or inherited from the type) before hovering it.
             if (location.properties.locationSettings?.selectable !== false || location.properties.locationSettings?.selectable !== null) {
                 mapsIndoorsInstance.hoverLocation(location);
             }

--- a/packages/map-template/src/components/WebComponentWrappers/ListItemLocation/ListItemLocation.jsx
+++ b/packages/map-template/src/components/WebComponentWrappers/ListItemLocation/ListItemLocation.jsx
@@ -21,20 +21,20 @@ function ListItemLocation({ location, locationClicked, icon, isHovered }) {
     useEffect(() => {
         const clickHandler = customEvent => locationClicked(customEvent.detail);
         const hoverHandler = () => {
-            // Check if the location is non-selectable before hovering it
-            if (location.properties.locationSettings?.selectable !== false) {
+            // Check if the location is non-selectable/inherited from type before hovering it
+            if (location.properties.locationSettings?.selectable !== false || location.properties.locationSettings?.selectable !== null) {
                 mapsIndoorsInstance.hoverLocation(location);
             }
         }
         const unhoverHandler = () => {
-            // Check if the location is non-selectable before unhovering it
-            if (!location.properties.locationSettings?.selectable !== false) {
+            // Check if the location is non-selectable/inherited from type before unhovering it
+            if (!location.properties.locationSettings?.selectable !== false || !location.properties.locationSettings?.selectable !== null) {
                 mapsIndoorsInstance.unhoverLocation(location);
             }
         }
 
-        // Add a "non-selectable" class to the non-selectable locations.
-        if (location.properties.locationSettings?.selectable === false) {
+        // Add a "non-selectable" class to the non-selectable/inherited from type locations.
+        if (location.properties.locationSettings?.selectable === false || location.properties.locationSettings?.selectable === null) {
             elementRef.current.classList.add("non-selectable");
         }
 

--- a/packages/map-template/src/components/WebComponentWrappers/ListItemLocation/ListItemLocation.jsx
+++ b/packages/map-template/src/components/WebComponentWrappers/ListItemLocation/ListItemLocation.jsx
@@ -21,19 +21,19 @@ function ListItemLocation({ location, locationClicked, icon, isHovered }) {
     useEffect(() => {
         const clickHandler = customEvent => locationClicked(customEvent.detail);
         const hoverHandler = () => {
-            // Check if the location is non-selectable/inherited from type before hovering it
+            // Check if the location is non-selectable(either set on the Location or inherited from the type) from type before hovering it.
             if (location.properties.locationSettings?.selectable !== false || location.properties.locationSettings?.selectable !== null) {
                 mapsIndoorsInstance.hoverLocation(location);
             }
         }
         const unhoverHandler = () => {
-            // Check if the location is non-selectable/inherited from type before unhovering it
+            // Check if the location is non-selectable (either set on the Location or inherited from the type) from type before unhovering it.
             if (!location.properties.locationSettings?.selectable !== false || !location.properties.locationSettings?.selectable !== null) {
                 mapsIndoorsInstance.unhoverLocation(location);
             }
         }
 
-        // Add a "non-selectable" class to the non-selectable/inherited from type locations.
+        // Add a "non-selectable" class to the non-selectable (either set on the Location or inherited from the type) from type locations.
         if (location.properties.locationSettings?.selectable === false || location.properties.locationSettings?.selectable === null) {
             elementRef.current.classList.add("non-selectable");
         }

--- a/packages/map-template/src/components/WebComponentWrappers/ListItemLocation/ListItemLocation.jsx
+++ b/packages/map-template/src/components/WebComponentWrappers/ListItemLocation/ListItemLocation.jsx
@@ -27,7 +27,7 @@ function ListItemLocation({ location, locationClicked, icon, isHovered }) {
             }
         }
         const unhoverHandler = () => {
-            // Check if the location is non-selectable (either set on the Location or inherited from the type) from type before unhovering it.
+            // Check if the location is non-selectable (either set on the Location or inherited from the type) before unhovering it.
             if (!location.properties.locationSettings?.selectable !== false || !location.properties.locationSettings?.selectable !== null) {
                 mapsIndoorsInstance.unhoverLocation(location);
             }


### PR DESCRIPTION
# What 

- Remove hover effect on "inherit from type" non-selectable locations if the type has "non-selectable" set

# How 

- In addition to checking if the `selectable` property is false, add a check for the `null` value which indicates whether the location in inheriting from type. 