### PR TITLE
Map as standalone react component: build

### DIFF
--- a/packages/react-components/buildTools/build.mjs
+++ b/packages/react-components/buildTools/build.mjs
@@ -1,0 +1,40 @@
+// Use "build" from Vite to build the React component in a distribution folder.
+
+import { build } from 'vite';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const libraries = [
+    // React Component
+    {
+        build: {
+            outDir: './dist',
+            lib: {
+                entry: path.resolve(__dirname, 'reactcomponent.js'),
+                name: 'MIMapReact', // unused, but required
+                fileName: format => `mi-map-react.${format}.js`,
+                formats: ['es', 'umd']
+            },
+            emptyOutDir: false,
+            rollupOptions: {
+                external: ['react', 'react-dom'],
+                output: {
+                    globals: {
+                        react: 'React',
+                        'react-dom': 'ReactDOM'
+                    }
+                }
+            }
+        },
+        plugins: [
+            cssInjectedByJsPlugin()
+        ]
+    }
+]
+
+libraries.forEach(async (library) => {
+    await build(library);
+});

--- a/packages/react-components/buildTools/reactcomponent.js
+++ b/packages/react-components/buildTools/reactcomponent.js
@@ -1,0 +1,3 @@
+import MIMap from '../src/components/MIMap/MIMap.jsx';
+
+export default MIMap;

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "node buildTools/build.mjs",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
   },
@@ -27,6 +27,7 @@
     "mapbox-gl": "^3.7.0",
     "prop-types": "^15.8.1",
     "sass": "^1.57.1",
-    "vite": "^4.4.5"
+    "vite": "^4.4.5",
+    "vite-plugin-css-injected-by-js": "^3.1.0"
   }
 }

--- a/packages/react-components/src/components/MIMap/GoogleMapsMap/GoogleMapsMap.jsx
+++ b/packages/react-components/src/components/MIMap/GoogleMapsMap/GoogleMapsMap.jsx
@@ -14,7 +14,7 @@ GoogleMapsMap.propTypes = {
     bounds: PropTypes.object,
     heading: PropTypes.number,
     tilt: PropTypes.number,
-    mapsIndoorsInstance: PropTypes.object.isRequired,
+    mapsIndoorsInstance: PropTypes.object,
     mapOptions: PropTypes.object
 }
 /**
@@ -26,7 +26,7 @@ GoogleMapsMap.propTypes = {
  * @param {object} [props.bounds] - Map bounds. Will win over center+zoom if set. Use the format { south: number, west: number, north: number, east: number }
  * @param {number} [props.heading] - The heading of the map (rotation from north) as a number. Not recommended for maps with 2D Models.
  * @param {number} [props.tilt] - The tilt of the map as a number. Not recommended for maps with 2D Models.
- * @param {Object} props.mapsIndoorsInstance - Instance of MapsIndoors class: https://app.mapsindoors.com/mapsindoors/js/sdk/latest/docs/mapsindoors.MapsIndoors.html
+ * @param {Object} [props.mapsIndoorsInstance] - Instance of MapsIndoors class: https://app.mapsindoors.com/mapsindoors/js/sdk/latest/docs/mapsindoors.MapsIndoors.html
  * @param {Object} [props.mapOptions] - Options for instantiating and styling the map.
  */
 function GoogleMapsMap({ apiKey, onInitialized, center, zoom, bounds, heading, tilt, mapsIndoorsInstance, mapOptions }) {

--- a/packages/react-components/src/components/MIMap/MIMap.jsx
+++ b/packages/react-components/src/components/MIMap/MIMap.jsx
@@ -5,9 +5,6 @@ import GoogleMapsMap from './GoogleMapsMap/GoogleMapsMap';
 import { defineCustomElements } from '@mapsindoors/components/dist/esm/loader.js';
 import './MIMap.scss';
 
-// Define the Custom Elements from our components package.
-defineCustomElements();
-
 const mapTypes = {
     Google: 'google',
     Mapbox: 'mapbox'
@@ -44,6 +41,14 @@ function MIMap({ apiKey, gmApiKey, mapboxAccessToken, center, zoom, bounds, bear
 
     const [mapType, setMapType] = useState();
     const [mapsIndoorsInstance, setMapsIndoorsInstance] = useState();
+
+    useEffect(() => {
+        // Make sure to define the MI Components custom elements if they are not already defined.
+        // Best way for now is to check that is to check for the existance of one of them in the custom elements registry.
+        if (!window.customElements.get('mi-floor-selector')) {
+            defineCustomElements();
+        }
+    }, []);
 
     useEffect(() => {
         if (apiKey) {

--- a/packages/react-components/src/components/MIMap/MapboxMap/MapboxMap.jsx
+++ b/packages/react-components/src/components/MIMap/MapboxMap/MapboxMap.jsx
@@ -14,7 +14,7 @@ MapboxMap.propTypes = {
     bounds: PropTypes.object,
     bearing: PropTypes.number,
     pitch: PropTypes.number,
-    mapsIndoorsInstance: PropTypes.object.isRequired,
+    mapsIndoorsInstance: PropTypes.object,
     mapOptions: PropTypes.object
 }
 
@@ -27,7 +27,7 @@ MapboxMap.propTypes = {
  * @param {object} [props.bounds] - Map bounds. Will win over center+zoom if set. Use the format { south: number, west: number, north: number, east: number }
  * @param {number} [props.bearing] - The bearing of the map (rotation from north) as a number.
  * @param {number} [props.pitch] - The pitch of the map as a number.
- * @param {Object} props.mapsIndoorsInstance - Instance of MapsIndoors class: https://app.mapsindoors.com/mapsindoors/js/sdk/latest/docs/mapsindoors.MapsIndoors.html
+ * @param {Object} [props.mapsIndoorsInstance] - Instance of MapsIndoors class: https://app.mapsindoors.com/mapsindoors/js/sdk/latest/docs/mapsindoors.MapsIndoors.html
  * @param {Object} [props.mapOptions] - Options for instantiating and styling the map.
  */
 function MapboxMap({ accessToken, onInitialized, center, zoom, bounds, bearing, pitch, mapsIndoorsInstance, mapOptions }) {


### PR DESCRIPTION
- Add build script that builds the MIMap component so it can be used in other packages (and potentially to be released on NPM).
- removed condition for mapsIndoorsInstance to be a required property on the map sub components, since that is not really the case, and it throws warnings when trying to use the MIMap in the Map Template.
- Only define the MI Components custom elements if they are not already defined. Otherwise we risk errors when the map is used as part of another app that also uses the MI Components.