### PR TITLE
fix: casing issue for case sensitive file systems

### DIFF
--- a/packages/react-components/src/components/MIMap/MapboxMap/MapboxMap.jsx
+++ b/packages/react-components/src/components/MIMap/MapboxMap/MapboxMap.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import mapboxgl from 'mapbox-gl';
 import 'mapbox-gl/dist/mapbox-gl.css';
 import './MapboxMap.scss';
-import ViewModeSwitch from './ViewmodeSwitch/ViewModeSwitch';
+import ViewModeSwitch from './ViewModeSwitch/ViewModeSwitch';
 import { useIsDesktop } from '../../../hooks/useIsDesktop';
 import isNullOrUndefined from '../../../../../map-template/src/helpers/isNullOrUndefined';
 


### PR DESCRIPTION
Not all file system are case insensitive. This means that on some systems, resolving the ViewModeSwitch component fails because of wrong letter casing.