### PR TITLE
Map as standalone component: Fix broken tilt when resetting

### DIFF
--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -139,7 +139,7 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
     const [initialFilteredLocations, setInitialFilteredLocations] = useState();
 
     const [appConfig, setAppConfig] = useRecoilState(appConfigState);
-    const [solution, setSolution] = useRecoilState(solutionState);
+    const [, setSolution] = useRecoilState(solutionState);
 
     const [, setTileStyle] = useRecoilState(tileStyleState);
     const [, setStartZoomLevel] = useRecoilState(startZoomLevelState);

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -405,7 +405,7 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
 
     /*
      * React on changes in the pitch prop.
-     * If the pitch is not set, set it to 45 degrees if the required modules are enabled (2D/3D switch).
+     * If the pitch is not set, set it to 45 degrees if the view mode switch is visible.
      */
     useEffect(() => {
         if (!isNullOrUndefined(pitch)) {

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -634,6 +634,7 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
             onMapPositionInvestigating={() => setIsMapPositionInvestigating(true)}
             onLocationClick={(location) => locationClicked(location)}
             onViewModeSwitchKnown={visible => setViewModeSwitchVisible(visible)}
+            resetCount={resetCount}
         />
     </div>
 }

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -55,6 +55,7 @@ import appConfigState from '../../atoms/appConfigState.js';
 import { useCurrentVenue } from '../../hooks/useCurrentVenue.js';
 import showExternalIDsState from '../../atoms/showExternalIDsState.js'
 import showRoadNamesState from '../../atoms/showRoadNamesState.js';
+import isNullOrUndefined from '../../helpers/isNullOrUndefined.js';
 
 // Define the Custom Elements from our components package.
 defineCustomElements();
@@ -137,7 +138,7 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
     const [initialFilteredLocations, setInitialFilteredLocations] = useState();
 
     const [appConfig, setAppConfig] = useRecoilState(appConfigState);
-    const [, setSolution] = useRecoilState(solutionState);
+    const [solution, setSolution] = useRecoilState(solutionState);
 
     const [, setTileStyle] = useRecoilState(tileStyleState);
     const [, setStartZoomLevel] = useRecoilState(startZoomLevelState);
@@ -403,10 +404,15 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
 
     /*
      * React on changes in the pitch prop.
+     * If the pitch is not set, set it to 45 degrees if the required modules are enabled (2D/3D switch).
      */
     useEffect(() => {
-        setPitch(pitch);
-    }, [pitch]);
+        if (!isNullOrUndefined(pitch)) {
+            setPitch(pitch);
+        } else if (solution && ['mapbox', '3dwalls', 'floorplan'].every(requiredModule => solution.modules.map(module => module.toLowerCase()).includes(requiredModule))) {
+            setPitch(45);
+        }
+    }, [pitch, solution]);
 
     /*
      * React on changes in the bearing prop.

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -119,6 +119,7 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
     const [, setHideNonMatches] = useRecoilState(hideNonMatchesState);
     const [, setshowExternalIDs] = useRecoilState(showExternalIDsState);
     const [, setShowRoadNames] = useRecoilState(showRoadNamesState);
+    const [viewModeSwitchVisible, setViewModeSwitchVisible] = useState();
 
     const [showVenueSelector, setShowVenueSelector] = useState(true);
     const [showPositionControl, setShowPositionControl] = useState(true);
@@ -409,10 +410,10 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
     useEffect(() => {
         if (!isNullOrUndefined(pitch)) {
             setPitch(pitch);
-        } else if (solution && ['mapbox', '3dwalls', 'floorplan'].every(requiredModule => solution.modules.map(module => module.toLowerCase()).includes(requiredModule))) {
+        } else if (viewModeSwitchVisible) {
             setPitch(45);
         }
-    }, [pitch, solution]);
+    }, [pitch, viewModeSwitchVisible]);
 
     /*
      * React on changes in the bearing prop.
@@ -632,6 +633,7 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
             onMapPositionKnown={() => mapPositionKnown()}
             onMapPositionInvestigating={() => setIsMapPositionInvestigating(true)}
             onLocationClick={(location) => locationClicked(location)}
+            onViewModeSwitchKnown={visible => setViewModeSwitchVisible(visible)}
         />
     </div>
 }

--- a/packages/map-template/src/components/MapWrapper/MapWrapper.jsx
+++ b/packages/map-template/src/components/MapWrapper/MapWrapper.jsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useRecoilState, useRecoilValue } from 'recoil';
 import MIMap from '@mapsindoors/react-components/src/components/MIMap/MIMap';
 import { mapTypes } from "../../constants/mapTypes";
@@ -36,9 +36,10 @@ let _tileStyle;
  * @param {function} props.onMapPositionKnown - Function that is run when the map bounds was changed due to fitting to a Venue or Location.
  * @param {boolean} props.useMapProviderModule - If you want to use the Map Provider set on your solution in the MapsIndoors CMS, set this to true.
  * @param {function} onMapPositionInvestigating - Function that is run when the map position is being determined.
+ * @param {function} onViewModeSwitchKnown - Function that is run when the view mode switch is known (if it is to be shown of not).
  * @returns
  */
