### PR TITLE
Add cleared event emitter to dropdown component

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [13.21.1] - 2024-09-XX
+## [13.22.0] - 2024-09-19
 
 ### Added
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.21.1] - 2024-09-XX
+
+### Added
+
+- `cleared` event emitter to `mi-dropdown` component. It notifies when dropdown search input is cleared.
+
 ## [13.21.0] - 2024-09-18
 
 ### Added

--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -1620,6 +1620,9 @@ declare namespace LocalJSX {
           * @type {EventEmitter}
          */
         "onChange"?: (event: MiDropdownCustomEvent<any>) => void;
+        /**
+          * Emit an event when search field is cleared.
+         */
         "onCleared"?: (event: MiDropdownCustomEvent<void>) => void;
         /**
           * Gets or sets the state of the dropdown. If the attribute is set to true then the dropdown will be expanded.

--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -1620,6 +1620,7 @@ declare namespace LocalJSX {
           * @type {EventEmitter}
          */
         "onChange"?: (event: MiDropdownCustomEvent<any>) => void;
+        "onCleared"?: (event: MiDropdownCustomEvent<void>) => void;
         /**
           * Gets or sets the state of the dropdown. If the attribute is set to true then the dropdown will be expanded.
           * @type {boolean}

--- a/packages/components/src/components/dropdown/dropdown.tsx
+++ b/packages/components/src/components/dropdown/dropdown.tsx
@@ -30,12 +30,17 @@ export class Dropdown {
     }) change: EventEmitter;
 
     /**
+     * Emit an event when search field is cleared.
+     */
+    @Event() cleared: EventEmitter<void>;
+
+    /**
      * Gets or sets the state of the dropdown.
      * If the attribute is set to true then the dropdown will be expanded.
      *
      * @type {boolean}
      */
-    @Prop() open = false;
+    @Prop() open: boolean = false;
 
     /**
      * Gets or sets the list items.
@@ -505,6 +510,7 @@ export class Dropdown {
             this.filterElement.value = '';
             this.filterElement.focus();
             this.currentItems = this.items;
+            this.cleared.emit();
         }
 
         this.isClearButtonVisible = false;

--- a/packages/components/src/components/dropdown/readme.md
+++ b/packages/components/src/components/dropdown/readme.md
@@ -156,9 +156,10 @@ mi-dropdown::part(button) {
 
 ## Events
 
-| Event    | Description                                      | Type               |
-| -------- | ------------------------------------------------ | ------------------ |
-| `change` | Triggers an event when the selection is changed. | `CustomEvent<any>` |
+| Event     | Description                                      | Type                |
+| --------- | ------------------------------------------------ | ------------------- |
+| `change`  | Triggers an event when the selection is changed. | `CustomEvent<any>`  |
+| `cleared` |                                                  | `CustomEvent<void>` |
 
 
 ## Methods

--- a/packages/components/src/components/dropdown/readme.md
+++ b/packages/components/src/components/dropdown/readme.md
@@ -159,7 +159,7 @@ mi-dropdown::part(button) {
 | Event     | Description                                      | Type                |
 | --------- | ------------------------------------------------ | ------------------- |
 | `change`  | Triggers an event when the selection is changed. | `CustomEvent<any>`  |
-| `cleared` |                                                  | `CustomEvent<void>` |
+| `cleared` | Emit an event when search field is cleared.      | `CustomEvent<void>` |
 
 
 ## Methods


### PR DESCRIPTION
Added cleared emitter so we can listen in the CMS when black X button is used.