### PR TITLE
Add property to switch between the "highlight" and "filter" methods on the SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23769,7 +23769,7 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.44.3",
+      "version": "1.45.0",
       "devDependencies": {
         "@googlemaps/js-api-loader": "^1.15.1",
         "@mapsindoors/components": "*",

--- a/packages/map-template/.github/README.md
+++ b/packages/map-template/.github/README.md
@@ -86,6 +86,7 @@ When loading the MapsIndoors Map component for the first time, the map will resp
 |`miTransitionLevel`|`number`|The zoom level on which to transition from Mapbox to MapsIndoors data. Default value is 17. This feature is only available for Mapbox. |
 |`category`|`string`|If you want to indicate an active category on the map. The value should be the Key (Administrative ID). |
 |`searchAllVenues`|`bool`|If you want to perform search across all venues in the solution. |
+|`hideNonMatches`|`bool`|Determine whether the locations on the map should be filtered (only show the matched locations and hide the rest) or highlighted (show all locations and highlight the matched ones with a red dot by default). If set to true, the locations will be filtered. |
 
 ## Using Query Parameters
 
@@ -117,6 +118,7 @@ The supported query parameters are the following:
 22. `miTransitionLevel` - The zoom level on which to transition from Mapbox to MapsIndoors data. Default value is 17. This feature is only available for Mapbox.
 23. `category` - If you want to indicate an active category on the map. The value should be the Key (Administrative ID).
 24. `searchAllVenues` - If you want to perform search across all venues in the solution.
+25. `hideNonMatches` - Determine whether the locations on the map should be filtered (only show the matched locations and hide the rest) or highlighted (show all locations and highlight the matched ones with a red dot by default). If set to true, the locations will be filtered.
 
 **Note!** All the query parameters need to be separated with the `&` symbol, without any spaces in between.
 **Note!** When using parameters such as `directionsTo`, `directionsFrom`, `locationId`, `externalIDs`, and `tileStyle` make sure you are using the correct `apiKey` parameter to which they belong.

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.46.0] - 2024-05-23
+
+### Added
+
+- Added new property `hideNonMatches` which determines whether the locations on the map should be filtered (only show the matched locations and hide the rest) or highlighted (show all locations and highlight the matched ones with a red dot by default). If set to true, the locations will be filtered.
+
 ## [1.45.0] - 2024-05-15
 
 ### Added

--- a/packages/map-template/README.md
+++ b/packages/map-template/README.md
@@ -137,6 +137,7 @@ Note that when using the React component, the properties should conform to JSX p
 |`mi-transition-level`|`miTransitionLevel`|`number`|The zoom level on which to transition from Mapbox to MapsIndoors data. Default value is 17. This feature is only available for Mapbox. |
 |`category`|`category`|`string`|If you want to indicate an active category on the map. The value should be the Key (Administrative ID). |
 |`search-all-venues`|`searchAllVenues`|`bool`|If you want to perform search across all venues in the solution. |
+|`hide-non-matches`|`hideNonMatches`|`bool`|Determine whether the locations on the map should be filtered (only show the matched locations and hide the rest) or highlighted (show all locations and highlight the matched ones with a red dot by default). If set to true, the locations will be filtered. |
 
 ## Using Query Parameters
 
@@ -168,6 +169,7 @@ The supported query parameters are the following:
 22. `miTransitionLevel` - The zoom level on which to transition from Mapbox to MapsIndoors data. Default value is 17. This feature is only available for Mapbox.
 23. `category` - If you want to indicate an active category on the map. The value should be the Key (Administrative ID).
 24. `searchAllVenues` - If you want to perform search across all venues in the solution.
+25. `hideNonMatches` - Determine whether the locations on the map should be filtered (only show the matched locations and hide the rest) or highlighted (show all locations and highlight the matched ones with a red dot by default). If set to true, the locations will be filtered.
 
 **Note!** All the query parameters need to be separated with the `&` symbol, without any spaces in between.
 **Note!** When using parameters such as `directionsTo`, `directionsFrom`, `locationId`, `externalIDs`, and `tileStyle` make sure you are using the correct `apiKey` parameter to which they belong.

--- a/packages/map-template/releaseTools/webcomponent.js
+++ b/packages/map-template/releaseTools/webcomponent.js
@@ -33,7 +33,8 @@ MapsIndoorsMap.propTypes = {
     category: PropTypes.string,
     language: PropTypes.string,
     searchAllVenues: PropTypes.bool,
-    useKeyboard: PropTypes.bool
+    useKeyboard: PropTypes.bool,
+    hideNonMatches: PropTypes.bool
 };
 
 const WebMapsIndoorsMap = reactToWebComponent(MapsIndoorsMap, React, ReactDOM);

