### PR TITLE
Fix category order in the MT

### DIFF
--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.52.0] - 2024-06-19
+
+### Added
+
+- Changed the order of how categories are displayed. Now their order is dictated by AppConfig.
+
 ## [1.51.1] - 2024-06-18
 
 ### Fixed

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -605,7 +605,7 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
                 const appConfigCategory = appConfig?.menuInfo.mainmenu.find(category => category.categoryKey === key);
 
                 if (appConfigCategory) {
-                    uniqueCategories.set(appConfigCategory.categoryKey, {displayName: location.properties.categories[key], iconUrl: appConfigCategory?.iconUrl })
+                    uniqueCategories.set(appConfigCategory.categoryKey, { displayName: location.properties.categories[key], iconUrl: appConfigCategory?.iconUrl })
                 }
             }
         }

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -593,7 +593,6 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
      * @param {array} locationsResult
      */
     function getCategories(locationsResult) {
-        // Initialise the unique categories map
         let uniqueCategories = new Map();
 
         // Loop through the locations and count the unique locations.
@@ -605,19 +604,20 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
                 // Get the categories from the App Config that have a matching key.
                 const appConfigCategory = appConfig?.menuInfo.mainmenu.find(category => category.categoryKey === key);
 
-                if (uniqueCategories.has(key)) {
-                    let count = uniqueCategories.get(key).count;
-                    uniqueCategories.set(key, { count: ++count, displayName: location.properties.categories[key], iconUrl: appConfigCategory?.iconUrl });
-                } else {
-                    uniqueCategories.set(key, { count: 1, displayName: location.properties.categories[key], iconUrl: appConfigCategory?.iconUrl });
+                if (appConfigCategory) {
+                    uniqueCategories.set(appConfigCategory.categoryKey, {displayName: location.properties.categories[key], iconUrl: appConfigCategory?.iconUrl })
                 }
             }
         }
 
-        // Sort the categories with most locations associated.
-        uniqueCategories = Array.from(uniqueCategories).sort((a, b) => b[1].count - a[1].count);
+        // Sort categories by the place in the mainmenu array. Use index to do that.
+        const sortedCategories = Array.from(uniqueCategories).sort((a, b) => {
+            const orderA = appConfig.menuInfo.mainmenu.findIndex(category => category.categoryKey === a[0]);
+            const orderB = appConfig.menuInfo.mainmenu.findIndex(category => category.categoryKey === b[0]);
+            return orderA - orderB;
+        });
 
-        setCategories(uniqueCategories);
+        setCategories(sortedCategories);
     }
 
     /*


### PR DESCRIPTION
How:
- I simply assigned uniqueCategories to all categories that are active in the CMS and that exist.
- I performed a sorting method on the array. Order is dictated by the CMS. We can do it by finding the index.