### PR TITLE
Simplify README files

### DIFF
--- a/packages/map-template/.github/README.md
+++ b/packages/map-template/.github/README.md
@@ -1,6 +1,6 @@
 # Map Template
 
-This app is built on React, with our Web Components used where applicable.
+This app is built on React, with our Web Components used where applicable. See NPM link [here](https://www.npmjs.com/package/@mapsindoors/map-template). 
 
 ## Running the app
 
@@ -53,95 +53,6 @@ If you have a React app, you can use any of these React Components in your own a
 #### Working on Components used in Map Template
 
 To have any Stencil component changes be reflected in this project, you need to run  `npx lerna run build` from the root folder. There are no watch scripts yet.
-
-## Supported properties on the MapsIndoors Map component
-
-The MapsIndoors Map component supports a list of props (see the list below) that can be configured in the `App.jsx` file.
-When loading the MapsIndoors Map component for the first time, the map will respect the default values set for the `apiKey`, `venue`, `logo` and `primaryColor` props, which can be found in the `MapsIndoorsMap.jsx` file under the `defaultProps` object.
-
-|Property|Type|Description|
-|:--|:--|:--|
-|`apiKey`|`string`|The MapsIndoors Solution you want to load. Takes both API key as string and "App alias". |
-|`gmApiKey`|`string`|Your Google Maps API key. Can also be set in the MapsIndoors App Config as "gmKey" under "appSettings". |
-|`mapboxAccessToken`|`string`|Your Mapbox Access Token. Setting it will load a Mapbox map. Can also be set in the MapsIndoors App Config "mapboxAccessToken" under "appSettings". If you set both a Mapbox Access Token and Google Maps API key, the Mapbox Access Token takes precedence. |
-|`venue`|`string`|The Venue to load from your MapsIndoors Solution. |
-|`locationId`|`string`|Set a MapsIndoors Location ID to show it on the map and its details in the sheet. |
-|`primaryColor`|`string`|The primary color to use throughout the app. |
-|`logo`|`string`|The logo to show during initial load. |
-|`appUserRoles`|`array`|A list of App User Roles to apply when loading data. Used like so: `appUserRoles={["App User Role"]}`|
-|`directionsFrom`|`string`|Set a MapsIndoors Location ID or the string `USER_POSITION` to be used as origin to instantly show directions. |
-|`directionsTo`|`string`|Set a MapsIndoors Location ID or the string `USER_POSITION` to be used as destination to instantly show directions. |
-|`externalIDs`|`array`|Array of external IDs which filters the map and shows a list of locations. Because of the way browsers work, you can not use External IDs with the `,`, `&`, `#` and `+`, character in them, as they are interpreted by the browser in a particular way. |
-|`tileStyle`|`string`|Name of Tile Style to display on the map. |
-|`startZoomLevel`|`number`|The initial zoom level of the map. |
-|`supportsUrlParameters`|`bool`|Indicates if the Map Template supports URL parameters. |
-|`gmMapId`|`string`|The Google Maps Map ID associated with a specific map style or feature. |
-|`pitch`|`number`|The pitch (Mapbox) or tilt (Google) value of the map. The value of the pitch can be between 0-85 degrees on a Mapbox map. |
-|`bearing`|`number`|The bearing (Mapbox) or heading (Google) value of the map. It accepts any value, and will modify it to fit into the range [0, 360]. |
-|`useMapProviderModule`|`bool`|Set to `true` if the Map Template should take MapsIndoors Solution Modules into consideration when determining what map type to use.|
-|`language`|`string`|The language to show textual content in. Supported values are "en" for English, "da" for Danish, "de" for German, "fr" for French, "it" for Italian, "es" for Spanish and "nl" for Dutch. If the prop is not set, the language of the browser will be used (if it is one of the supported languages - otherwise it will default to English). |
-|`kioskOriginLocationId`|`string`|If running the Map Template as a Kiosk, provide the Location ID that represents the location of the Kiosk. |
-|`timeout`|`number`|If you want the Map Template to reset the map position and the UI elements to the initial state after some time of inactivity, use this to specify the number of seconds of inactivity before resetting. This property is not dependent on the `kioskOriginLocationId`. |
-|`useKeyboard`|`bool`|If running the Map Template as a Kiosk, set this prop to `true` and it will display a virtual keyboard. This property is dependent on the `kioskOriginLocationId`. |
-|`miTransitionLevel`|`number`|The zoom level on which to transition from Mapbox to MapsIndoors data. Default value is 17. This feature is only available for Mapbox. |
-|`category`|`string`|If you want to indicate an active category on the map. The value should be the Key (Administrative ID). |
-|`searchAllVenues`|`bool`|If you want to perform search across all venues in the solution. |
-|`hideNonMatches`|`bool`|Determine whether the locations on the map should be filtered (only show the matched locations and hide the rest) or highlighted (show all locations and highlight the matched ones with a red dot by default). If set to true, the locations will be filtered. |
-|`show-road-names`|`showRoadNames`|`bool`|A boolean parameter that dictates whether Mapbox road names should be shown. By default, Mapbox road names are hidden when MapsIndoors data is shown. It is dictated by `mi-transition-level` which default value is 17. |
-|`show-external-ids`|`showExternalIDs`|`bool`|Determine whether the Location details should show the external ID or not. The default value is set to false. |
-
-## Using Query Parameters
-
-The Map Template supports using query parameters for all the properties provided by the MapsIndoorsMap component if the `supportsUrlParameters` property is set to true.
-
-The supported query parameters are the following:
-
-1. `apiKey` - Used like this `apiKey=yourApiKey`. If no apiKey is provided, the app will default to `mapspeople3d`.
-2. `venue` - Used like this `venue=yourVenueName` - the Venue property is case sensitive. If no venue is provided, the app will select the first venue from the solution in alphabetical order.
-3. `locationId` - Used like this `locationId=yourLocationId`
-4. `primaryColor` - Used like this `primaryColor=000000`. **Note!** You need to provide a hex color value, without the `#`, due to the hashtag being a reserved symbol that has a predefined purpose in a query string. If no primary color is provided, the app will default to the MapsPeople brand color.
-5. `logo` - Used like this `logo=https://images.g2crowd.com/uploads/product/image/social_landscape/social_landscape_7a75ff13f42605422950b411ab7e03b5/mapspeople.png`. Use an image address to provide a different logo on the loading screen. If no logo is provided, the app will default to the MapsPeople icon.
-6. `appUserRoles` - Used like this `appUserRoles=visitor,staff,security` - the App User Roles are case sensitive. **Note!** You need to provide a list of comma separated values, without any spaces between the comma and the value. This will further be converted into an array of appUserRoles.
-7. `directionsFrom` - Used like this `directionsFrom=yourOriginLocationId` when having a location ID, or like this `directionsFrom=USER_POSITION` when having the user location. Using the `directionsFrom` property in the URL followed by the selection of a destination location in the search view results in the wayfinding having both the origin and the destination prefilled.
-8. `directionsTo` - Used like this `directionsTo=yourDestinationLocationId` when having a location ID, or like this `directionsTo=USER_POSITION` when having the user location.
-9. `externalIDs` - Used like this `externalIDs=0.0.1,0.0.2,0.0.3`. **Note!** You need to provide a list of comma separated values, without any spaces between the comma and the value. This will further be converted into an array of external IDs. Because of the way browsers work, you **cannot** use External IDs with the `,`, `&`, `#` and `+`, character in them, as they are interpreted by the browser in a particular way.
-10. `tileStyle` - Used like this `tileStyle=yourTileStyleName`. If no tile style is provided, the app will show the default tile style.
-11. `mapboxAccessToken` - Used like this `mapboxAccessToken=yourMapboxAccessToken`. Can also be set in the MapsIndoors App Config "mapboxAccessToken" under "appSettings". If both the `mapboxAccessToken` and the `gmApiKey` are present, the app will load a Mapbox map.
-12. `gmApiKey` - Used like this `gmApiKey=yourGmApiKey`. Can also be set in the MapsIndoors App Config as "gmKey" under "appSettings". If both the `mapboxAccessToken` and the `gmApiKey` are present, the app will load a Mapbox map.
-13. `startZoomLevel` - Used like this `startZoomLevel=22`.
-14. `gmMapId` - Used like this `gmMapId=yourGmMapId`.
-15. `pitch` - Used like this `pitch=30`. Not compatible with MapsIndoors 2D models and MapsIndoors labels on Google Maps. The value of the pitch can be between 0-85 degrees on a Mapbox map.
-16. `bearing` - Used like this `bearing=180`. Not compatible with MapsIndoors 2D models and MapsIndoors labels on Google Maps.  It accepts any value, and will modify it to fit into the range [0, 360].
-17. `useMapProviderModule` - Set to "true" if the Map Template should take MapsIndoors solution modules into consideration when determining what map type to use.
-18. `language` - The language to show textual content in. Supported values are "en" for English, "da" for Danish, "de" for German, "fr" for French, "it" for Italian, "es" for Spanish and "nl" for Dutch. If the prop is not set, the language of the browser will be used (if it is one of the supported languages - otherwise it will default to English).
-19. `kioskOriginLocationId` - If running the Map Template as a Kiosk, provide the Location ID that represents the location of the Kiosk.
-20. `timeout` - If you want the Map Template to reset the map position and the UI elements to the initial state after some time of inactivity, use this to specify the number of seconds of inactivity before resetting. This property is not dependent on the `kioskOriginLocationId`.
-21. `useKeyboard` -  If running the Map Template as a Kiosk, set this prop to `true` and it will display a virtual keyboard. This property is dependent on the `kioskOriginLocationId`.
-22. `miTransitionLevel` - The zoom level on which to transition from Mapbox to MapsIndoors data. Default value is 17. This feature is only available for Mapbox.
-23. `category` - If you want to indicate an active category on the map. The value should be the Key (Administrative ID).
-24. `searchAllVenues` - If you want to perform search across all venues in the solution.
-25. `hideNonMatches` - Determine whether the locations on the map should be filtered (only show the matched locations and hide the rest) or highlighted (show all locations and highlight the matched ones with a red dot by default). If set to true, the locations will be filtered.
-26. `showRoadNames` - A boolean parameter that dictates whether Mapbox road names should be shown. By default, Mapbox road names are hidden when MapsIndoors data is shown. It is dictated by `mi-transition-level` which default value is 17.
-27. `showExternalIDs` - Determine whether the location details on the map should have an external ID visible. The default value is set to false.
-
-**Note!** All the query parameters need to be separated with the `&` symbol, without any spaces in between.
-**Note!** When using parameters such as `directionsTo`, `directionsFrom`, `locationId`, `externalIDs`, and `tileStyle` make sure you are using the correct `apiKey` parameter to which they belong.
-**Note!** When using the `gmMapId` property, you need to use it together with the `gmApiKey` that it is associated with.
-
-Example of URL:
-
-`https://domain.com/?apiKey=yourApiKey&venue=yourVenueName&locationId=yourLocationId&primaryColor=000000&logo=https://images.g2crowd.com/uploads/product/image/social_landscape/social_landscape_7a75ff13f42605422950b411ab7e03b5/mapspeople.png&appUserRoles=visitor,staff,security`
-
-**Important!** Not all the query parameters can be used together, as they serve their own purpose which in some cases overlaps with other query parameters. Example of cases that **DON’T** work together:
-
-`locationId` + `startZoomLevel` → the `startZoomLevel` has priority over the `locationId`
-
-`locationId` + `externalIDs` → the `locationId` has priority over the `externalIDs`
-
-`directionsTo` + `directionsFrom` + `locationId` → the `directionsTo` + `directionsFrom` have priority over the `locationId`
-
-`directionsTo` + `directionsFrom` + `externalIDs` → the `directionsTo` + `directionsFrom` have priority over the `externalIDs`
-
 
 ## Deploying Map Template to a cloud storage provider
 

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.55.2] - 2024-10-18
+
+### Fixed
+
+- Simplify documentation on the README files.
+
 ## [1.55.1] - 2024-10-17
 
 ### Fixed


### PR DESCRIPTION
Cleaned up the README file which is displayed on the GitHub page and removed all the duplicate code for props and query parameters. With this change, we avoid maintaining two separate README files. 
Instead, a link to NPM has been shared which can be accessed to see all the props and query parameters.