--- a/packages/map-template/src/atoms/hideNonMatchesState.js
+++ b/packages/map-template/src/atoms/hideNonMatchesState.js
@@ -1,0 +1,8 @@
+import { atom } from 'recoil';
+
+const hideNonMatchesState = atom({
+    key: 'hideNonMatches',
+    default: false
+});
+
+export default hideNonMatchesState;

--- a/packages/map-template/src/components/Map/Map.jsx
+++ b/packages/map-template/src/components/Map/Map.jsx
@@ -154,6 +154,7 @@ function Map({ onLocationClick, onVenueChangedOnMap, useMapProviderModule, onMap
 
         const locationIds = locations.map(location => location.id);
 
+        // Check if the hideNonMatches prop or highlight method in the SDK exists 
         if (hideNonMatches || !mapsIndoorsInstance.highlight) {
             mapsIndoorsInstance.filter(locationIds);
         } else {

--- a/packages/map-template/src/components/Map/Map.jsx
+++ b/packages/map-template/src/components/Map/Map.jsx
@@ -154,14 +154,10 @@ function Map({ onLocationClick, onVenueChangedOnMap, useMapProviderModule, onMap
 
         const locationIds = locations.map(location => location.id);
 
-        if (hideNonMatches) {
+        if (hideNonMatches || !mapsIndoorsInstance.highlight) {
             mapsIndoorsInstance.filter(locationIds);
         } else {
-            if (mapsIndoorsInstance.highlight) {
-                mapsIndoorsInstance.highlight(locationIds);
-            } else {
-                mapsIndoorsInstance.filter(locationIds);
-            }
+            mapsIndoorsInstance.highlight(locationIds);
         }
     }, [filteredLocations, filteredLocationsByExternalIDs, mapsIndoorsInstance, hideNonMatches]);
 

--- a/packages/map-template/src/components/Map/Map.jsx
+++ b/packages/map-template/src/components/Map/Map.jsx
@@ -21,6 +21,7 @@ import solutionState from '../../atoms/solutionState';
 import notificationMessageState from '../../atoms/notificationMessageState';
 import useMapBoundsDeterminer from '../../hooks/useMapBoundsDeterminer';
 import currentVenueNameState from "../../atoms/currentVenueNameState";
+import hideNonMatchesState from "../../atoms/hideNonMatchesState";
 
 /**
  * Private variable used for storing the tile style.
@@ -55,6 +56,8 @@ function Map({ onLocationClick, onVenueChangedOnMap, useMapProviderModule, onMap
     const solution = useRecoilValue(solutionState);
     const [, setErrorMessage] = useRecoilState(notificationMessageState);
     const [, setCurrentVenueName] = useRecoilState(currentVenueNameState);
+    const hideNonMatches = useRecoilValue(hideNonMatchesState);
+
     useLiveData(apiKey);
 
     const [mapPositionKnown, venueOnMap] = useMapBoundsDeterminer();
@@ -139,26 +142,28 @@ function Map({ onLocationClick, onVenueChangedOnMap, useMapProviderModule, onMap
     }, [venueOnMap]);
 
     /*
-     * Show the filtered locations on the map based on their IDs or external IDs if present.
-     * Check if the highlight or filter methods exist.
+     * Dynamically filter or highlight location based on the "filteredLocations", "filteredLocationsByExternalIDs" and "hideNonMatches" property.
      */
     useEffect(() => {
-        if (mapsIndoorsInstance) {
-            if (filteredLocations) {
-                if (mapsIndoorsInstance.highlight) {
-                    mapsIndoorsInstance.highlight(filteredLocations.map(location => location.id));
-                } else if (mapsIndoorsInstance.filter) {
-                    mapsIndoorsInstance.filter(filteredLocations.map(location => location.id));
-                }
-            } else if (filteredLocationsByExternalIDs) {
-                if (mapsIndoorsInstance.highlight) {
-                    mapsIndoorsInstance.highlight(filteredLocationsByExternalIDs.map(location => location.id));
-                } else if (mapsIndoorsInstance.filter) {
-                    mapsIndoorsInstance.filter(filteredLocationsByExternalIDs.map(location => location.id));
-                }
+        if (!mapsIndoorsInstance) return;
+
+        // Determine which set of locations to work with
+        // If none of the locations are available, return the function
+        const locations = filteredLocations || filteredLocationsByExternalIDs;
+        if (!locations) return;
+
+        const locationIds = locations.map(location => location.id);
+
+        if (hideNonMatches) {
+            if (mapsIndoorsInstance.filter) {
+                mapsIndoorsInstance.filter(locationIds);
+            }
+        } else {
+            if (mapsIndoorsInstance.highlight) {
+                mapsIndoorsInstance.highlight(locationIds);
             }
         }
-    }, [filteredLocations, filteredLocationsByExternalIDs, mapsIndoorsInstance]);
+    }, [filteredLocations, filteredLocationsByExternalIDs, mapsIndoorsInstance, hideNonMatches]);
 
     /*
      * React to changes in bearing and pitch props and set them on the map if mapsIndoorsInstance exists.

--- a/packages/map-template/src/components/Map/Map.jsx
+++ b/packages/map-template/src/components/Map/Map.jsx
@@ -155,12 +155,12 @@ function Map({ onLocationClick, onVenueChangedOnMap, useMapProviderModule, onMap
         const locationIds = locations.map(location => location.id);
 
         if (hideNonMatches) {
-            if (mapsIndoorsInstance.filter) {
-                mapsIndoorsInstance.filter(locationIds);
-            }
+            mapsIndoorsInstance.filter(locationIds);
         } else {
             if (mapsIndoorsInstance.highlight) {
                 mapsIndoorsInstance.highlight(locationIds);
+            } else {
+                mapsIndoorsInstance.filter(locationIds);
             }
         }
     }, [filteredLocations, filteredLocationsByExternalIDs, mapsIndoorsInstance, hideNonMatches]);

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -524,10 +524,10 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
      * React on changes to the hideNonMatches prop.
      */
     useEffect(() => {
-        if (mapsindoorsSDKAvailable && hideNonMatches) {
+        if (hideNonMatches) {
             setHideNonMatches(hideNonMatches);
         }
-    }, [hideNonMatches, mapsindoorsSDKAvailable]);
+    }, [hideNonMatches]);
 
 
     /**

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -85,7 +85,7 @@ defineCustomElements();
  * @param {number} [props.timeout] - If you want the Map Template to reset map position and UI elements to the initial state after some time of inactivity, use this to specify the number of seconds of inactivity before resetting.
  * @param {number} [props.miTransitionLevel] - The zoom level on which to transition from Mapbox to MapsIndoors data. Default value is 17. This feature is only available for Mapbox.
  * @param {boolean} [props.searchAllVenues] - If you want to perform search across all venues in the solution.
- * @param {boolean} [props.hideNonMatches] - Determine whether the locations on the map should be filtered or highlighted. If set to true, the locations will be filtered.
+ * @param {boolean} [props.hideNonMatches] - Determine whether the locations on the map should be filtered (only show the matched locations and hide the rest) or highlighted (show all location and highlight the matched ones with a red dot by default). If set to true, the locations will be filtered.
  */
 function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, primaryColor, logo, appUserRoles, directionsFrom, directionsTo, externalIDs, tileStyle, startZoomLevel, bearing, pitch, gmMapId, useMapProviderModule, kioskOriginLocationId, language, supportsUrlParameters, useKeyboard, timeout, miTransitionLevel, category, searchAllVenues, hideNonMatches }) {
 

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -53,6 +53,7 @@ import isLegendDialogVisibleState from '../../atoms/isLegendDialogVisibleState.j
 import searchAllVenuesState from '../../atoms/searchAllVenues.js';
 import currentVenueNameState from '../../atoms/currentVenueNameState.js';
 import categoryState from '../../atoms/categoryState.js';
+import hideNonMatchesState from '../../atoms/hideNonMatchesState.js';
 
 // Define the Custom Elements from our components package.
 defineCustomElements();
@@ -84,8 +85,9 @@ defineCustomElements();
  * @param {number} [props.timeout] - If you want the Map Template to reset map position and UI elements to the initial state after some time of inactivity, use this to specify the number of seconds of inactivity before resetting.
  * @param {number} [props.miTransitionLevel] - The zoom level on which to transition from Mapbox to MapsIndoors data. Default value is 17. This feature is only available for Mapbox.
  * @param {boolean} [props.searchAllVenues] - If you want to perform search across all venues in the solution.
+ * @param {boolean} [props.hideNonMatches] - Determine whether the locations on the map should be filtered or highlighted. If set to true, the locations will be filtered.
  */
-function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, primaryColor, logo, appUserRoles, directionsFrom, directionsTo, externalIDs, tileStyle, startZoomLevel, bearing, pitch, gmMapId, useMapProviderModule, kioskOriginLocationId, language, supportsUrlParameters, useKeyboard, timeout, miTransitionLevel, category, searchAllVenues }) {
+function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, primaryColor, logo, appUserRoles, directionsFrom, directionsTo, externalIDs, tileStyle, startZoomLevel, bearing, pitch, gmMapId, useMapProviderModule, kioskOriginLocationId, language, supportsUrlParameters, useKeyboard, timeout, miTransitionLevel, category, searchAllVenues, hideNonMatches }) {
 
     const [, setApiKey] = useRecoilState(apiKeyState);
     const [, setGmApiKey] = useRecoilState(gmApiKeyState);
@@ -110,7 +112,8 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
     const [, setMiTransitionLevel] = useRecoilState(miTransitionLevelState);
     const [, setSelectedCategory] = useRecoilState(selectedCategoryState);
     const [, setSearchAllVenues] = useRecoilState(searchAllVenuesState);
- 	const [, setCategory] = useRecoilState(categoryState);
+    const [, setCategory] = useRecoilState(categoryState);
+    const [, setHideNonMatches] = useRecoilState(hideNonMatchesState);
 
     const [showVenueSelector, setShowVenueSelector] = useState(true);
     const [showPositionControl, setShowPositionControl] = useState(true);
@@ -516,6 +519,16 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
             getVenueCategories(currentVenueName)
         }
     }, [currentVenueName, mapsindoorsSDKAvailable]);
