### PR TITLE
feature: Implement App Config v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21485,7 +21485,7 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.66.5",
+      "version": "1.67.0",
       "devDependencies": {
         "@googlemaps/js-api-loader": "^1.15.1",
         "@mapsindoors/components": "*",

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -258,6 +258,7 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
     useEffect(() => {
         if (mapsindoorsSDKAvailable) {
             const languageToUse = appConfig?.appSettings?.language ? appConfig.appSettings.language : language ? language : navigator.language;
+            console.log(appConfig);
 
             // Set the language on the MapsIndoors SDK in order to get eg. Mapbox and Google directions in that language.
             // The MapsIndoors data only accepts the first part of the IETF language string, hence the split.
@@ -441,8 +442,14 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
      * React on changes in the primary color prop.
      */
     useEffect(() => {
-        setPrimaryColor(primaryColor);
-    }, [primaryColor]);
+
+        // TODO: App Config takes the priority. primaryColor is always defined, so in this case URL will NOT override app config value.
+        if (appConfig?.appSettings?.primaryColor) {
+            setPrimaryColor(appConfig?.appSettings?.primaryColor)
+        } else {
+            setPrimaryColor(primaryColor)
+        }
+    }, [primaryColor, appConfig]);
 
     /*
      * React on changes in the start zoom level prop.

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -257,8 +257,8 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
      */
     useEffect(() => {
         if (mapsindoorsSDKAvailable) {
-            const languageToUse = appConfig?.appSettings?.language ? appConfig.appSettings.language : language ? language : navigator.language;
-            console.log(appConfig);
+            // Sets language to use. Priority: URL/Query Param -> App Config -> browser's default language.
+            const languageToUse = language ? language : appConfig?.appSettings?.language ? appConfig.appSettings.language : navigator.language;
 
             // Set the language on the MapsIndoors SDK in order to get eg. Mapbox and Google directions in that language.
             // The MapsIndoors data only accepts the first part of the IETF language string, hence the split.
@@ -421,7 +421,7 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
     }, [currentAppView]);
 
     /*
-     * React on changes in the venue prop.
+     * React on changes in the venue prop. If not defined in the URL, check if it is defined in app config.
      */
     useEffect(() => {
         if (!isNullOrUndefined(venue)) {
@@ -439,7 +439,7 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
     }, [tileStyle]);
 
     /*
-     * React on changes in the primary color prop.
+     * React on changes in the primary color prop. If not defined in the URL, check if it is defined in app config. Otherwise set to default color.
      */
     useEffect(() => {
         const defaultPrimaryColor = '#005655';
@@ -455,7 +455,7 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
     }, [primaryColor, appConfig]);
 
     /*
-     * React on changes in the start zoom level prop.
+     * React on changes in the start zoom level prop. If not defined in the URL, check if it is defined in app config.
      */
     useEffect(() => {
         if (!isNullOrUndefined(startZoomLevel)) {
@@ -466,7 +466,7 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
     }, [startZoomLevel, appConfig]);
 
     /*
-     * React on changes in the pitch prop.
+     * React on changes in the pitch prop. If not defined in the URL, check if it is defined in app config.
      * If the pitch is not set, set it to 45 degrees if the view mode switch is visible.
      */
     useEffect(() => {
@@ -480,7 +480,7 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
     }, [pitch, viewModeSwitchVisible, appConfig]);
 
     /*
-     * React on changes in the bearing prop.
+     * React on changes in the bearing prop. If not defined in the URL, check if it is defined in app config.
      */
     useEffect(() => {
         if (!isNullOrUndefined(bearing)) {
@@ -491,7 +491,7 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
     }, [bearing, appConfig]);
 
     /*
-     * React on changes in the logo prop.
+     * React on changes in the logo prop. If not defined in the URL, check if it is defined in app config. Otherwise set to default logo.
      */
     useEffect(() => {
         const defaultLogo = 'https://app.mapsindoors.com/mapsindoors/gfx/mapspeople-logo/mapspeople-pin.svg';

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -480,9 +480,12 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
      * React on changes in the bearing prop.
      */
     useEffect(() => {
-        setBearing(bearing);
-    }, [bearing]);
-
+        if (!isNullOrUndefined(bearing)) {
+            setBearing(bearing)
+        } else {
+            setBearing(appConfig?.appSettings?.bearing)
+        }
+    }, [bearing, appConfig]);
     /*
      * React on changes in the logo prop.
      */

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -257,7 +257,7 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
      */
     useEffect(() => {
         if (mapsindoorsSDKAvailable) {
-            const languageToUse = language ? language : navigator.language;
+            const languageToUse = appConfig?.appSettings?.language ? appConfig.appSettings.language : language ? language : navigator.language;
 
             // Set the language on the MapsIndoors SDK in order to get eg. Mapbox and Google directions in that language.
             // The MapsIndoors data only accepts the first part of the IETF language string, hence the split.
@@ -295,7 +295,7 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
 
             setCurrentLanguage(languageToUse);
         }
-    }, [language, mapsindoorsSDKAvailable]);
+    }, [language, mapsindoorsSDKAvailable, appConfig]);
 
     /**
      * React on changes in the MapsIndoors API key by fetching the required data.

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -442,8 +442,6 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
      * React on changes in the primary color prop.
      */
     useEffect(() => {
-
-        // TODO: App Config takes the priority. primaryColor is always defined, so in this case URL will NOT override app config value.
         if (appConfig?.appSettings?.primaryColor) {
             setPrimaryColor(appConfig?.appSettings?.primaryColor)
         } else {
@@ -490,9 +488,7 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
      * React on changes in the logo prop.
      */
     useEffect(() => {
-
-        // TODO: App Config takes the priority. logo is always defined, so in this case URL will NOT override app config value.
-        if (appConfig?.appSettings?.logo) {
+        if (appConfig?.appSettings?.logo && logo) {
             setLogo(appConfig?.appSettings?.logo)
         } else {
             setLogo(logo)

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -423,8 +423,12 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
      * React on changes in the venue prop.
      */
     useEffect(() => {
-        setCurrentVenueName(venue);
-    }, [venue]);
+        if (!isNullOrUndefined(venue)) {
+            setCurrentVenueName(venue)
+        } else {
+            setCurrentVenueName(appConfig?.appSettings?.venue)
+        }
+    }, [venue, appConfig]);
 
     /*
      * React on changes in the tile style prop.

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -455,8 +455,12 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
      * React on changes in the start zoom level prop.
      */
     useEffect(() => {
-        setStartZoomLevel(startZoomLevel);
-    }, [startZoomLevel]);
+        if (!isNullOrUndefined(startZoomLevel)) {
+            setStartZoomLevel(startZoomLevel)
+        } else {
+            setStartZoomLevel(appConfig?.appSettings?.startZoomLevel)
+        }
+    }, [startZoomLevel, appConfig]);
 
     /*
      * React on changes in the pitch prop.

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -490,8 +490,12 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
      * React on changes in the logo prop.
      */
     useEffect(() => {
-        setLogo(logo);
-    }, [logo]);
+        if (!isNullOrUndefined(logo)) {
+            setLogo(logo)
+        } else {
+            setLogo(appConfig?.appSettings?.logo)
+        }
+    }, [logo, appConfig]);
 
     /*
      * React on changes in the miTransitionLevel prop.

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -490,10 +490,12 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
      * React on changes in the logo prop.
      */
     useEffect(() => {
-        if (!isNullOrUndefined(logo)) {
-            setLogo(logo)
-        } else {
+
+        // TODO: App Config takes the priority. logo is always defined, so in this case URL will NOT override app config value.
+        if (appConfig?.appSettings?.logo) {
             setLogo(appConfig?.appSettings?.logo)
+        } else {
+            setLogo(logo)
         }
     }, [logo, appConfig]);
 

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -469,10 +469,12 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
     useEffect(() => {
         if (!isNullOrUndefined(pitch)) {
             setPitch(pitch);
-        } else if (viewModeSwitchVisible) {
+        } else if (appConfig?.appSettings?.pitch) {
+            setPitch(appConfig?.appSettings?.pitch)
+        } else {
             setPitch(45);
         }
-    }, [pitch, viewModeSwitchVisible]);
+    }, [pitch, viewModeSwitchVisible, appConfig]);
 
     /*
      * React on changes in the bearing prop.

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -442,10 +442,15 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
      * React on changes in the primary color prop.
      */
     useEffect(() => {
-        if (appConfig?.appSettings?.primaryColor) {
+        const defaultPrimaryColor = '#005655';
+
+        // Sets primary color. Priority: URL/Query Param -> App Config -> Default.
+        if (!isNullOrUndefined(primaryColor)) {
+            setPrimaryColor(primaryColor)
+        } else if (!isNullOrUndefined(appConfig?.appSettings?.primaryColor)) {
             setPrimaryColor(appConfig?.appSettings?.primaryColor)
         } else {
-            setPrimaryColor(primaryColor)
+            setPrimaryColor(defaultPrimaryColor);
         }
     }, [primaryColor, appConfig]);
 
@@ -484,14 +489,20 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
             setBearing(appConfig?.appSettings?.bearing)
         }
     }, [bearing, appConfig]);
+
     /*
      * React on changes in the logo prop.
      */
     useEffect(() => {
-        if (appConfig?.appSettings?.logo && logo) {
+        const defaultLogo = 'https://app.mapsindoors.com/mapsindoors/gfx/mapspeople-logo/mapspeople-pin.svg';
+
+        // Sets logo. Priority: URL/Query Param -> App Config -> Default.
+        if (!isNullOrUndefined(logo)) {
+            setLogo(logo)
+        } else if (appConfig?.appSettings?.logo) {
             setLogo(appConfig?.appSettings?.logo)
         } else {
-            setLogo(logo)
+            setLogo(defaultLogo);
         }
     }, [logo, appConfig]);
 

--- a/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
+++ b/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
@@ -88,8 +88,6 @@ function MapsIndoorsMap(props) {
 
         const defaultProps = {
             apiKey: 'mapspeople3d',
-            logo: 'https://app.mapsindoors.com/mapsindoors/gfx/mapspeople-logo/mapspeople-pin.svg',
-            primaryColor: '#005655', // --brand-colors-dark-pine-100 from MIDT
             useMapProviderModule: false,
             useKeyboard: false,
             searchAllVenues: false,
@@ -143,7 +141,7 @@ function MapsIndoorsMap(props) {
             apiKey,
             venue,
             locationId: props.supportsUrlParameters && locationIdQueryParameter ? locationIdQueryParameter : props.locationId,
-            logo: props.supportsUrlParameters && logoQueryParameter ? logoQueryParameter : (props.logo || defaultProps.logo),
+            logo: props.supportsUrlParameters && logoQueryParameter ? logoQueryParameter : (props.logo),
             directionsFrom: props.supportsUrlParameters && directionsFromQueryParameter ? directionsFromQueryParameter : props.directionsFrom,
             directionsTo: props.supportsUrlParameters && directionsToQueryParameter ? directionsToQueryParameter : props.directionsTo,
             tileStyle: props.supportsUrlParameters && tileStyleQueryParameter ? tileStyleQueryParameter : props.tileStyle,
@@ -152,7 +150,7 @@ function MapsIndoorsMap(props) {
             bearing: props.supportsUrlParameters && bearingQueryParameter ? bearingQueryParameter : props.bearing,
             gmApiKey: props.supportsUrlParameters && gmApiKeyQueryParameter ? gmApiKeyQueryParameter : props.gmApiKey,
             mapboxAccessToken: props.supportsUrlParameters && mapboxAccessTokenQueryParameter ? mapboxAccessTokenQueryParameter : props.mapboxAccessToken,
-            primaryColor: props.supportsUrlParameters && primaryColorQueryParameter ? '#' + primaryColorQueryParameter : (props.primaryColor || defaultProps.primaryColor),
+            primaryColor: props.supportsUrlParameters && primaryColorQueryParameter ? '#' + primaryColorQueryParameter : (props.primaryColor),
             appUserRoles: props.supportsUrlParameters && appUserRolesQueryParameter ? appUserRolesQueryParameter : props.appUserRoles,
             externalIDs: props.supportsUrlParameters && externalIDsQueryParameter ? externalIDsQueryParameter : props.externalIDs,
             gmMapId: props.supportsUrlParameters && gmMapIdQueryParameter ? gmMapIdQueryParameter : props.gmMapId,


### PR DESCRIPTION
This merge request skips logic to deal with mapboxAccessToken or gmKey.

It should cover: `language`, `primaryColor`, `logo`, `venue`, `startZoomLevel`, `pitch` and `bearing` props.