### PR TITLE
Fix zooming when Map Bounds are not fitted

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22622,7 +22622,7 @@
     },
     "packages/components": {
       "name": "@mapsindoors/components",
-      "version": "13.24.1",
+      "version": "13.25.0",
       "license": "MIT",
       "dependencies": {
         "@11ty/eleventy": "^2.0.1",
@@ -22662,7 +22662,7 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.64.0",
+      "version": "1.65.2",
       "devDependencies": {
         "@googlemaps/js-api-loader": "^1.15.1",
         "@mapsindoors/components": "*",

--- a/packages/map-template/src/hooks/useMapBoundsDeterminer.js
+++ b/packages/map-template/src/hooks/useMapBoundsDeterminer.js
@@ -62,7 +62,7 @@ const useMapBoundsDeterminer = () => {
     /*
      * When relevant state changes, run code to go to a location in the world.
      */
-    useEffect(() =>  {
+    useEffect(() => {
         determineMapBounds();
     }, [mapsIndoorsInstance, currentVenueName, locationId, kioskOriginLocationId, pitch, bearing, startZoomLevel, categories]);
 
@@ -116,7 +116,7 @@ const useMapBoundsDeterminer = () => {
             } else if (currentVenue) {
                 // When showing a venue, the map is fitted to the bounds of the Venue with no padding.
                 setMapPositionKnown(currentVenue.geometry);
-                goTo(currentVenue.geometry, mapsIndoorsInstance, 0, 0, startZoomLevel, currentPitch, bearing);
+                goTo(currentVenue.geometry, mapsIndoorsInstance, 0, 0, startZoomLevel, currentPitch, bearing, mapPositionKnown);
             }
         }
     }
@@ -158,14 +158,14 @@ export default useMapBoundsDeterminer;
  * @param {number} pitch - Map pitch (tilt).
  * @param {number} bearing - Mp bearing (rotation) in degrees from north.
  */
-function goTo(geometry, mapsIndoorsInstance, paddingBottom, paddingLeft, zoomLevel, pitch, bearing) {
+function goTo(geometry, mapsIndoorsInstance, paddingBottom, paddingLeft, zoomLevel, pitch, bearing, mapPositionKnown) {
     mapsIndoorsInstance.getMapView().tilt(pitch || 0);
     mapsIndoorsInstance.getMapView().rotate(bearing || 0);
     mapsIndoorsInstance.goTo({ type: 'Feature', geometry, properties: {}}, {
         maxZoom: zoomLevel ?? 22,
         padding: { top: 0, right: 0, bottom: paddingBottom, left: paddingLeft },
     }).then(() => {
-        if (zoomLevel) {
+        if (zoomLevel && mapPositionKnown !== false) {
             mapsIndoorsInstance.setZoom(zoomLevel);
         }
     });


### PR DESCRIPTION
I found out that `mapPositionKnown` property has two values during its' lifetime: **false** - when the location is not known and **GeoJSON object** - when location is known. 

To fix it I passed `mapPositionKnown` as last param to `goTo()` function and I explicitly check if `mapPositionKnown` is not **false**. Then I perform zooming.

Working solution:

Uploading Screen Recording 2025-01-14 at 20.33.42.mov…

