### PR TITLE
Fix wrong map bounds when using locationId or kioskOriginLocationId props

### DIFF
--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.69.1] - 2025-02-18
+
+### Fixed
+
+- The map now correctly zoom to a Location as expected when using the `locationId` or `kioskOriginLocationId` prop.
+
 ## [1.69.0] - 2025-02-17
 
 ### Added

--- a/packages/map-template/src/hooks/useMapBoundsDeterminer.js
+++ b/packages/map-template/src/hooks/useMapBoundsDeterminer.js
@@ -103,7 +103,7 @@ const useMapBoundsDeterminer = () => {
 
                             getDesktopPaddingBottom().then(desktopPaddingBottom => {
                                 setMapPositionKnown(kioskLocation.geometry);
-                                goTo(kioskLocation.geometry, mapsIndoorsInstance, desktopPaddingBottom, 0, getZoomLevel(startZoomLevel), currentPitch, bearing);
+                                goTo(kioskLocation.geometry, mapsIndoorsInstance, desktopPaddingBottom, 0, undefined, currentPitch, bearing);
                             });
                         }
                     });
@@ -134,12 +134,12 @@ const useMapBoundsDeterminer = () => {
                             if (isDesktop) {
                                 getDesktopPaddingLeft().then(desktopPaddingLeft => {
                                     setMapPositionKnown(location.geometry);
-                                    goTo(location.geometry, mapsIndoorsInstance, 0, desktopPaddingLeft, getZoomLevel(startZoomLevel), currentPitch, bearing);
+                                    goTo(location.geometry, mapsIndoorsInstance, 0, desktopPaddingLeft, undefined, currentPitch, bearing);
                                 });
                             } else {
                                 getMobilePaddingBottom().then(mobilePaddingBottom => {
                                     setMapPositionKnown(location.geometry);
-                                    goTo(location.geometry, mapsIndoorsInstance, mobilePaddingBottom, 0, getZoomLevel(startZoomLevel), currentPitch, bearing);
+                                    goTo(location.geometry, mapsIndoorsInstance, mobilePaddingBottom, 0, undefined, currentPitch, bearing);
                                 });
                             }
                         }
@@ -272,9 +272,9 @@ export default useMapBoundsDeterminer;
 function goTo(geometry, mapsIndoorsInstance, paddingBottom, paddingLeft, zoomLevel, pitch, bearing) {
     const initialLoadZoomLevel = 18;
 
-    // If zoom level is default, use goTo() function that also fits bounds.
+    // If zoom level is undefined or default, use goTo() function that also fits bounds.
     // Otherwise, set center to be a center point of a given geometry with a specified zoom level.
-    if (zoomLevel === initialLoadZoomLevel) {
+    if (zoomLevel === undefined || zoomLevel === initialLoadZoomLevel) {
         mapsIndoorsInstance.getMapView().tilt(pitch || 0);
         mapsIndoorsInstance.getMapView().rotate(bearing || 0);
         mapsIndoorsInstance.goTo({ type: 'Feature', geometry, properties: {} }, {


### PR DESCRIPTION
# What

Fixes bug where wrong map bounds are used when using the `locationId` or `kioskOriginLocationId` props. In those cases, the map should zoom to fit the location.

# How

Introduce the usage of an undefined zoom level when calling `goTo` for the mentioned cases. No zoom level should be used there.