### PR TITLE
Map as standalone component: Expose MapsIndoors instance

### DIFF
--- a/packages/react-components/src/App.jsx
+++ b/packages/react-components/src/App.jsx
@@ -1,7 +1,22 @@
+import { useEffect, useState } from 'react';
 import './App.css'
 import MIMap from './components/MIMap/MIMap'
 
 function App() {
+
+    const [mapsIndoorsInstance, setMapsIndoorsInstance] = useState();
+
+    useEffect(() => {
+        if (mapsIndoorsInstance) {
+            // For demo purpose: setup MapsIndoors click event listener that sets clicked location to be invisible.
+            mapsIndoorsInstance.on('click', (location) => {
+                const displayRule = mapsIndoorsInstance.getDisplayRule(location);
+                displayRule.visible = false;
+                mapsIndoorsInstance.setDisplayRule(location.id, displayRule);
+            });
+        }
+    }, [mapsIndoorsInstance]);
+
     return (
         <>
             <h1>MapsIndoors React Components</h1>
@@ -13,6 +28,7 @@ function App() {
                     mapboxAccessToken={import.meta.env.VITE_MAPBOX_ACCESS_TOKEN}
                     center={{ lat: 57.05825378109134, lng: 9.951020621279326 }}
                     zoom={19.2}
+                    onMapsIndoorsInstanceReady={miInstance => setMapsIndoorsInstance(miInstance)}
                 />
             </div>
         </>

--- a/packages/react-components/src/components/MIMap/MIMap.jsx
+++ b/packages/react-components/src/components/MIMap/MIMap.jsx
@@ -19,7 +19,8 @@ MIMap.propTypes = {
     mapboxAccessToken: PropTypes.string,
     center: PropTypes.object,
     zoom: PropTypes.number,
-    mapOptions: PropTypes.object
+    mapOptions: PropTypes.object,
+    onMapsIndoorsInstanceReady: PropTypes.func
 }
 
 /**
@@ -30,9 +31,10 @@ MIMap.propTypes = {
  * @param {Object} props.center - Object with latitude and longitude on which the map will center. Example: { lat: 55, lng: 10 }
  * @param {number} props.zoom - Zoom level for the map.
  * @param {Object} props.mapOptions - Options for instantiating and styling the map.
+ * @param {function} props.onMapsIndoorsInstanceReady - Callback for when the MapsIndoors instance (https://app.mapsindoors.com/mapsindoors/js/sdk/latest/docs/mapsindoors.MapsIndoors.html) is ready. The instance is given as payload.
  * @returns
  */
-function MIMap({ apiKey, gmApiKey, mapboxAccessToken, center, zoom, mapOptions }) {
+function MIMap({ apiKey, gmApiKey, mapboxAccessToken, center, zoom, mapOptions, onMapsIndoorsInstanceReady }) {
 
     const [mapType, setMapType] = useState();
     const [mapsIndoorsInstance, setMapsIndoorsInstance] = useState();
@@ -59,10 +61,14 @@ function MIMap({ apiKey, gmApiKey, mapboxAccessToken, center, zoom, mapOptions }
             }
         });
 
-         // TODO: Turn off visibility for building outline for demo purposes until the SDK supports Display Rules for Buildings too.
-         mi.setDisplayRule(['MI_BUILDING_OUTLINE'], { visible: false });
+        // TODO: Turn off visibility for building outline for demo purposes until the SDK supports Display Rules for Buildings too.
+        mi.setDisplayRule(['MI_BUILDING_OUTLINE'], { visible: false });
 
-         setMapsIndoorsInstance(mi);
+        setMapsIndoorsInstance(mi);
+
+        if (typeof onMapsIndoorsInstanceReady === 'function') {
+            onMapsIndoorsInstanceReady(mi);
+        }
     }
 
     /*


### PR DESCRIPTION
Expose the MapsIndoors instance as a function prop and showcase that it works in the test app by setting up a MI click event listener.