+
+    /*
+     * React on changes to the hideNonMatches prop.
+     */
+    useEffect(() => {
+        if (mapsindoorsSDKAvailable && hideNonMatches) {
+            setHideNonMatches(hideNonMatches);
+        }
+    }, [hideNonMatches, mapsindoorsSDKAvailable]);
+
 
     /**
      * When venue is fitted while initializing the data,

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -85,7 +85,7 @@ defineCustomElements();
  * @param {number} [props.timeout] - If you want the Map Template to reset map position and UI elements to the initial state after some time of inactivity, use this to specify the number of seconds of inactivity before resetting.
  * @param {number} [props.miTransitionLevel] - The zoom level on which to transition from Mapbox to MapsIndoors data. Default value is 17. This feature is only available for Mapbox.
  * @param {boolean} [props.searchAllVenues] - If you want to perform search across all venues in the solution.
- * @param {boolean} [props.hideNonMatches] - Determine whether the locations on the map should be filtered (only show the matched locations and hide the rest) or highlighted (show all location and highlight the matched ones with a red dot by default). If set to true, the locations will be filtered.
+ * @param {boolean} [props.hideNonMatches] - Determine whether the locations on the map should be filtered (only show the matched locations and hide the rest) or highlighted (show all locations and highlight the matched ones with a red dot by default). If set to true, the locations will be filtered.
  */
 function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, primaryColor, logo, appUserRoles, directionsFrom, directionsTo, externalIDs, tileStyle, startZoomLevel, bearing, pitch, gmMapId, useMapProviderModule, kioskOriginLocationId, language, supportsUrlParameters, useKeyboard, timeout, miTransitionLevel, category, searchAllVenues, hideNonMatches }) {
 

--- a/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
+++ b/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
@@ -32,7 +32,7 @@ import MapTemplate from '../MapTemplate/MapTemplate.jsx';
  * @param {number} [props.miTransitionLevel] - The zoom level on which to transition from Mapbox to MapsIndoors data. Default value is 17. This feature is only available for Mapbox.
  * @param {string} [props.category] - If you want to indicate an active category on the map. The value should be the Key (Administrative ID).
  * @param {boolean} [props.searchAllVenues] - If you want to perform search across all venues in the solution.
- * @param {boolean} [props.hideNonMatches] - Determine whether the locations on the map should be filtered (only show the matched locations and hide the rest) or highlighted (show all location and highlight the matched ones with a red dot by default). If set to true, the locations will be filtered.
+ * @param {boolean} [props.hideNonMatches] - Determine whether the locations on the map should be filtered (only show the matched locations and hide the rest) or highlighted (show all locations and highlight the matched ones with a red dot by default). If set to true, the locations will be filtered.
  */
 function MapsIndoorsMap(props) {
 
@@ -109,7 +109,7 @@ function MapsIndoorsMap(props) {
             miTransitionLevel: props.supportsUrlParameters && miTransitionLevelQueryParameter ? miTransitionLevelQueryParameter : props.miTransitionLevel,
 			category: props.supportsUrlParameters && categoryQueryParameter ? categoryQueryParameter : props.category,
             searchAllVenues: props.supportsUrlParameters && searchAllVenuesParameter ? searchAllVenuesParameter : (props.searchAllVenues || defaultProps.searchAllVenues),
-            hideNonMatches: props.supportsUrlParameters && hideNonMatchesQueryParameter ? hideNonMatchesQueryParameter : (props.hideNonMatches || defaultProps.hideNonMatches),
+            hideNonMatches: props.supportsUrlParameters && hideNonMatchesQueryParameter ? hideNonMatchesQueryParameter : props.hideNonMatches,
         });
     }, [props]);
 