-function MapWrapper({ onLocationClick, onMapPositionKnown, useMapProviderModule, onMapPositionInvestigating }) {
+function MapWrapper({ onLocationClick, onMapPositionKnown, useMapProviderModule, onMapPositionInvestigating, onViewModeSwitchKnown }) {
     const apiKey = useRecoilValue(apiKeyState);
     const gmApiKey = useRecoilValue(gmApiKeyState);
     const mapboxAccessToken = useRecoilValue(mapboxAccessTokenState);
@@ -206,7 +207,7 @@ function MapWrapper({ onLocationClick, onMapPositionKnown, useMapProviderModule,
      * @param {object} miInstance
      * @param {object} positionControl
      */
-    const onInitialized = (miInstance, positionControl) => {
+    const onInitialized = (miInstance, positionControl, viewModeSwitchVisible) => {
         // Detect when the mouse hovers over a location and store the hovered location
         // If the location is non-selectable, remove the hovering by calling the unhoverLocation() method.
         miInstance.on('mouseenter', () => {
@@ -260,6 +261,8 @@ function MapWrapper({ onLocationClick, onMapPositionKnown, useMapProviderModule,
             });
         }
         setPositionControl(positionControl);
+
+        onViewModeSwitchKnown(viewModeSwitchVisible);
     }
 
     /*

--- a/packages/map-template/src/components/MapWrapper/MapWrapper.jsx
+++ b/packages/map-template/src/components/MapWrapper/MapWrapper.jsx
@@ -37,9 +37,10 @@ let _tileStyle;
  * @param {boolean} props.useMapProviderModule - If you want to use the Map Provider set on your solution in the MapsIndoors CMS, set this to true.
  * @param {function} onMapPositionInvestigating - Function that is run when the map position is being determined.
  * @param {function} onViewModeSwitchKnown - Function that is run when the view mode switch is known (if it is to be shown of not).
+ * @param {number} resetCount - A counter that is incremented when the map should be reset.
  * @returns
  */
-function MapWrapper({ onLocationClick, onMapPositionKnown, useMapProviderModule, onMapPositionInvestigating, onViewModeSwitchKnown }) {
+function MapWrapper({ onLocationClick, onMapPositionKnown, useMapProviderModule, onMapPositionInvestigating, onViewModeSwitchKnown, resetCount }) {
     const apiKey = useRecoilValue(apiKeyState);
     const gmApiKey = useRecoilValue(gmApiKeyState);
     const mapboxAccessToken = useRecoilValue(mapboxAccessTokenState);
@@ -279,6 +280,7 @@ function MapWrapper({ onLocationClick, onMapPositionKnown, useMapProviderModule,
             mapboxAccessToken={mapType === mapTypes.Mapbox ? mapboxAccessToken : undefined}
             gmApiKey={mapType === mapTypes.Google ? gmApiKey : undefined}
             onInitialized={onInitialized}
+            resetUICounter={resetCount}
         />}
     </>)
 };

--- a/packages/map-template/src/components/MapWrapper/MapWrapper.jsx
+++ b/packages/map-template/src/components/MapWrapper/MapWrapper.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useRecoilState, useRecoilValue } from 'recoil';
 import MIMap from '@mapsindoors/react-components/src/components/MIMap/MIMap';
 import { mapTypes } from "../../constants/mapTypes";

--- a/packages/map-template/src/hooks/useMapBoundsDeterminer.js
+++ b/packages/map-template/src/hooks/useMapBoundsDeterminer.js
@@ -201,7 +201,7 @@ function mapboxGotoBBox(bbox, mapsIndoorsInstance, paddingBottom, paddingLeft, z
     // need to be able to use pitch and bearing in one go,
     // and we want to turn of panning animation.
     mapboxMap.fitBounds(bbox, {
-        pitch: pitch || mapboxMap.getPitch() || 0,
+        pitch: pitch || 0,
         bearing: bearing || 0,
         animate: false,
         padding: { top: 0, right: 0, bottom: paddingBottom, left: paddingLeft }

--- a/packages/react-components/src/components/MIMap/MIMap.jsx
+++ b/packages/react-components/src/components/MIMap/MIMap.jsx
@@ -19,7 +19,7 @@ MIMap.propTypes = {
     bounds: PropTypes.object,
     bearing: PropTypes.number,
     pitch: PropTypes.number,
-    resetViewMode: PropTypes.bool,
+    resetUICounter: PropTypes.number,
     mapOptions: PropTypes.object,
     onInitialized: PropTypes.func
 }
@@ -34,13 +34,13 @@ MIMap.propTypes = {
  * @param {object} [props.bounds] - Map bounds. Will win over center+zoom if set. Use the format { south: number, west: number, north: number, east: number }
  * @param {number} [props.bearing] - The bearing of the map (rotation from north) as a number. Not recommended for Google Maps with 2D Models.
  * @param {number} [props.pitch] - The pitch of the map as a number. Not recommended for Google Maps with 2D Models.
- * @param {string} [props.resetViewMode] - For Mapbox only: Reset the view mode to 3D when set to true.
+ * @param {number} [props.resetUICounter] - Re-render prop. Change value in order (for Mapbox only) to reset the view mode to 3D.
  * @param {Object} [props.mapOptions] - Options for instantiating and styling the map. In addition to map specific options, it can also contain a brandingColor prop (hex string) and a fitBoundsPadding object ({top: number, right: number, bottom: number, left: number }).
  * @param {function} [props.onInitialized] - Callback for when the MapsIndoors instance (https://app.mapsindoors.com/mapsindoors/js/sdk/latest/docs/mapsindoors.MapsIndoors.html)
  *    and position control and knowledge of the View mode switch is ready. The instance, position control and boolean for if the view mode switch is active is given as payload.
  * @returns
  */
-function MIMap({ apiKey, gmApiKey, mapboxAccessToken, center, zoom, bounds, bearing, pitch, resetViewMode, mapOptions, onInitialized }) {
+function MIMap({ apiKey, gmApiKey, mapboxAccessToken, center, zoom, bounds, bearing, pitch, resetUICounter, mapOptions, onInitialized }) {
 
     const [mapType, setMapType] = useState();
     const [mapsIndoorsInstance, setMapsIndoorsInstance] = useState();
@@ -128,7 +128,7 @@ function MIMap({ apiKey, gmApiKey, mapboxAccessToken, center, zoom, bounds, bear
 
     return <>
         {mapType === mapTypes.Google && <GoogleMapsMap mapsIndoorsInstance={mapsIndoorsInstance} apiKey={gmApiKey} onInitialized={onMapViewInitialized} onPositionControl={setPositionControl} center={center} zoom={zoom} mapOptions={mapOptions} heading={bearing} tilt={pitch} bounds={bounds} />}
-        {mapType === mapTypes.Mapbox && <MapboxMap mapsIndoorsInstance={mapsIndoorsInstance} accessToken={mapboxAccessToken} onInitialized={onMapViewInitialized} onPositionControl={setPositionControl} center={center} zoom={zoom} mapOptions={mapOptions} bearing={bearing} pitch={pitch} bounds={bounds} resetViewMode={resetViewMode} viewModeSwitchVisible={viewModeSwitchVisible} />}
+        {mapType === mapTypes.Mapbox && <MapboxMap mapsIndoorsInstance={mapsIndoorsInstance} accessToken={mapboxAccessToken} onInitialized={onMapViewInitialized} onPositionControl={setPositionControl} center={center} zoom={zoom} mapOptions={mapOptions} bearing={bearing} pitch={pitch} bounds={bounds} resetViewMode={resetUICounter} viewModeSwitchVisible={viewModeSwitchVisible} />}
     </>
 }
 

--- a/packages/react-components/src/components/MIMap/MIMap.jsx
+++ b/packages/react-components/src/components/MIMap/MIMap.jsx
@@ -36,7 +36,8 @@ MIMap.propTypes = {
  * @param {number} [props.pitch] - The pitch of the map as a number. Not recommended for Google Maps with 2D Models.
  * @param {string} [props.resetViewMode] - For Mapbox only: Reset the view mode to 3D when set to true.
  * @param {Object} [props.mapOptions] - Options for instantiating and styling the map. In addition to map specific options, it can also contain a brandingColor prop (hex string) and a fitBoundsPadding object ({top: number, right: number, bottom: number, left: number }).
- * @param {function} [props.onInitialized] - Callback for when the MapsIndoors instance (https://app.mapsindoors.com/mapsindoors/js/sdk/latest/docs/mapsindoors.MapsIndoors.html) and position control is ready. The instance and position control is given as payload.
+ * @param {function} [props.onInitialized] - Callback for when the MapsIndoors instance (https://app.mapsindoors.com/mapsindoors/js/sdk/latest/docs/mapsindoors.MapsIndoors.html)
+ *    and position control and knowledge of the View mode switch is ready. The instance, position control and boolean for if the view mode switch is active is given as payload.
  * @returns
  */
 function MIMap({ apiKey, gmApiKey, mapboxAccessToken, center, zoom, bounds, bearing, pitch, resetViewMode, mapOptions, onInitialized }) {
@@ -44,6 +45,7 @@ function MIMap({ apiKey, gmApiKey, mapboxAccessToken, center, zoom, bounds, bear
     const [mapType, setMapType] = useState();
     const [mapsIndoorsInstance, setMapsIndoorsInstance] = useState();
     const [positionControl, setPositionControl] = useState();
+    const [viewModeSwitchVisible, setViewModeSwitchVisible] = useState();
     const [solution, setSolution] = useState();
 
     useEffect(() => {
@@ -94,10 +96,24 @@ function MIMap({ apiKey, gmApiKey, mapboxAccessToken, center, zoom, bounds, bear
      * Execute the onInitialized callback when both the MapsIndoors instance and the position control is ready.
      */
     useEffect(() => {
-        if (typeof onInitialized === 'function' && mapsIndoorsInstance && positionControl) {
-            onInitialized(mapsIndoorsInstance, positionControl);
+        if (typeof onInitialized === 'function' && mapsIndoorsInstance && positionControl && typeof viewModeSwitchVisible === 'boolean') {
+            onInitialized(mapsIndoorsInstance, positionControl, viewModeSwitchVisible);
         }
-    }, [mapsIndoorsInstance, positionControl]);
+    }, [mapsIndoorsInstance, positionControl, viewModeSwitchVisible]);
+
+    /*
+     * For Mapbox maps, determine if the View Mode switch should be shown based on the Solution.
+     */
+    useEffect(() => {
+        if (!solution) return;
+
+        // If the required modules are enabled, show the Visibility Switch and set the View Mode
+        if (mapType === mapTypes.Mapbox && ['mapbox', '3dwalls', 'floorplan'].every(requiredModule => solution.modules.map(module => module.toLowerCase()).includes(requiredModule))) {
+            setViewModeSwitchVisible(true);
+        } else {
+            setViewModeSwitchVisible(false);
+        }
+    }, [solution, mapType]);
 
     /*
      * Determine map type based on the given map provider tokens.
@@ -112,7 +128,7 @@ function MIMap({ apiKey, gmApiKey, mapboxAccessToken, center, zoom, bounds, bear
 
     return <>
         {mapType === mapTypes.Google && <GoogleMapsMap mapsIndoorsInstance={mapsIndoorsInstance} apiKey={gmApiKey} onInitialized={onMapViewInitialized} onPositionControl={setPositionControl} center={center} zoom={zoom} mapOptions={mapOptions} heading={bearing} tilt={pitch} bounds={bounds} />}
-        {mapType === mapTypes.Mapbox && <MapboxMap mapsIndoorsInstance={mapsIndoorsInstance} accessToken={mapboxAccessToken} onInitialized={onMapViewInitialized} onPositionControl={setPositionControl} center={center} zoom={zoom} mapOptions={mapOptions} bearing={bearing} pitch={pitch} bounds={bounds} solution={solution} resetViewMode={resetViewMode} />}
+        {mapType === mapTypes.Mapbox && <MapboxMap mapsIndoorsInstance={mapsIndoorsInstance} accessToken={mapboxAccessToken} onInitialized={onMapViewInitialized} onPositionControl={setPositionControl} center={center} zoom={zoom} mapOptions={mapOptions} bearing={bearing} pitch={pitch} bounds={bounds} resetViewMode={resetViewMode} viewModeSwitchVisible={viewModeSwitchVisible} />}
     </>
 }
 

--- a/packages/react-components/src/components/MIMap/MapboxMap/MapboxMap.jsx
+++ b/packages/react-components/src/components/MIMap/MapboxMap/MapboxMap.jsx
@@ -16,7 +16,7 @@ MapboxMap.propTypes = {
     bounds: PropTypes.object,
     bearing: PropTypes.number,
     pitch: PropTypes.number,
-    resetViewMode: PropTypes.bool,
+    resetViewMode: PropTypes.number,
     mapsIndoorsInstance: PropTypes.object,
     viewModeSwitchVisible: PropTypes.bool,
     mapOptions: PropTypes.object
@@ -32,7 +32,7 @@ MapboxMap.propTypes = {
  * @param {object} [props.bounds] - Map bounds. Will win over center+zoom if set. Use the format { south: number, west: number, north: number, east: number }
  * @param {number} [props.bearing] - The bearing of the map (rotation from north) as a number.
  * @param {number} [props.pitch] - The pitch of the map as a number.
- * @param {boolean} [props.resetViewMode] - Set to true to reset the view mode to initial 3D mode.
+ * @param {number} [props.resetViewMode] - Increase number to reset the view mode to initial 3D mode.
  * @param {Object} [props.mapsIndoorsInstance] - Instance of MapsIndoors class: https://app.mapsindoors.com/mapsindoors/js/sdk/latest/docs/mapsindoors.MapsIndoors.html
  * @param {Object} [props.viewModeSwitchVisible] - Set to true to show the view mode switch.
  * @param {Object} [props.mapOptions] - Options for instantiating and styling the map as well as UI elements.

--- a/packages/react-components/src/components/MIMap/MapboxMap/MapboxMap.jsx
+++ b/packages/react-components/src/components/MIMap/MapboxMap/MapboxMap.jsx
@@ -18,7 +18,7 @@ MapboxMap.propTypes = {
     pitch: PropTypes.number,
     resetViewMode: PropTypes.bool,
     mapsIndoorsInstance: PropTypes.object,
-    solution: PropTypes.object,
+    viewModeSwitchVisible: PropTypes.bool,
     mapOptions: PropTypes.object
 }
 
@@ -34,10 +34,10 @@ MapboxMap.propTypes = {
  * @param {number} [props.pitch] - The pitch of the map as a number.
  * @param {boolean} [props.resetViewMode] - Set to true to reset the view mode to initial 3D mode.
  * @param {Object} [props.mapsIndoorsInstance] - Instance of MapsIndoors class: https://app.mapsindoors.com/mapsindoors/js/sdk/latest/docs/mapsindoors.MapsIndoors.html
- * @param {Object} [props.solution] - The Solution data corresponding to the API key.
+ * @param {Object} [props.viewModeSwitchVisible] - Set to true to show the view mode switch.
  * @param {Object} [props.mapOptions] - Options for instantiating and styling the map as well as UI elements.
  */
-function MapboxMap({ accessToken, onInitialized, onPositionControl, center, zoom, bounds, bearing, pitch, resetViewMode, mapsIndoorsInstance, solution, mapOptions }) {
+function MapboxMap({ accessToken, onInitialized, onPositionControl, center, zoom, bounds, bearing, pitch, resetViewMode, mapsIndoorsInstance, viewModeSwitchVisible, mapOptions }) {
 
     const [mapViewInstance, setMapViewInstance] = useState();
     const [hasFloorSelector, setHasFloorSelector] = useState(false);
@@ -142,7 +142,7 @@ function MapboxMap({ accessToken, onInitialized, onPositionControl, center, zoom
     }, []);
 
     return <div className="mapsindoors-map mapbox-map-container" id="map">
-        <ViewModeSwitch reset={resetViewMode} mapView={mapViewInstance} pitch={pitch} activeColor={mapOptions?.brandingColor} solution={solution} />
+        {viewModeSwitchVisible && <ViewModeSwitch reset={resetViewMode} mapView={mapViewInstance} pitch={pitch} activeColor={mapOptions?.brandingColor} />}
     </div>
 }
 

--- a/packages/react-components/src/components/MIMap/MapboxMap/ViewModeSwitch/ViewModeSwitch.jsx
+++ b/packages/react-components/src/components/MIMap/MapboxMap/ViewModeSwitch/ViewModeSwitch.jsx
@@ -17,7 +17,7 @@ ViewModeSwitch.propTypes = {
     mapView: PropTypes.object,
     pitch: PropTypes.number,
     solution: PropTypes.object,
-    reset: PropTypes.bool,
+    reset: PropTypes.number,
     activeColor: PropTypes.string
 }
 
@@ -27,7 +27,7 @@ ViewModeSwitch.propTypes = {
  * @param {Object} [props.mapView] - Instance of a MapsIndoors MapView
  * @param {number} [props.pitch] - The value of the pitch property on the map (not necessarily the current map pitch)
  * @param {Object} [props.solution] - The current MapsIndoors solution
- * @param {boolean} [props.reset] - Set to true to reset to initial 3D mode
+ * @param {number} [props.reset] - Set/increase the number reset to initial 3D mode
  * @param {string} [props.activeColor='#005655'] - The color to use to mark the active view mode
  */
 function ViewModeSwitch({ mapView, pitch, reset, activeColor='#005655' }) {

--- a/packages/react-components/src/components/MIMap/MapboxMap/ViewModeSwitch/ViewModeSwitch.jsx
+++ b/packages/react-components/src/components/MIMap/MapboxMap/ViewModeSwitch/ViewModeSwitch.jsx
@@ -30,20 +30,9 @@ ViewModeSwitch.propTypes = {
  * @param {boolean} [props.reset] - Set to true to reset to initial 3D mode
  * @param {string} [props.activeColor='#005655'] - The color to use to mark the active view mode
  */
-function ViewModeSwitch({ mapView, pitch, solution, reset, activeColor='#005655' }) {
+function ViewModeSwitch({ mapView, pitch, reset, activeColor='#005655' }) {
 
-    const [visible, setVisible] = useState(false);
-    const [viewMode, setViewMode] = useState();
-
-    useEffect(() => {
-        if (!solution) return;
-
-        // If the required modules are enabled, show the Visibility Switch and set the View Mode
-        if (['mapbox', '3dwalls', 'floorplan'].every(requiredModule => solution.modules.map(module => module.toLowerCase()).includes(requiredModule))) {
-            setVisible(true);
-            setViewMode(ViewModes.initial3D);
-        }
-    }, [solution]);
+    const [viewMode, setViewMode] = useState(ViewModes.initial3D);
 
     useEffect(() => {
         if (reset) {
@@ -52,7 +41,7 @@ function ViewModeSwitch({ mapView, pitch, solution, reset, activeColor='#005655'
     }, [reset]);
 
     useEffect(() => {
-        if (visible === true && mapView) {
+        if (mapView) {
             switch (viewMode) {
                 // If the 2D View Mode has been clicked, hide the 3D features and tilt the map to 0 degrees.
                 case ViewModes.clicked2D:
@@ -77,24 +66,22 @@ function ViewModeSwitch({ mapView, pitch, solution, reset, activeColor='#005655'
                     // Intentionally left blank
             }
         }
-    }, [viewMode, mapView, visible]);
+    }, [viewMode, mapView]);
 
-    return <>
-        {visible && <div className="view-mode-switch">
-            <button className="view-mode-switch__button"
-                onClick={() => setViewMode(ViewModes.clicked2D)}
-                style={{ backgroundColor: viewMode === ViewModes.clicked2D ? activeColor : 'white' }}
-            >
-                {viewMode === ViewModes.clicked2D ? <Light2D /> : <Dark2D />}
-            </button>
-            <button className="view-mode-switch__button"
-                onClick={() => setViewMode(ViewModes.clicked3D)}
-                style={{ backgroundColor: [ViewModes.initial3D, ViewModes.clicked3D].includes(viewMode) ? activeColor : 'white' }}
-            >
-                {[ViewModes.initial3D, ViewModes.clicked3D].includes(viewMode) ? <Light3D /> : <Dark3D />}
-            </button>
-        </div>}
-    </>
+    return <div className="view-mode-switch">
+        <button className="view-mode-switch__button"
+            onClick={() => setViewMode(ViewModes.clicked2D)}
+            style={{ backgroundColor: viewMode === ViewModes.clicked2D ? activeColor : 'white' }}
+        >
+            {viewMode === ViewModes.clicked2D ? <Light2D /> : <Dark2D />}
+        </button>
+        <button className="view-mode-switch__button"
+            onClick={() => setViewMode(ViewModes.clicked3D)}
+            style={{ backgroundColor: [ViewModes.initial3D, ViewModes.clicked3D].includes(viewMode) ? activeColor : 'white' }}
+        >
+            {[ViewModes.initial3D, ViewModes.clicked3D].includes(viewMode) ? <Light3D /> : <Dark3D />}
+        </button>
+    </div>
 }
 
 export default ViewModeSwitch;


### PR DESCRIPTION
Make pitch/tilt work properly when resetting (ie. when using the timeout prop). This is reverting an earlier (wrong) decision to include the current pitch when fitting bounds.

However, it causes the same logic (which modules need to be enabled in order to show the viewmode switch) to appear in both the react-components package and now also the map-template package. Any ideas to mitigate this @andreeaceachir142 ?