### PR TITLE
Map as standalone component: Fix timing issue in ViewModeSwitch

### DIFF
--- a/packages/react-components/src/components/MIMap/MapboxMap/ViewModeSwitch/ViewModeSwitch.jsx
+++ b/packages/react-components/src/components/MIMap/MapboxMap/ViewModeSwitch/ViewModeSwitch.jsx
@@ -42,29 +42,42 @@ function ViewModeSwitch({ mapView, pitch, reset, activeColor='#005655' }) {
 
     useEffect(() => {
         if (mapView) {
-            switch (viewMode) {
-                // If the 2D View Mode has been clicked, hide the 3D features and tilt the map to 0 degrees.
-                case ViewModes.clicked2D:
-                    mapView.tilt(0, 2000);
-                    mapView.hideFeatures([mapView.FeatureType.MODEL3D, mapView.FeatureType.WALLS3D, mapView.FeatureType.EXTRUSION3D, mapView.FeatureType.EXTRUDEDBUILDINGS]);
-                    break;
+            // Make sure the map is ready before applying view mode changes. This is to mitigate a timing issue with the hideFeatures method on the SDK.
+            const mapViewReady = new Promise((resolve) => {
+                if (mapView.isReady) {
+                    resolve();
+                } else {
+                    mapView.on('ready', () => {
+                        resolve();
+                    });
+                }
+            });
 
-                // If the Visibility Switch has not been interacted with, hide the 2D features
-                // Tilt the map to the 'currentPitch' value - this is the value that the timeout property resets to.
-                case ViewModes.initial3D:
-                    mapView.tilt(!isNullOrUndefined(pitch) ? pitch : 45, 2000);
-                    mapView.hideFeatures([mapView.FeatureType.MODEL2D, mapView.FeatureType.WALLS2D]);
-                    break;
+            mapViewReady.then(() => {
+                switch (viewMode) {
+                    // If the 2D View Mode has been clicked, hide the 3D features and tilt the map to 0 degrees.
+                    case ViewModes.clicked2D:
+                        mapView.tilt(0, 2000);
+                        mapView.hideFeatures([mapView.FeatureType.MODEL3D, mapView.FeatureType.WALLS3D, mapView.FeatureType.EXTRUSION3D, mapView.FeatureType.EXTRUDEDBUILDINGS]);
+                        break;
 
-                // If the 3D View Mode has been clicked, hide the 2D features and tilt the map to 45 degrees.
-                case ViewModes.clicked3D:
-                    mapView.tilt(45, 2000);
-                    mapView.hideFeatures([mapView.FeatureType.MODEL2D, mapView.FeatureType.WALLS2D]);
-                    break;
+                    // If the Visibility Switch has not been interacted with, hide the 2D features
+                    // Tilt the map to the 'currentPitch' value - this is the value that the timeout property resets to.
+                    case ViewModes.initial3D:
+                        mapView.tilt(!isNullOrUndefined(pitch) ? pitch : 45, 2000);
+                        mapView.hideFeatures([mapView.FeatureType.MODEL2D, mapView.FeatureType.WALLS2D]);
+                        break;
 
-                default:
-                    // Intentionally left blank
-            }
+                    // If the 3D View Mode has been clicked, hide the 2D features and tilt the map to 45 degrees.
+                    case ViewModes.clicked3D:
+                        mapView.tilt(45, 2000);
+                        mapView.hideFeatures([mapView.FeatureType.MODEL2D, mapView.FeatureType.WALLS2D]);
+                        break;
+
+                    default:
+                        // Intentionally left blank
+                }
+            });
         }
     }, [viewMode, mapView]);
 


### PR DESCRIPTION
fix: wrap the view mode handling in a promise to make sure the MapView is ready. Because if it is not, the calls to hideFeatures will not work (current SDK bug).