### PR TITLE
Map as standalone react component: better ways to control world position

### DIFF
--- a/packages/react-components/src/components/MIMap/GoogleMapsMap/GoogleMapsMap.jsx
+++ b/packages/react-components/src/components/MIMap/GoogleMapsMap/GoogleMapsMap.jsx
@@ -12,6 +12,7 @@ GoogleMapsMap.propTypes = {
     center: PropTypes.object,
     zoom: PropTypes.number,
     heading: PropTypes.number,
+    tilt: PropTypes.number,
     mapsIndoorsInstance: PropTypes.object,
     mapOptions: PropTypes.object
 }
@@ -22,10 +23,11 @@ GoogleMapsMap.propTypes = {
  * @param {Object} props.center - Object with latitude and longitude on which the map will center. Example: { lat: 55, lng: 10 }
  * @param {number} props.zoom - Zoom level for the map.
  * @param {number} props.heading - The heading of the map (rotation from north) as a number. Not recommended for maps with 2D Models.
+ * @param {number} [props.tilt] - The tilt of the map as a number. Not recommended for maps with 2D Models.
  * @param {Object} props.mapsIndoorsInstance - Instance of MapsIndoors class: https://app.mapsindoors.com/mapsindoors/js/sdk/latest/docs/mapsindoors.MapsIndoors.html
  * @param {Object} props.mapOptions - Options for instantiating and styling the map.
  */
-function GoogleMapsMap({ apiKey, onInitialized, center, zoom, heading, mapsIndoorsInstance, mapOptions }) {
+function GoogleMapsMap({ apiKey, onInitialized, center, zoom, heading, tilt, mapsIndoorsInstance, mapOptions }) {
 
     const [google, setGoogle] = useState();
     const [mapViewInstance, setMapViewInstance] = useState();
@@ -53,6 +55,12 @@ function GoogleMapsMap({ apiKey, onInitialized, center, zoom, heading, mapsIndoo
             mapViewInstance.getMap().setHeading(heading);
         }
     }, [heading, mapViewInstance]);
+
+    useEffect(() => {
+        if (mapViewInstance && !isNullOrUndefined(tilt)) {
+            mapViewInstance.getMap().setTilt(tilt);
+        }
+    }, [tilt, mapViewInstance]);
 
     // Add map controls to the map when ready.
     useEffect(() => {
@@ -104,6 +112,7 @@ function GoogleMapsMap({ apiKey, onInitialized, center, zoom, heading, mapsIndoo
                 center: center ?? { lat: 0, lng: 0 }, // The MapsIndoors SDK needs a starting point and a zoom level to avoid timing issues when setting a venue.
                 zoom: zoom ?? 21,
                 heading: heading ?? 0,
+                tilt: tilt ?? 0,
                 ...mapOptions
             };
 

--- a/packages/react-components/src/components/MIMap/GoogleMapsMap/GoogleMapsMap.jsx
+++ b/packages/react-components/src/components/MIMap/GoogleMapsMap/GoogleMapsMap.jsx
@@ -14,20 +14,20 @@ GoogleMapsMap.propTypes = {
     bounds: PropTypes.object,
     heading: PropTypes.number,
     tilt: PropTypes.number,
-    mapsIndoorsInstance: PropTypes.object,
+    mapsIndoorsInstance: PropTypes.object.isRequired,
     mapOptions: PropTypes.object
 }
 /**
  * @param {Object} props
  * @param {string} props.apiKey - Google Maps API key.
  * @param {function} props.onInitialized - Function that is called when the map view is initialized.
- * @param {Object} props.center - Object with latitude and longitude on which the map will center. Example: { lat: 55, lng: 10 }
- * @param {number} props.zoom - Zoom level for the map.
- * @param {object} props.bounds - Map bounds. Will win over center+zoom if set. Use the format { south: number, west: number, north: number, east: number }
- * @param {number} props.heading - The heading of the map (rotation from north) as a number. Not recommended for maps with 2D Models.
+ * @param {Object} [props.center] - Object with latitude and longitude on which the map will center. Example: { lat: 55, lng: 10 }
+ * @param {number} [props.zoom] - Zoom level for the map.
+ * @param {object} [props.bounds] - Map bounds. Will win over center+zoom if set. Use the format { south: number, west: number, north: number, east: number }
+ * @param {number} [props.heading] - The heading of the map (rotation from north) as a number. Not recommended for maps with 2D Models.
  * @param {number} [props.tilt] - The tilt of the map as a number. Not recommended for maps with 2D Models.
  * @param {Object} props.mapsIndoorsInstance - Instance of MapsIndoors class: https://app.mapsindoors.com/mapsindoors/js/sdk/latest/docs/mapsindoors.MapsIndoors.html
- * @param {Object} props.mapOptions - Options for instantiating and styling the map.
+ * @param {Object} [props.mapOptions] - Options for instantiating and styling the map.
  */
 function GoogleMapsMap({ apiKey, onInitialized, center, zoom, bounds, heading, tilt, mapsIndoorsInstance, mapOptions }) {
 

--- a/packages/react-components/src/components/MIMap/GoogleMapsMap/GoogleMapsMap.jsx
+++ b/packages/react-components/src/components/MIMap/GoogleMapsMap/GoogleMapsMap.jsx
@@ -11,6 +11,7 @@ GoogleMapsMap.propTypes = {
     onInitialized: PropTypes.func.isRequired,
     center: PropTypes.object,
     zoom: PropTypes.number,
+    bounds: PropTypes.object,
     heading: PropTypes.number,
     tilt: PropTypes.number,
     mapsIndoorsInstance: PropTypes.object,
@@ -22,12 +23,13 @@ GoogleMapsMap.propTypes = {
  * @param {function} props.onInitialized - Function that is called when the map view is initialized.
  * @param {Object} props.center - Object with latitude and longitude on which the map will center. Example: { lat: 55, lng: 10 }
  * @param {number} props.zoom - Zoom level for the map.
+ * @param {object} props.bounds - Map bounds. Will win over center+zoom if set. Use the format { south: number, west: number, north: number, east: number }
  * @param {number} props.heading - The heading of the map (rotation from north) as a number. Not recommended for maps with 2D Models.
  * @param {number} [props.tilt] - The tilt of the map as a number. Not recommended for maps with 2D Models.
  * @param {Object} props.mapsIndoorsInstance - Instance of MapsIndoors class: https://app.mapsindoors.com/mapsindoors/js/sdk/latest/docs/mapsindoors.MapsIndoors.html
  * @param {Object} props.mapOptions - Options for instantiating and styling the map.
  */
-function GoogleMapsMap({ apiKey, onInitialized, center, zoom, heading, tilt, mapsIndoorsInstance, mapOptions }) {
+function GoogleMapsMap({ apiKey, onInitialized, center, zoom, bounds, heading, tilt, mapsIndoorsInstance, mapOptions }) {
 
     const [google, setGoogle] = useState();
     const [mapViewInstance, setMapViewInstance] = useState();
@@ -38,15 +40,22 @@ function GoogleMapsMap({ apiKey, onInitialized, center, zoom, heading, tilt, map
 
     /*
      * React on any props that are used to control the position of the map.
+     *
+     * If the bounds prop is set, it will win over center+zoom.
      */
     useEffect(() => {
         if (!mapViewInstance) return;
 
-        if (!isNullOrUndefined(center)) {
+        if (!isNullOrUndefined(bounds)) {
+            // Bounds will allways win over center+zoom.
+            mapsIndoorsInstance.getMapView().fitBounds(bounds, mapOptions?.fitBoundsPadding);
+        }
+
+        if (!isNullOrUndefined(center) && isNullOrUndefined(bounds)) {
             mapViewInstance.getMap().setCenter(center);
         }
 
-        if (!isNullOrUndefined(zoom)) {
+        if (!isNullOrUndefined(zoom) && isNullOrUndefined(bounds)) {
             mapViewInstance.getMap().setZoom(zoom);
         }
 
@@ -57,7 +66,7 @@ function GoogleMapsMap({ apiKey, onInitialized, center, zoom, heading, tilt, map
         if (!isNullOrUndefined(tilt)) {
             mapViewInstance.getMap().setTilt(tilt);
         }
-    }, [mapViewInstance, center, zoom, heading, tilt]);
+    }, [mapViewInstance, center, zoom, heading, tilt, bounds, mapOptions]);
 
     // Add map controls to the map when ready.
     useEffect(() => {

--- a/packages/react-components/src/components/MIMap/GoogleMapsMap/GoogleMapsMap.jsx
+++ b/packages/react-components/src/components/MIMap/GoogleMapsMap/GoogleMapsMap.jsx
@@ -4,12 +4,14 @@ import { Loader as GoogleMapsApiLoader } from '@googlemaps/js-api-loader';
 import 'mapbox-gl/dist/mapbox-gl.css';
 import './GoogleMapsMap.scss';
 import { useIsDesktop } from '../../../hooks/useIsDesktop';
+import isNullOrUndefined from '../../../../../map-template/src/helpers/isNullOrUndefined';
 
 GoogleMapsMap.propTypes = {
     apiKey: PropTypes.string.isRequired,
     onInitialized: PropTypes.func.isRequired,
     center: PropTypes.object,
     zoom: PropTypes.number,
+    heading: PropTypes.number,
     mapsIndoorsInstance: PropTypes.object,
     mapOptions: PropTypes.object
 }
@@ -19,10 +21,11 @@ GoogleMapsMap.propTypes = {
  * @param {function} props.onInitialized - Function that is called when the map view is initialized.
  * @param {Object} props.center - Object with latitude and longitude on which the map will center. Example: { lat: 55, lng: 10 }
  * @param {number} props.zoom - Zoom level for the map.
+ * @param {number} props.heading - The heading of the map (rotation from north) as a number. Not recommended for maps with 2D Models.
  * @param {Object} props.mapsIndoorsInstance - Instance of MapsIndoors class: https://app.mapsindoors.com/mapsindoors/js/sdk/latest/docs/mapsindoors.MapsIndoors.html
  * @param {Object} props.mapOptions - Options for instantiating and styling the map.
  */
-function GoogleMapsMap({ apiKey, onInitialized, center, zoom, mapsIndoorsInstance, mapOptions }) {
+function GoogleMapsMap({ apiKey, onInitialized, center, zoom, heading, mapsIndoorsInstance, mapOptions }) {
 
     const [google, setGoogle] = useState();
     const [mapViewInstance, setMapViewInstance] = useState();
@@ -44,6 +47,12 @@ function GoogleMapsMap({ apiKey, onInitialized, center, zoom, mapsIndoorsInstanc
             mapViewInstance.getMap().setZoom(zoom);
         }
     }, [zoom]);
+
+    useEffect(() => {
+        if (mapViewInstance && !isNullOrUndefined(heading)) {
+            mapViewInstance.getMap().setHeading(heading);
+        }
+    }, [heading, mapViewInstance]);
 
     // Add map controls to the map when ready.
     useEffect(() => {
@@ -94,6 +103,7 @@ function GoogleMapsMap({ apiKey, onInitialized, center, zoom, mapsIndoorsInstanc
                 disableDefaultUI: true, // Disable Map Type control, Street view control and Zoom controls.
                 center: center ?? { lat: 0, lng: 0 }, // The MapsIndoors SDK needs a starting point and a zoom level to avoid timing issues when setting a venue.
                 zoom: zoom ?? 21,
+                heading: heading ?? 0,
                 ...mapOptions
             };
 

--- a/packages/react-components/src/components/MIMap/GoogleMapsMap/GoogleMapsMap.jsx
+++ b/packages/react-components/src/components/MIMap/GoogleMapsMap/GoogleMapsMap.jsx
@@ -36,31 +36,28 @@ function GoogleMapsMap({ apiKey, onInitialized, center, zoom, heading, tilt, map
     const [hasZoomControl, setHasZoomControl] = useState(false);
     const isDesktop = useIsDesktop();
 
+    /*
+     * React on any props that are used to control the position of the map.
+     */
     useEffect(() => {
         if (!mapViewInstance) return;
-        if (center) {
+
+        if (!isNullOrUndefined(center)) {
             mapViewInstance.getMap().setCenter(center);
         }
-    }, [center]);
 
-    useEffect(() => {
-        if (!mapViewInstance) return;
-        if (zoom) {
+        if (!isNullOrUndefined(zoom)) {
             mapViewInstance.getMap().setZoom(zoom);
         }
-    }, [zoom]);
 
-    useEffect(() => {
-        if (mapViewInstance && !isNullOrUndefined(heading)) {
+        if (!isNullOrUndefined(heading)) {
             mapViewInstance.getMap().setHeading(heading);
         }
-    }, [heading, mapViewInstance]);
 
-    useEffect(() => {
-        if (mapViewInstance && !isNullOrUndefined(tilt)) {
+        if (!isNullOrUndefined(tilt)) {
             mapViewInstance.getMap().setTilt(tilt);
         }
-    }, [tilt, mapViewInstance]);
+    }, [mapViewInstance, center, zoom, heading, tilt]);
 
     // Add map controls to the map when ready.
     useEffect(() => {

--- a/packages/react-components/src/components/MIMap/MIMap.jsx
+++ b/packages/react-components/src/components/MIMap/MIMap.jsx
@@ -19,6 +19,7 @@ MIMap.propTypes = {
     mapboxAccessToken: PropTypes.string,
     center: PropTypes.object,
     zoom: PropTypes.number,
+    bearing: PropTypes.number,
     mapOptions: PropTypes.object,
     onMapsIndoorsInstanceReady: PropTypes.func
 }
@@ -30,11 +31,12 @@ MIMap.propTypes = {
  * @param {string} props.mapboxAccessToken - Mapbox Access Token if you want to show a Mapbox map.
  * @param {Object} props.center - Object with latitude and longitude on which the map will center. Example: { lat: 55, lng: 10 }
  * @param {number} props.zoom - Zoom level for the map.
+ * @param {number} props.bearing - The bearing of the map (rotation from north) as a number. Not recommended for Google Maps with 2D Models.
  * @param {Object} props.mapOptions - Options for instantiating and styling the map.
  * @param {function} props.onMapsIndoorsInstanceReady - Callback for when the MapsIndoors instance (https://app.mapsindoors.com/mapsindoors/js/sdk/latest/docs/mapsindoors.MapsIndoors.html) is ready. The instance is given as payload.
  * @returns
  */
-function MIMap({ apiKey, gmApiKey, mapboxAccessToken, center, zoom, mapOptions, onMapsIndoorsInstanceReady }) {
+function MIMap({ apiKey, gmApiKey, mapboxAccessToken, center, zoom, bearing, mapOptions, onMapsIndoorsInstanceReady }) {
 
     const [mapType, setMapType] = useState();
     const [mapsIndoorsInstance, setMapsIndoorsInstance] = useState();
@@ -83,8 +85,8 @@ function MIMap({ apiKey, gmApiKey, mapboxAccessToken, center, zoom, mapOptions, 
     }, [gmApiKey, mapboxAccessToken]);
 
     return <>
-        {mapType === mapTypes.Google && <GoogleMapsMap mapsIndoorsInstance={mapsIndoorsInstance} apiKey={gmApiKey} onInitialized={onMapViewInitialized} center={center} zoom={zoom} mapOptions={mapOptions} />}
-        {mapType === mapTypes.Mapbox && <MapboxMap mapsIndoorsInstance={mapsIndoorsInstance} accessToken={mapboxAccessToken} onInitialized={onMapViewInitialized} center={center} zoom={zoom} mapOptions={mapOptions} />}
+        {mapType === mapTypes.Google && <GoogleMapsMap mapsIndoorsInstance={mapsIndoorsInstance} apiKey={gmApiKey} onInitialized={onMapViewInitialized} center={center} zoom={zoom} mapOptions={mapOptions} heading={bearing} />}
+        {mapType === mapTypes.Mapbox && <MapboxMap mapsIndoorsInstance={mapsIndoorsInstance} accessToken={mapboxAccessToken} onInitialized={onMapViewInitialized} center={center} zoom={zoom} mapOptions={mapOptions} bearing={bearing} />}
     </>
 }
 

--- a/packages/react-components/src/components/MIMap/MIMap.jsx
+++ b/packages/react-components/src/components/MIMap/MIMap.jsx
@@ -20,6 +20,7 @@ MIMap.propTypes = {
     center: PropTypes.object,
     zoom: PropTypes.number,
     bearing: PropTypes.number,
+    pitch: PropTypes.number,
     mapOptions: PropTypes.object,
     onMapsIndoorsInstanceReady: PropTypes.func
 }
@@ -32,11 +33,12 @@ MIMap.propTypes = {
  * @param {Object} props.center - Object with latitude and longitude on which the map will center. Example: { lat: 55, lng: 10 }
  * @param {number} props.zoom - Zoom level for the map.
  * @param {number} props.bearing - The bearing of the map (rotation from north) as a number. Not recommended for Google Maps with 2D Models.
+ * @param {number} [props.pitch] - The pitch of the map as a number. Not recommended for Google Maps with 2D Models.
  * @param {Object} props.mapOptions - Options for instantiating and styling the map.
  * @param {function} props.onMapsIndoorsInstanceReady - Callback for when the MapsIndoors instance (https://app.mapsindoors.com/mapsindoors/js/sdk/latest/docs/mapsindoors.MapsIndoors.html) is ready. The instance is given as payload.
  * @returns
  */
-function MIMap({ apiKey, gmApiKey, mapboxAccessToken, center, zoom, bearing, mapOptions, onMapsIndoorsInstanceReady }) {
+function MIMap({ apiKey, gmApiKey, mapboxAccessToken, center, zoom, bearing, pitch, mapOptions, onMapsIndoorsInstanceReady }) {
 
     const [mapType, setMapType] = useState();
     const [mapsIndoorsInstance, setMapsIndoorsInstance] = useState();
@@ -85,8 +87,8 @@ function MIMap({ apiKey, gmApiKey, mapboxAccessToken, center, zoom, bearing, map
     }, [gmApiKey, mapboxAccessToken]);
 
     return <>
-        {mapType === mapTypes.Google && <GoogleMapsMap mapsIndoorsInstance={mapsIndoorsInstance} apiKey={gmApiKey} onInitialized={onMapViewInitialized} center={center} zoom={zoom} mapOptions={mapOptions} heading={bearing} />}
-        {mapType === mapTypes.Mapbox && <MapboxMap mapsIndoorsInstance={mapsIndoorsInstance} accessToken={mapboxAccessToken} onInitialized={onMapViewInitialized} center={center} zoom={zoom} mapOptions={mapOptions} bearing={bearing} />}
+        {mapType === mapTypes.Google && <GoogleMapsMap mapsIndoorsInstance={mapsIndoorsInstance} apiKey={gmApiKey} onInitialized={onMapViewInitialized} center={center} zoom={zoom} mapOptions={mapOptions} heading={bearing} tilt={pitch} />}
+        {mapType === mapTypes.Mapbox && <MapboxMap mapsIndoorsInstance={mapsIndoorsInstance} accessToken={mapboxAccessToken} onInitialized={onMapViewInitialized} center={center} zoom={zoom} mapOptions={mapOptions} bearing={bearing} pitch={pitch} />}
     </>
 }
 

--- a/packages/react-components/src/components/MIMap/MIMap.jsx
+++ b/packages/react-components/src/components/MIMap/MIMap.jsx
@@ -29,15 +29,15 @@ MIMap.propTypes = {
 /**
  * @param {Object} props
  * @param {string} props.apiKey - MapsIndoors API key or solution alias.
- * @param {string} props.gmApiKey - Google Maps API key if you want to show a Google Maps map.
- * @param {string} props.mapboxAccessToken - Mapbox Access Token if you want to show a Mapbox map.
- * @param {Object} props.center - Object with latitude and longitude on which the map will center. Example: { lat: 55, lng: 10 }
- * @param {number} props.zoom - Zoom level for the map.
- * @param {object} props.bounds - Map bounds. Will win over center+zoom if set. Use the format { south: number, west: number, north: number, east: number }
- * @param {number} props.bearing - The bearing of the map (rotation from north) as a number. Not recommended for Google Maps with 2D Models.
+ * @param {string} [props.gmApiKey] - Google Maps API key if you want to show a Google Maps map.
+ * @param {string} [props.mapboxAccessToken] - Mapbox Access Token if you want to show a Mapbox map.
+ * @param {Object} [props.center] - Object with latitude and longitude on which the map will center. Example: { lat: 55, lng: 10 }
+ * @param {number} [props.zoom] - Zoom level for the map.
+ * @param {object} [props.bounds] - Map bounds. Will win over center+zoom if set. Use the format { south: number, west: number, north: number, east: number }
+ * @param {number} [props.bearing] - The bearing of the map (rotation from north) as a number. Not recommended for Google Maps with 2D Models.
  * @param {number} [props.pitch] - The pitch of the map as a number. Not recommended for Google Maps with 2D Models.
- * @param {Object} props.mapOptions - Options for instantiating and styling the map. In addition to map specific options, it can also contain a floorSelectorColor prop (hex string) and a fitBoundsPadding object ({top: number, right: number, bottom: number, left: number }).
- * @param {function} props.onMapsIndoorsInstanceReady - Callback for when the MapsIndoors instance (https://app.mapsindoors.com/mapsindoors/js/sdk/latest/docs/mapsindoors.MapsIndoors.html) is ready. The instance is given as payload.
+ * @param {Object} [props.mapOptions] - Options for instantiating and styling the map. In addition to map specific options, it can also contain a floorSelectorColor prop (hex string) and a fitBoundsPadding object ({top: number, right: number, bottom: number, left: number }).
+ * @param {function} [props.onMapsIndoorsInstanceReady] - Callback for when the MapsIndoors instance (https://app.mapsindoors.com/mapsindoors/js/sdk/latest/docs/mapsindoors.MapsIndoors.html) is ready. The instance is given as payload.
  * @returns
  */
 function MIMap({ apiKey, gmApiKey, mapboxAccessToken, center, zoom, bounds, bearing, pitch, mapOptions, onMapsIndoorsInstanceReady }) {

--- a/packages/react-components/src/components/MIMap/MIMap.jsx
+++ b/packages/react-components/src/components/MIMap/MIMap.jsx
@@ -19,6 +19,7 @@ MIMap.propTypes = {
     mapboxAccessToken: PropTypes.string,
     center: PropTypes.object,
     zoom: PropTypes.number,
+    bounds: PropTypes.object,
     bearing: PropTypes.number,
     pitch: PropTypes.number,
     mapOptions: PropTypes.object,
@@ -32,13 +33,14 @@ MIMap.propTypes = {
  * @param {string} props.mapboxAccessToken - Mapbox Access Token if you want to show a Mapbox map.
  * @param {Object} props.center - Object with latitude and longitude on which the map will center. Example: { lat: 55, lng: 10 }
  * @param {number} props.zoom - Zoom level for the map.
+ * @param {object} props.bounds - Map bounds. Will win over center+zoom if set. Use the format { south: number, west: number, north: number, east: number }
  * @param {number} props.bearing - The bearing of the map (rotation from north) as a number. Not recommended for Google Maps with 2D Models.
  * @param {number} [props.pitch] - The pitch of the map as a number. Not recommended for Google Maps with 2D Models.
- * @param {Object} props.mapOptions - Options for instantiating and styling the map.
+ * @param {Object} props.mapOptions - Options for instantiating and styling the map. In addition to map specific options, it can also contain a floorSelectorColor prop (hex string) and a fitBoundsPadding object ({top: number, right: number, bottom: number, left: number }).
  * @param {function} props.onMapsIndoorsInstanceReady - Callback for when the MapsIndoors instance (https://app.mapsindoors.com/mapsindoors/js/sdk/latest/docs/mapsindoors.MapsIndoors.html) is ready. The instance is given as payload.
  * @returns
  */
-function MIMap({ apiKey, gmApiKey, mapboxAccessToken, center, zoom, bearing, pitch, mapOptions, onMapsIndoorsInstanceReady }) {
+function MIMap({ apiKey, gmApiKey, mapboxAccessToken, center, zoom, bounds, bearing, pitch, mapOptions, onMapsIndoorsInstanceReady }) {
 
     const [mapType, setMapType] = useState();
     const [mapsIndoorsInstance, setMapsIndoorsInstance] = useState();
@@ -87,8 +89,8 @@ function MIMap({ apiKey, gmApiKey, mapboxAccessToken, center, zoom, bearing, pit
     }, [gmApiKey, mapboxAccessToken]);
 
     return <>
-        {mapType === mapTypes.Google && <GoogleMapsMap mapsIndoorsInstance={mapsIndoorsInstance} apiKey={gmApiKey} onInitialized={onMapViewInitialized} center={center} zoom={zoom} mapOptions={mapOptions} heading={bearing} tilt={pitch} />}
-        {mapType === mapTypes.Mapbox && <MapboxMap mapsIndoorsInstance={mapsIndoorsInstance} accessToken={mapboxAccessToken} onInitialized={onMapViewInitialized} center={center} zoom={zoom} mapOptions={mapOptions} bearing={bearing} pitch={pitch} />}
+        {mapType === mapTypes.Google && <GoogleMapsMap mapsIndoorsInstance={mapsIndoorsInstance} apiKey={gmApiKey} onInitialized={onMapViewInitialized} center={center} zoom={zoom} mapOptions={mapOptions} heading={bearing} tilt={pitch} bounds={bounds} />}
+        {mapType === mapTypes.Mapbox && <MapboxMap mapsIndoorsInstance={mapsIndoorsInstance} accessToken={mapboxAccessToken} onInitialized={onMapViewInitialized} center={center} zoom={zoom} mapOptions={mapOptions} bearing={bearing} pitch={pitch} bounds={bounds} />}
     </>
 }
 

--- a/packages/react-components/src/components/MIMap/MapboxMap/MapboxMap.jsx
+++ b/packages/react-components/src/components/MIMap/MapboxMap/MapboxMap.jsx
@@ -14,7 +14,7 @@ MapboxMap.propTypes = {
     bounds: PropTypes.object,
     bearing: PropTypes.number,
     pitch: PropTypes.number,
-    mapsIndoorsInstance: PropTypes.object,
+    mapsIndoorsInstance: PropTypes.object.isRequired,
     mapOptions: PropTypes.object
 }
 
@@ -22,13 +22,13 @@ MapboxMap.propTypes = {
  * @param {Object} props
  * @param {string} props.accessToken -  Mapbox Access Token.
  * @param {function} props.onInitialized - Function that is called when the map view is initialized.
- * @param {Object} props.center - Object with latitude and longitude on which the map will center. Example: { lat: 55, lng: 10 }
- * @param {number} props.zoom - Zoom level for the map.
- * @param {object} props.bounds - Map bounds. Will win over center+zoom if set. Use the format { south: number, west: number, north: number, east: number }
- * @param {number} props.bearing - The bearing of the map (rotation from north) as a number.
+ * @param {Object} [props.center] - Object with latitude and longitude on which the map will center. Example: { lat: 55, lng: 10 }
+ * @param {number} [props.zoom] - Zoom level for the map.
+ * @param {object} [props.bounds] - Map bounds. Will win over center+zoom if set. Use the format { south: number, west: number, north: number, east: number }
+ * @param {number} [props.bearing] - The bearing of the map (rotation from north) as a number.
  * @param {number} [props.pitch] - The pitch of the map as a number.
  * @param {Object} props.mapsIndoorsInstance - Instance of MapsIndoors class: https://app.mapsindoors.com/mapsindoors/js/sdk/latest/docs/mapsindoors.MapsIndoors.html
- * @param {Object} props.mapOptions - Options for instantiating and styling the map.
+ * @param {Object} [props.mapOptions] - Options for instantiating and styling the map.
  */
 function MapboxMap({ accessToken, onInitialized, center, zoom, bounds, bearing, pitch, mapsIndoorsInstance, mapOptions }) {
 

--- a/packages/react-components/src/components/MIMap/MapboxMap/MapboxMap.jsx
+++ b/packages/react-components/src/components/MIMap/MapboxMap/MapboxMap.jsx
@@ -12,6 +12,7 @@ MapboxMap.propTypes = {
     center: PropTypes.object,
     zoom: PropTypes.number,
     bearing: PropTypes.number,
+    pitch: PropTypes.number,
     mapsIndoorsInstance: PropTypes.object,
     mapOptions: PropTypes.object
 }
@@ -23,10 +24,11 @@ MapboxMap.propTypes = {
  * @param {Object} props.center - Object with latitude and longitude on which the map will center. Example: { lat: 55, lng: 10 }
  * @param {number} props.zoom - Zoom level for the map.
  * @param {number} props.bearing - The bearing of the map (rotation from north) as a number.
+ * @param {number} [props.pitch] - The pitch of the map as a number.
  * @param {Object} props.mapsIndoorsInstance - Instance of MapsIndoors class: https://app.mapsindoors.com/mapsindoors/js/sdk/latest/docs/mapsindoors.MapsIndoors.html
  * @param {Object} props.mapOptions - Options for instantiating and styling the map.
  */
-function MapboxMap({ accessToken, onInitialized, center, zoom, bearing, mapsIndoorsInstance, mapOptions }) {
+function MapboxMap({ accessToken, onInitialized, center, zoom, bearing, pitch, mapsIndoorsInstance, mapOptions }) {
 
     const [mapViewInstance, setMapViewInstance] = useState();
     const [hasFloorSelector, setHasFloorSelector] = useState(false);
@@ -53,6 +55,12 @@ function MapboxMap({ accessToken, onInitialized, center, zoom, bearing, mapsIndo
             mapViewInstance.getMap().setBearing(bearing);
         }
     }, [bearing, mapViewInstance]);
+
+    useEffect(() => {
+        if (mapViewInstance && !isNullOrUndefined(pitch)) {
+            mapViewInstance.getMap().setPitch(pitch);
+        }
+    }, [pitch, mapViewInstance]);
 
     // Add map controls to the map when ready
     useEffect(() => {
@@ -101,6 +109,7 @@ function MapboxMap({ accessToken, onInitialized, center, zoom, bearing, mapsIndo
             center: center ?? { lat: 0, lng: 0 }, // The MapsIndoors SDK needs a starting point and a zoom level to avoid timing issues when setting a venue.
             zoom: zoom ?? 15,
             bearing: bearing ?? 0,
+            pitch: pitch ?? 0,
             ...mapOptions
         };
 

--- a/packages/react-components/src/components/MIMap/MapboxMap/MapboxMap.jsx
+++ b/packages/react-components/src/components/MIMap/MapboxMap/MapboxMap.jsx
@@ -36,31 +36,29 @@ function MapboxMap({ accessToken, onInitialized, center, zoom, bearing, pitch, m
     const [hasZoomControl, setHasZoomControl] = useState(false);
     const isDesktop = useIsDesktop();
 
+    /*
+     * React on any props that are used to control the position of the map.
+     */
     useEffect(() => {
         if (!mapViewInstance) return;
-        if (center) {
+
+        if (!isNullOrUndefined(center)) {
             mapViewInstance.getMap().setCenter(center);
         }
-    }, [center]);
 
-    useEffect(() => {
-        if (!mapViewInstance) return;
-        if (zoom) {
+        if (!isNullOrUndefined(zoom)) {
             mapViewInstance.getMap().setZoom(zoom);
         }
-    }, [zoom]);
 
-    useEffect(() => {
-        if (mapViewInstance && !isNullOrUndefined(bearing)) {
+        if (!isNullOrUndefined(bearing)) {
             mapViewInstance.getMap().setBearing(bearing);
         }
-    }, [bearing, mapViewInstance]);
 
-    useEffect(() => {
-        if (mapViewInstance && !isNullOrUndefined(pitch)) {
+        if (!isNullOrUndefined(pitch)) {
             mapViewInstance.getMap().setPitch(pitch);
         }
-    }, [pitch, mapViewInstance]);
+    }, [mapViewInstance, center, zoom, bearing, pitch]);
+
 
     // Add map controls to the map when ready
     useEffect(() => {

--- a/packages/react-components/src/components/MIMap/MapboxMap/MapboxMap.jsx
+++ b/packages/react-components/src/components/MIMap/MapboxMap/MapboxMap.jsx
@@ -4,12 +4,14 @@ import mapboxgl from 'mapbox-gl';
 import 'mapbox-gl/dist/mapbox-gl.css';
 import './MapboxMap.scss';
 import { useIsDesktop } from '../../../hooks/useIsDesktop';
+import isNullOrUndefined from '../../../../../map-template/src/helpers/isNullOrUndefined';
 
 MapboxMap.propTypes = {
     accessToken: PropTypes.string.isRequired,
     onInitialized: PropTypes.func.isRequired,
     center: PropTypes.object,
     zoom: PropTypes.number,
+    bearing: PropTypes.number,
     mapsIndoorsInstance: PropTypes.object,
     mapOptions: PropTypes.object
 }
@@ -20,10 +22,11 @@ MapboxMap.propTypes = {
  * @param {function} props.onInitialized - Function that is called when the map view is initialized.
  * @param {Object} props.center - Object with latitude and longitude on which the map will center. Example: { lat: 55, lng: 10 }
  * @param {number} props.zoom - Zoom level for the map.
+ * @param {number} props.bearing - The bearing of the map (rotation from north) as a number.
  * @param {Object} props.mapsIndoorsInstance - Instance of MapsIndoors class: https://app.mapsindoors.com/mapsindoors/js/sdk/latest/docs/mapsindoors.MapsIndoors.html
  * @param {Object} props.mapOptions - Options for instantiating and styling the map.
  */
-function MapboxMap({ accessToken, onInitialized, center, zoom, mapsIndoorsInstance, mapOptions }) {
+function MapboxMap({ accessToken, onInitialized, center, zoom, bearing, mapsIndoorsInstance, mapOptions }) {
 
     const [mapViewInstance, setMapViewInstance] = useState();
     const [hasFloorSelector, setHasFloorSelector] = useState(false);
@@ -44,6 +47,12 @@ function MapboxMap({ accessToken, onInitialized, center, zoom, mapsIndoorsInstan
             mapViewInstance.getMap().setZoom(zoom);
         }
     }, [zoom]);
+
+    useEffect(() => {
+        if (mapViewInstance && !isNullOrUndefined(bearing)) {
+            mapViewInstance.getMap().setBearing(bearing);
+        }
+    }, [bearing, mapViewInstance]);
 
     // Add map controls to the map when ready
     useEffect(() => {
@@ -91,6 +100,7 @@ function MapboxMap({ accessToken, onInitialized, center, zoom, mapsIndoorsInstan
             element: document.getElementById('map'),
             center: center ?? { lat: 0, lng: 0 }, // The MapsIndoors SDK needs a starting point and a zoom level to avoid timing issues when setting a venue.
             zoom: zoom ?? 15,
+            bearing: bearing ?? 0,
             ...mapOptions
         };
 


### PR DESCRIPTION
- Implement three new props on the MIMap component: `bounds`, `bearing` and `pitch`. These can be used to control what part of the world the map shows at any given time. `bounds` will always win over `center`+`zoom`.
- Added another property on the `mapOptions` object: `fitBoundsPadding` that can be used to control the padding in pixels when fitting to bounds.
- Clarified which props are required and which are optional.