### PR TITLE
Fix 2D/3D switch not respecting primaryColor prop

### DIFF
--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.68.3] - 2025-02-13
+
+## Fixed
+
+- Fix 2D/3D selector not respecting the primaryColor query parameter
+
 ## [1.68.2] - 2025-02-11
 
 ## Fixed

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -131,7 +131,7 @@ MapTemplate.propTypes = {
  */
 function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, primaryColor, logo, appUserRoles, directionsFrom, directionsTo, externalIDs, tileStyle, startZoomLevel, bearing, pitch, gmMapId, useMapProviderModule, kioskOriginLocationId, language, supportsUrlParameters, useKeyboard, timeout, miTransitionLevel, category, searchAllVenues, hideNonMatches, showRoadNames, showExternalIDs, searchExternalLocations, center }) {
 
-    const [mapOptions, setMapOptions] = useState();
+    const [mapOptions, setMapOptions] = useState({ brandingColor: primaryColor });
     const [, setApiKey] = useRecoilState(apiKeyState);
     const [, setGmApiKey] = useRecoilState(gmApiKeyState);
     const [, setMapboxAccessToken] = useRecoilState(mapboxAccessTokenState);

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -131,6 +131,7 @@ MapTemplate.propTypes = {
  */
 function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, primaryColor, logo, appUserRoles, directionsFrom, directionsTo, externalIDs, tileStyle, startZoomLevel, bearing, pitch, gmMapId, useMapProviderModule, kioskOriginLocationId, language, supportsUrlParameters, useKeyboard, timeout, miTransitionLevel, category, searchAllVenues, hideNonMatches, showRoadNames, showExternalIDs, searchExternalLocations, center }) {
 
+    const [mapOptions, setMapOptions] = useState();
     const [, setApiKey] = useRecoilState(apiKeyState);
     const [, setGmApiKey] = useRecoilState(gmApiKeyState);
     const [, setMapboxAccessToken] = useRecoilState(mapboxAccessTokenState);
@@ -228,6 +229,18 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
             }
         });
     }
+
+    /**
+     * Updates the map options state by merging new options with existing ones
+     * @param {Object} newMapOptions - The new map options to merge with existing options
+     * @returns {void}
+     */
+    const handleMapOptionsChange = (newMapOptions) => {
+        setMapOptions(previousMapOptions => ({
+            ...previousMapOptions,
+            ...newMapOptions
+        }))
+    };
 
     /*
      * If the app is inactive, run code to reset UI and state.
@@ -685,6 +698,8 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
             onLocationClick={(location) => locationClicked(location)}
             onViewModeSwitchKnown={visible => setViewModeSwitchVisible(visible)}
             resetCount={resetCount}
+            mapOptions={mapOptions}
+            onMapOptionsChange={handleMapOptionsChange}
         />
     </div>
 }

--- a/packages/map-template/src/components/MapWrapper/MapWrapper.jsx
+++ b/packages/map-template/src/components/MapWrapper/MapWrapper.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useRecoilState, useRecoilValue } from 'recoil';
 import MIMap from '@mapsindoors/react-components/src/components/MIMap/MIMap';
 import { mapTypes } from "../../constants/mapTypes";
@@ -29,7 +29,9 @@ MapWrapper.propTypes = {
     useMapProviderModule: PropTypes.bool.isRequired,
     onMapPositionInvestigating: PropTypes.func.isRequired,
     onViewModeSwitchKnown: PropTypes.func.isRequired,
-    resetCount: PropTypes.number.isRequired
+    resetCount: PropTypes.number.isRequired,
+    mapOptions: PropTypes.object,
+    onMapOptionsChange: PropTypes.func,
 };
 
 /**
@@ -49,9 +51,11 @@ let _tileStyle;
  * @param {function} onMapPositionInvestigating - Function that is run when the map position is being determined.
  * @param {function} onViewModeSwitchKnown - Function that is run when the view mode switch is known (if it is to be shown of not).
  * @param {number} resetCount - A counter that is incremented when the map should be reset.
+ * @param {object} props.mapOptions - Options for instantiating and styling the map as well as UI elements.
+ * @param {function} props.onMapOptionsChange - Function that is run when the map options are changed.
  * @returns
  */
-function MapWrapper({ onLocationClick, onMapPositionKnown, useMapProviderModule, onMapPositionInvestigating, onViewModeSwitchKnown, resetCount }) {
+function MapWrapper({ onLocationClick, onMapPositionKnown, useMapProviderModule, onMapPositionInvestigating, onViewModeSwitchKnown, resetCount, mapOptions, onMapOptionsChange }) {
     const apiKey = useRecoilValue(apiKeyState);
     const gmApiKey = useRecoilValue(gmApiKeyState);
     const mapboxAccessToken = useRecoilValue(mapboxAccessTokenState);
@@ -68,7 +72,6 @@ function MapWrapper({ onLocationClick, onMapPositionKnown, useMapProviderModule,
     const solution = useRecoilValue(solutionState);
     const [, setErrorMessage] = useRecoilState(notificationMessageState);
     const hideNonMatches = useRecoilValue(hideNonMatchesState);
-    const [mapOptions, setMapOptions] = useState({});
     const miTransitionLevel = useRecoilValue(miTransitionLevelState);
 
     useLiveData(apiKey);
@@ -292,7 +295,7 @@ function MapWrapper({ onLocationClick, onMapPositionKnown, useMapProviderModule,
      */
     useEffect(() => {
         if (!isNaN(parseInt(miTransitionLevel))) {
-            setMapOptions({ miTransitionLevel: miTransitionLevel })
+            onMapOptionsChange({ miTransitionLevel: miTransitionLevel })
         }
     }, [miTransitionLevel])
 


### PR DESCRIPTION
# What 
- Fix 2D/3D selector not respecting the primaryColor query parameter
# How
- Refactor mapOptions by moving the declaration up the dependency tree
- Add a handle function that can be passed down to child components that can add additional values to mapOptions
- Set up primary color prop in mapOptions