--- a/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
+++ b/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
@@ -32,6 +32,7 @@ import MapTemplate from '../MapTemplate/MapTemplate.jsx';
  * @param {number} [props.miTransitionLevel] - The zoom level on which to transition from Mapbox to MapsIndoors data. Default value is 17. This feature is only available for Mapbox.
  * @param {string} [props.category] - If you want to indicate an active category on the map. The value should be the Key (Administrative ID).
  * @param {boolean} [props.searchAllVenues] - If you want to perform search across all venues in the solution.
+ * @param {boolean} [props.hideNonMatches] - Determine whether the locations on the map should be filtered or highlighted. If set to true, the locations will be filtered.
  */
 function MapsIndoorsMap(props) {
 
@@ -54,6 +55,7 @@ function MapsIndoorsMap(props) {
             useMapProviderModule: false,
             useKeyboard: false, 
             searchAllVenues: false,
+            hideNonMatches: false
         };
 
         const apiKeyQueryParameter = queryStringParams.get('apiKey');
@@ -80,6 +82,7 @@ function MapsIndoorsMap(props) {
         const miTransitionLevelQueryParameter = queryStringParams.get('miTransitionLevel');
 		const categoryQueryParameter = queryStringParams.get('category');
 		const searchAllVenuesParameter = getBooleanQueryParameter(queryStringParams.get('searchAllVenues'));
+		const hideNonMatchesQueryParameter = getBooleanQueryParameter(queryStringParams.get('hideNonMatches'));
 
         setMapTemplateProps({
             apiKey: props.supportsUrlParameters && apiKeyQueryParameter ? apiKeyQueryParameter : (props.apiKey || defaultProps.apiKey),
@@ -107,6 +110,7 @@ function MapsIndoorsMap(props) {
             miTransitionLevel: props.supportsUrlParameters && miTransitionLevelQueryParameter ? miTransitionLevelQueryParameter : props.miTransitionLevel,
 			category: props.supportsUrlParameters && categoryQueryParameter ? categoryQueryParameter : props.category,
             searchAllVenues: props.supportsUrlParameters && searchAllVenuesParameter ? searchAllVenuesParameter : (props.searchAllVenues || defaultProps.searchAllVenues),
+            hideNonMatches: props.supportsUrlParameters && hideNonMatchesQueryParameter ? hideNonMatchesQueryParameter : (props.hideNonMatches || defaultProps.hideNonMatches),
         });
     }, [props]);
 

--- a/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
+++ b/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
@@ -32,7 +32,7 @@ import MapTemplate from '../MapTemplate/MapTemplate.jsx';
  * @param {number} [props.miTransitionLevel] - The zoom level on which to transition from Mapbox to MapsIndoors data. Default value is 17. This feature is only available for Mapbox.
  * @param {string} [props.category] - If you want to indicate an active category on the map. The value should be the Key (Administrative ID).
  * @param {boolean} [props.searchAllVenues] - If you want to perform search across all venues in the solution.
- * @param {boolean} [props.hideNonMatches] - Determine whether the locations on the map should be filtered or highlighted. If set to true, the locations will be filtered.
+ * @param {boolean} [props.hideNonMatches] - Determine whether the locations on the map should be filtered (only show the matched locations and hide the rest) or highlighted (show all location and highlight the matched ones with a red dot by default). If set to true, the locations will be filtered.
  */
 function MapsIndoorsMap(props) {
 
@@ -54,8 +54,7 @@ function MapsIndoorsMap(props) {
             primaryColor: '#005655', // --brand-colors-dark-pine-100 from MIDT
             useMapProviderModule: false,
             useKeyboard: false, 
-            searchAllVenues: false,
-            hideNonMatches: false
+            searchAllVenues: false
         };
 
         const apiKeyQueryParameter = queryStringParams.get('apiKey');


### PR DESCRIPTION
# What 

- Add a new property named `hideNonMatches` to switch between the "highlight" and "filter" methods on the SDK

# How

- Add a new boolean prop `hideNonMatches`
- If set to `true`, the results will be filtered, otherwise hilghlighted