### PR TITLE
Bugfix for wayfinding skipping first step

### DIFF
--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.54.7] - 2024-09-12
+
+### Fixed
+
+- Fix bug where wayfinding steps were misaligned.
+
 ## [1.54.6] - 2024-09-03
 
 ### Fixed

--- a/packages/map-template/src/components/Directions/Directions.jsx
+++ b/packages/map-template/src/components/Directions/Directions.jsx
@@ -93,10 +93,10 @@ function Directions({ isOpen, onBack, onSetSize, snapPointSwiped, onRouteFinishe
                     }
                 });
 
-                directionsRenderer.setRoute(directions.directionsResult);
-
-                // Set the step index to be 0 in order to display the correct instruction on the map.
-                directionsRenderer.setStepIndex(0);
+                directionsRenderer.setRoute(directions.directionsResult).then(() => {
+                    // Set the step index to be 0 in order to display the correct instruction on the map.
+                    directionsRenderer.setStepIndex(0);
+                });
 
                 destinationInfoElement.current.location = directions.destinationLocation;
 


### PR DESCRIPTION
When setting a route on the DirectionsRenderer, wait for setRoute to resolve before setting the step index. The setRoute method recently became asynchronous, meaning that the step index would be reset to -1 just before resolving, causing a mismatch in which step is active.