### PR TITLE
Make google maps work again

### DIFF
--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.62.1] - 2024-12-10
+
+## Fixed
+
+- Fixed bug that would cause a Google Maps map to never show.
+
 ## [1.62.0] - 2024-12-10
 
 ### Added

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -97,7 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix bug whwre 2D geometry was not always shown.
+- Fix bug where 2D geometry was not always shown.
 
 ## [1.54.4] - 2024-08-14
 

--- a/packages/react-components/CHANGELOG.md
+++ b/packages/react-components/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0] - unreleased
+## [1.0.1] - 2024-12-10
+
+### Fixed
+
+- Issue where a Google Maps map would never declare itself initialized.
+
+## [1.0.0] - 2024-12-10
 
 ### Added
 

--- a/packages/react-components/src/components/MIMap/MIMap.jsx
+++ b/packages/react-components/src/components/MIMap/MIMap.jsx
@@ -115,10 +115,8 @@ function MIMap({ apiKey, gmApiKey, mapboxAccessToken, center, zoom, bounds, bear
      * For Mapbox maps, determine if the View Mode switch should be shown based on the Solution.
      */
     useEffect(() => {
-        if (!solution) return;
-
         // If the required modules are enabled, show the Visibility Switch and set the View Mode
-        if (mapType === mapTypes.Mapbox && ['mapbox', '3dwalls', 'floorplan'].every(requiredModule => solution.modules.map(module => module.toLowerCase()).includes(requiredModule))) {
+        if (solution && mapType === mapTypes.Mapbox && ['mapbox', '3dwalls', 'floorplan'].every(requiredModule => solution.modules.map(module => module.toLowerCase()).includes(requiredModule))) {
             setViewModeSwitchVisible(true);
         } else {
             setViewModeSwitchVisible(false);


### PR DESCRIPTION
Avoid early exit in case the solution is not set. The solution is only set when the map is a Mapbox map, and this caused the viewModeSwitchVisible not to be set for Google maps, causing the map never to declare itself initialized.
