### PR TITLE
Don't use the whole IETF language string when setting the MapsIndoors SDK language

### DIFF
--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.51.1] - 2024-06-18
+
+### Fixed
+
+- Fixed issue where MapsIndoors data could be wrongly shown in the default language in case the given IETF language string consisted of more than a primary language subtag.
+
 ## [1.51.0] - 2024-06-17
 
 ### Added

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -213,7 +213,8 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
             const languageToUse = language ? language : navigator.language;
 
             // Set the language on the MapsIndoors SDK in order to get eg. Mapbox and Google directions in that language.
-            window.mapsindoors.MapsIndoors.setLanguage(languageToUse);
+            // The MapsIndoors data only accepts the first part of the IETF language string, hence the split.
+            window.mapsindoors.MapsIndoors.setLanguage(languageToUse.split('-')[0]);
 
             // If relevant, fetch venues, categories and the current location again to get them in the new language
             window.mapsindoors.services.LocationsService.once('update_completed', () => {


### PR DESCRIPTION
**What**

Don't use the whole IETF language string when setting the MapsIndoors SDK language.

**Why**

The SDK/backend does not work properly when using the whole IETF language string. Eg. using `es-co` will cause the fetched data to fallback to the default language, since it is only possible to define translations for `es` in the MapsIndoors platform.

**How**

Only use the first part of the language string, eg. `es` or `en` when calling `setLanguage()`. Now when eg. using a browser with the language set to `es-co`, it will instruct the SDK to set the language as `es`, which corresponds better with the data.