### PR TITLE
Demo for offices release 1: fake device position

### DIFF
--- a/packages/demo-office/src/App.jsx
+++ b/packages/demo-office/src/App.jsx
@@ -1,6 +1,7 @@
 import './App.css'
 import MIMap from '@mapsindoors/react-components/src/components/MIMap/MIMap';
 import Header from './Header/Header';
+import addBlueDot from './tools/addBlueDot';
 
 function App() {
 
@@ -8,6 +9,18 @@ function App() {
     const center = { lng: -97.74203004999998, lat: 30.360050363249286 };
     // A well fitting zoom level
     const zoom = 17.6;
+
+    /**
+     * Callback for when the MapsIndoors instance is initialized.
+     */
+    const onInitialized = (mapsIndoorsInstance) => {
+        // Add fake blue dot signalling the current device position.
+        // This is NOT using the built in MapsIndoors positioning feature, but is just a faked visual representation.
+        const mapboxMap = mapsIndoorsInstance.getMap();
+        mapboxMap.on('style.load', () => {
+            addBlueDot(mapboxMap);
+        });
+    };
 
     return (
         <>
@@ -18,6 +31,7 @@ function App() {
                     mapboxAccessToken={import.meta.env.VITE_MAPBOX_ACCESS_TOKEN}
                     center={center}
                     zoom={zoom}
+                    onInitialized={onInitialized}
                 />
             </main>
         </>

--- a/packages/demo-office/src/App.jsx
+++ b/packages/demo-office/src/App.jsx
@@ -13,12 +13,15 @@ function App() {
     /**
      * Callback for when the MapsIndoors instance is initialized.
      */
-    const onInitialized = (mapsIndoorsInstance) => {
-        // Add fake blue dot signalling the current device position.
-        // This is NOT using the built in MapsIndoors positioning feature, but is just a faked visual representation.
+    const onInitialized = (mapsIndoorsInstance, positionControl) => {
         const mapboxMap = mapsIndoorsInstance.getMap();
         mapboxMap.on('style.load', () => {
+            // Add fake blue dot signalling the current device position.
+            // This is NOT using the built in MapsIndoors positioning feature, but is just a faked visual representation.
             addBlueDot(mapboxMap);
+
+            // Remove the built-in Position Control from the map. We will fake the position instead.
+            positionControl.remove()
         });
     };
 

--- a/packages/demo-office/src/fakeData.js
+++ b/packages/demo-office/src/fakeData.js
@@ -1,0 +1,9 @@
+/*
+ * This file is used to provide fake data for the demo.
+ */
+export default {
+    devicePosition: {
+        lat: 30.360573677092603,
+        lng: -97.74225010031331,
+    }
+};

--- a/packages/demo-office/src/tools/addBlueDot.js
+++ b/packages/demo-office/src/tools/addBlueDot.js
@@ -1,0 +1,96 @@
+import fakeData from '../fakeData';
+
+/**
+ * Add a blue dot to the Mapbox map based on a fake position.
+ */
+export default function(mapboxMap) {
+    // Generate a pulsing dot for the fake device position
+    const pulsingDot = generatePulsingDot(mapboxMap);
+    mapboxMap.addImage('pulsing-dot', pulsingDot, { pixelRatio: 2 });
+
+    // Add the fake device position as a source on the Mapbox map
+    mapboxMap.addSource('fake-device-position', {
+        type: 'geojson',
+        data: {
+            type: 'Feature',
+            geometry: {
+                type: 'Point',
+                coordinates: [fakeData.devicePosition.lng, fakeData.devicePosition.lat]
+            }
+        }
+    });
+
+    // Add a layer to the map that shows a blue dot at the fake device position
+    mapboxMap.addLayer({
+        id: 'fake-device-position',
+        type: 'symbol',
+        source: 'fake-device-position',
+        layout: {
+            'icon-image': 'pulsing-dot',
+            'icon-allow-overlap': true
+        }
+    });
+}
+
+/**
+ * Generate a pulsing dot for the map using a canvas.
+ */
+function generatePulsingDot(mapboxMap) {
+    const canvasSize = 100;
+
+    return {
+        width: canvasSize,
+        height: canvasSize,
+        data: new Uint8Array(canvasSize * canvasSize * 4),
+
+        onAdd: function () {
+            const canvas = document.createElement('canvas');
+            canvas.width = this.width;
+            canvas.height = this.height;
+            this.context = canvas.getContext('2d');
+        },
+
+        render: function () {
+            const duration = 1000; // ms
+
+            // Normalized time within the current cycle, between 0 and 1.
+            const t = (performance.now() % duration) / duration;
+
+            const radius = (canvasSize / 2) * 0.3;
+            const outerRadius = (canvasSize / 2) * 0.7 * t + radius;
+            const context = this.context;
+
+            // Draw the outer circle.
+            context.clearRect(0, 0, this.width, this.height);
+            context.beginPath();
+            context.arc(
+                this.width / 2,
+                this.height / 2,
+                outerRadius / 2,
+                0,
+                Math.PI * 2
+            );
+            context.fillStyle = `rgba(48, 113, 217, ${1 - t})`;
+            context.fill();
+
+            // Draw the inner circle.
+            context.beginPath();
+            context.arc(this.width / 2, this.height / 2, radius, 0, Math.PI * 2);
+            context.fillStyle = 'rgba(48, 113, 217, 1)';
+            context.strokeStyle = 'white';
+            context.lineWidth = 2 + 4 * (1 - t);
+            context.fill();
+            context.stroke();
+
+            // Update this image's data with data from the canvas.
+            this.data = context.getImageData(0, 0, this.width, this.height).data;
+
+            // Continuously repaint the map, resulting
+            // in the smooth animation of the dot.
+            mapboxMap.triggerRepaint();
+
+            // Return `true` to let the map know that the image was updated.
+            return true;
+        }
+    };
+}


### PR DESCRIPTION
# What

- Implement a "fake" blue dot on the Office demo

# How

- Adds a fake data set that contains a faked device position
- Adds an image created with the Canvas API (copied more or less from the old Vercel demo)
- Adds the faked device position as a data source on the Mapbox map
- Adds a new layer on the Mapbox map using the added data source and the image
- Remove the built-in Position Control from the MIMap since we don't want multiple blue dots