### PR TITLE
Map as a standalone component: make sure a venue is set

### DIFF
--- a/packages/react-components/src/components/MIMap/MIMap.jsx
+++ b/packages/react-components/src/components/MIMap/MIMap.jsx
@@ -76,6 +76,15 @@ function MIMap({ apiKey, gmApiKey, mapboxAccessToken, center, zoom, bounds, bear
             mapView
         });
 
+        // Set the venue based on the first building change if the current venue is different than the given building.
+        // This is a workaround for the SDK not setting the venue automatically, thus not loading 2D geometry.
+        mi.once('building_changed', (building) => {
+            const venue = mi.getVenue();
+            if (building && venue && building.venueId !== venue.id ) {
+                mi.setVenue(building.venueId);
+            }
+        });
+
         // Detect when the mouse hovers over a location and store the hovered location
         // If the location is non-selectable, remove the hovering by calling the unhoverLocation() method.
         mi.on('mouseenter', () => {


### PR DESCRIPTION
Fix: make sure a venue will always be selected in order to ensure that 2D geometry is always loaded.

This offloads the burden of having the consumer of the component needing to do this (setting a venue).