### PR TITLE
Fix: goTo() function refactoring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21485,7 +21485,7 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.66.5",
+      "version": "1.67.0",
       "devDependencies": {
         "@googlemaps/js-api-loader": "^1.15.1",
         "@mapsindoors/components": "*",

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,13 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.68.0] - 2024-02-03
+## [1.68.1] - 2025-02-11
+
+## Fixed
+
+- An issue when on initial load map would stop in a random position.
+
+## [1.68.0] - 2025-02-03
 
 ## Added
 
 - Added display of 2D models in 3D mode based on app config property
 
-## [1.67.0] - 2024-01-30
+## [1.67.0] - 2025-01-30
 
 ### Added
 

--- a/packages/map-template/src/hooks/useMapBoundsDeterminer.js
+++ b/packages/map-template/src/hooks/useMapBoundsDeterminer.js
@@ -282,10 +282,10 @@ function goTo(geometry, mapsIndoorsInstance, paddingBottom, paddingLeft, zoomLev
             padding: { top: 0, right: 0, bottom: paddingBottom, left: paddingLeft },
         })
     } else {
-        const centerOfBoundingBox = turf.center(geometry);
+        const centerOfGeometry = turf.center(geometry);
         const mapView = mapsIndoorsInstance.getMapView();
 
-        mapView.setCenter({ lat: centerOfBoundingBox.geometry.coordinates[1], lng: centerOfBoundingBox.geometry.coordinates[0]} )
+        mapView.setCenter({ lat: centerOfGeometry.geometry.coordinates[1], lng: centerOfGeometry.geometry.coordinates[0]} )
         mapsIndoorsInstance.setZoom(zoomLevel);
     }
 }

