### PR TITLE
bugfix: remove check for initialZoomLevel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21495,7 +21495,7 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.71.0",
+      "version": "1.71.1",
       "devDependencies": {
         "@googlemaps/js-api-loader": "^1.15.1",
         "@mapsindoors/components": "*",

--- a/packages/map-template/src/hooks/useMapBoundsDeterminer.js
+++ b/packages/map-template/src/hooks/useMapBoundsDeterminer.js
@@ -270,11 +270,9 @@ export default useMapBoundsDeterminer;
  * @param {number} bearing - Mp bearing (rotation) in degrees from north.
  */
 function goTo(geometry, mapsIndoorsInstance, paddingBottom, paddingLeft, zoomLevel, pitch, bearing) {
-    const initialLoadZoomLevel = 18;
-
     // If zoom level is undefined or default, use goTo() function that also fits bounds.
     // Otherwise, set center to be a center point of a given geometry with a specified zoom level.
-    if (zoomLevel === undefined || zoomLevel === initialLoadZoomLevel) {
+    if (zoomLevel === undefined) {
         mapsIndoorsInstance.getMapView().tilt(pitch || 0);
         mapsIndoorsInstance.getMapView().rotate(bearing || 0);
         mapsIndoorsInstance.goTo({ type: 'Feature', geometry, properties: {} }, {


### PR DESCRIPTION
I found out that when startZoomLevel is set to 18, in some cases it is actually is not set to 18 on the map.
It is due to goTo() function that at the end fits venue bounds. 

I removed the check for initialZoomLevel, so:
1. goTo() function will only work when startZoomLevel is not present - meaning that it will panTo venue as usually
2. When startZoomLevel is present in the URL or App.jsx, it will end up in the `else` part of the code.