### PR TITLE
Fix bug where pitch property didnt work when 2d/3d switch was not shown

### DIFF
--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.54.4] - 2024-08-14
+
+### Fixed
+
+- Fixed bug where pitch property was not respected in case 2D/3D switch was not shown.
+
 ## [1.54.3] - 2024-08-06
 
 ### Added

--- a/packages/map-template/src/selectors/currentPitch.js
+++ b/packages/map-template/src/selectors/currentPitch.js
@@ -26,7 +26,7 @@ const currentPitchSelector = selector({
                 result = 0;
                 break;
             default:
-                // Intentionally left blank.
+                result = pitch; // always default to any set pitch state
         }
 
         return result;


### PR DESCRIPTION
# What

- Fix bug where pitch property was not respected in case 2D/3D switch was not activated.

# How

- Make sure always to default to the set pitch state, instead of undefined in case there is no Mapbox view mode.