--- a/packages/map-template/src/hooks/useMapBoundsDeterminer.js
+++ b/packages/map-template/src/hooks/useMapBoundsDeterminer.js
@@ -270,11 +270,11 @@ export default useMapBoundsDeterminer;
  * @param {number} bearing - Mp bearing (rotation) in degrees from north.
  */
 function goTo(geometry, mapsIndoorsInstance, paddingBottom, paddingLeft, zoomLevel, pitch, bearing) {
-    const defaultZoomLevel = 18;
+    const initialLoadZoomLevel = 18;
 
     // If zoom level is default, use goTo() function that also fits bounds.
     // Otherwise, set center to be a center point of a given geometry with a specified zoom level.
-    if (zoomLevel === defaultZoomLevel) {
+    if (zoomLevel === initialLoadZoomLevel) {
         mapsIndoorsInstance.getMapView().tilt(pitch || 0);
         mapsIndoorsInstance.getMapView().rotate(bearing || 0);
         mapsIndoorsInstance.goTo({ type: 'Feature', geometry, properties: {} }, {

--- a/packages/map-template/src/hooks/useMapBoundsDeterminer.js
+++ b/packages/map-template/src/hooks/useMapBoundsDeterminer.js
@@ -270,17 +270,22 @@ export default useMapBoundsDeterminer;
  * @param {number} zoomLevel - Enforced zoom level.
  * @param {number} pitch - Map pitch (tilt).
  * @param {number} bearing - Mp bearing (rotation) in degrees from north.
- * @param {boolean} [mapPositionKnown] - Checks if map position is known. Based on that, we can perform zooming to a specific geometry, once map is loaded.
  */
-function goTo(geometry, mapsIndoorsInstance, paddingBottom, paddingLeft, zoomLevel, pitch, bearing, mapPositionKnown) {
-    mapsIndoorsInstance.getMapView().tilt(pitch || 0);
-    mapsIndoorsInstance.getMapView().rotate(bearing || 0);
-    mapsIndoorsInstance.goTo({ type: 'Feature', geometry, properties: {} }, {
-        maxZoom: zoomLevel ?? 22,
-        padding: { top: 0, right: 0, bottom: paddingBottom, left: paddingLeft },
-    }).then(() => {
-        if (zoomLevel && mapPositionKnown !== false) {
-            mapsIndoorsInstance.setZoom(zoomLevel);
-        }
-    });
+function goTo(geometry, mapsIndoorsInstance, paddingBottom, paddingLeft, zoomLevel, pitch, bearing) {
+    const defaultZoomLevel = 18;
+
+    if (zoomLevel === defaultZoomLevel) {
+        mapsIndoorsInstance.getMapView().tilt(pitch || 0);
+        mapsIndoorsInstance.getMapView().rotate(bearing || 0);
+        mapsIndoorsInstance.goTo({ type: 'Feature', geometry, properties: {} }, {
+            maxZoom: zoomLevel ?? 22,
+            padding: { top: 0, right: 0, bottom: paddingBottom, left: paddingLeft },
+        })
+    } else {
+        const centerOfBoundingBox = turf.center(geometry);
+        const mapView = mapsIndoorsInstance.getMapView();
+
+        mapView.setCenter({ lat: centerOfBoundingBox.geometry.coordinates[1], lng: centerOfBoundingBox.geometry.coordinates[0]} )
+        mapsIndoorsInstance.setZoom(zoomLevel);
+    }
 }

--- a/packages/map-template/src/hooks/useMapBoundsDeterminer.js
+++ b/packages/map-template/src/hooks/useMapBoundsDeterminer.js
@@ -56,7 +56,7 @@ const useMapBoundsDeterminer = () => {
     const [kioskLocationDisplayRuleWasChanged, setKioskLocationDisplayRuleWasChanged] = useState(false);
     const [currentVenueName, setCurrentVenueName] = useRecoilState(currentVenueNameState);
     const isMapReady = useRecoilState(isMapReadyState);
-    const [center, ] = useRecoilState(centerState);
+    const [center,] = useRecoilState(centerState);
 
     /**
      * If the app is inactive, run code to reset to initial map position.
@@ -148,10 +148,8 @@ const useMapBoundsDeterminer = () => {
             } else if (currentVenue) {
                 if (venueWasSelected) {
                     if (isDesktop) {
-                        getDesktopPaddingLeft().then(desktopPaddingLeft => {
-                            setMapPositionKnown(currentVenue.geometry);
-                            goTo(currentVenue.geometry, mapsIndoorsInstance, 0, desktopPaddingLeft, getZoomLevel(startZoomLevel), currentPitch, bearing);
-                        });
+                        setMapPositionKnown(currentVenue.geometry);
+                        goTo(currentVenue.geometry, mapsIndoorsInstance, 0, 0, getZoomLevel(startZoomLevel), currentPitch, bearing);
                     } else {
                         getMobilePaddingBottom().then(mobilePaddingBottom => {
                             setMapPositionKnown(currentVenue.geometry);
@@ -285,7 +283,7 @@ function goTo(geometry, mapsIndoorsInstance, paddingBottom, paddingLeft, zoomLev
         const centerOfGeometry = turf.center(geometry);
         const mapView = mapsIndoorsInstance.getMapView();
 
-        mapView.setCenter({ lat: centerOfGeometry.geometry.coordinates[1], lng: centerOfGeometry.geometry.coordinates[0]} )
+        mapView.setCenter({ lat: centerOfGeometry.geometry.coordinates[1], lng: centerOfGeometry.geometry.coordinates[0] })
         mapsIndoorsInstance.setZoom(zoomLevel);
     }
 }

--- a/packages/map-template/src/hooks/useMapBoundsDeterminer.js
+++ b/packages/map-template/src/hooks/useMapBoundsDeterminer.js
@@ -272,6 +272,8 @@ export default useMapBoundsDeterminer;
 function goTo(geometry, mapsIndoorsInstance, paddingBottom, paddingLeft, zoomLevel, pitch, bearing) {
     const defaultZoomLevel = 18;
 
+    // If zoom level is default, use goTo() function that also fits bounds.
+    // Otherwise, set center to be a center point of a given geometry with a specified zoom level.
     if (zoomLevel === defaultZoomLevel) {
         mapsIndoorsInstance.getMapView().tilt(pitch || 0);
         mapsIndoorsInstance.getMapView().rotate(bearing || 0);


### PR DESCRIPTION
goTo will not setZoom level, since it fits to bounds
When startZoomLevel is not 18, and is defined in the URL, setCenter to be center of a geometry with a specific zoom level