### PR TITLE
Feature: Implement useAppTitle prop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21495,7 +21495,7 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.71.1",
+      "version": "1.71.2",
       "devDependencies": {
         "@googlemaps/js-api-loader": "^1.15.1",
         "@mapsindoors/components": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21495,7 +21495,7 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.72.3",
+      "version": "1.73.0",
       "devDependencies": {
         "@googlemaps/js-api-loader": "^1.15.1",
         "@mapsindoors/components": "*",

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- New `useAppTitle` prop that Specifices if the app should use title defined by appConfig object.
+- New `useAppTitle` prop that specifies if the Map Template should set the document title as defined in the App Config.
 
 ## [1.71.2] - 2025-03-10
 

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.72.0] - 2025-03-10
+
+### Added
+
+- New `useAppTitle` prop that Specifices if the app should use title defined by appConfig object.
+
 ## [1.71.2] - 2025-03-10
 
 ### Fixed

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -15,8 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- New minZoom vlaue which is 14.
-- Fixed an issue when wayfinding would not show the whole route, but it's part.
+- New minZoom value which is 10.
+- Fixed an issue when wayfinding would not show the whole route.
 
 ## [1.72.3] - 2025-03-13
 

--- a/packages/map-template/index.html
+++ b/packages/map-template/index.html
@@ -5,7 +5,6 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#005655" />
-  <title>MapsIndoors Web</title>
 </head>
 
 <body>

--- a/packages/map-template/index.html
+++ b/packages/map-template/index.html
@@ -5,6 +5,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#005655" />
+  <title>MapsIndoors Web</title>
 </head>
 
 <body>

--- a/packages/map-template/releaseTools/webcomponent.js
+++ b/packages/map-template/releaseTools/webcomponent.js
@@ -36,7 +36,8 @@ const WebMapsIndoorsMap = r2wc(MapsIndoorsMap, {
         showExternalIDs: "boolean",
         showRoadNames: "boolean",
         searchExternalLocations: "boolean",
-        center: "string"
+        center: "string",
+        useAppTitle: "boolean"
     }
 
 })

--- a/packages/map-template/src/atoms/useAppTitleState.js
+++ b/packages/map-template/src/atoms/useAppTitleState.js
@@ -1,0 +1,8 @@
+import { atom } from 'recoil';
+
+const useAppTitleState = atom({
+    key: 'useAppTitle',
+    default: false
+});
+
+export default useAppTitleState;

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -131,7 +131,7 @@ MapTemplate.propTypes = {
  * @param {boolean} [props.showExternalIDs] - Determine whether the location details on the map should have an external ID visible. The default value is set to false.
  * @param {boolean} [props.searchExternalLocations] - If you want to perform search for external locations in the Wayfinding mode. If set to true, Mapbox/Google places will be displayed depending on the Map Provider you are using. If set to false, the results returned will only be MapsIndoors results. The default is true.
  * @param {string} [props.center] - Specifies the coordinates where the map should load, represented as latitude and longitude values separated by a comma. If the specified coordinates intersect with a Venue, that Venue will be set as the current Venue.
- * @param {boolean} [props.useAppTitle] - Specifies if the Map Template should set the document title as defined in the App Config.
+ * @param {boolean} [props.useAppTitle] - Specifies if the Map Template should set the document title as defined in the App Config. The default value is set to false.
  */
 function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, primaryColor, logo, appUserRoles, directionsFrom, directionsTo, externalIDs, tileStyle, startZoomLevel, bearing, pitch, gmMapId, useMapProviderModule, kioskOriginLocationId, language, supportsUrlParameters, useKeyboard, timeout, miTransitionLevel, category, searchAllVenues, hideNonMatches, showRoadNames, showExternalIDs, searchExternalLocations, center, useAppTitle }) {
 

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -131,7 +131,7 @@ MapTemplate.propTypes = {
  * @param {boolean} [props.showExternalIDs] - Determine whether the location details on the map should have an external ID visible. The default value is set to false.
  * @param {boolean} [props.searchExternalLocations] - If you want to perform search for external locations in the Wayfinding mode. If set to true, Mapbox/Google places will be displayed depending on the Map Provider you are using. If set to false, the results returned will only be MapsIndoors results. The default is true.
  * @param {string} [props.center] - Specifies the coordinates where the map should load, represented as latitude and longitude values separated by a comma. If the specified coordinates intersect with a Venue, that Venue will be set as the current Venue.
- * @param {string} [props.useAppTitle] - TODO
+ * @param {boolean} [props.useAppTitle] - Specifices if the app should use title defined by appConfig object. Default to 'MapsIndoors Web'.
  */
 function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, primaryColor, logo, appUserRoles, directionsFrom, directionsTo, externalIDs, tileStyle, startZoomLevel, bearing, pitch, gmMapId, useMapProviderModule, kioskOriginLocationId, language, supportsUrlParameters, useKeyboard, timeout, miTransitionLevel, category, searchAllVenues, hideNonMatches, showRoadNames, showExternalIDs, searchExternalLocations, center, useAppTitle }) {
 

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -635,7 +635,7 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
      * Sets app title.
      */
     useEffect(() => {
-        if (useAppTitle && !isNullOrUndefined(appConfig?.appSettings?.title)) {
+        if (useAppTitle === true && !isNullOrUndefined(appConfig?.appSettings?.title)) {
             document.title = appConfig.appSettings.title;
         }
     }, [useAppTitle, appConfig])

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -635,7 +635,9 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
      * Sets app title.
      */
     useEffect(() => {
-        document.title = (useAppTitle && appConfig) ? appConfig?.appSettings?.title : 'MapsIndoors Web'
+        if (useAppTitle && appConfig) {
+            document.title = appConfig?.appSettings?.title;
+        }
     }, [useAppTitle, appConfig])
 
     /**

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -131,7 +131,7 @@ MapTemplate.propTypes = {
  * @param {boolean} [props.showExternalIDs] - Determine whether the location details on the map should have an external ID visible. The default value is set to false.
  * @param {boolean} [props.searchExternalLocations] - If you want to perform search for external locations in the Wayfinding mode. If set to true, Mapbox/Google places will be displayed depending on the Map Provider you are using. If set to false, the results returned will only be MapsIndoors results. The default is true.
  * @param {string} [props.center] - Specifies the coordinates where the map should load, represented as latitude and longitude values separated by a comma. If the specified coordinates intersect with a Venue, that Venue will be set as the current Venue.
- * @param {boolean} [props.useAppTitle] - Specifices if the app should use title defined by appConfig object. Default to 'MapsIndoors Web'.
+ * @param {boolean} [props.useAppTitle] - Specifies if the Map Template should set the document title as defined in the App Config.
  */
 function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, primaryColor, logo, appUserRoles, directionsFrom, directionsTo, externalIDs, tileStyle, startZoomLevel, bearing, pitch, gmMapId, useMapProviderModule, kioskOriginLocationId, language, supportsUrlParameters, useKeyboard, timeout, miTransitionLevel, category, searchAllVenues, hideNonMatches, showRoadNames, showExternalIDs, searchExternalLocations, center, useAppTitle }) {
 

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -95,7 +95,8 @@ MapTemplate.propTypes = {
     showRoadNames: PropTypes.bool,
     searchExternalLocations: PropTypes.bool,
     supportsUrlParameters: PropTypes.bool,
-    center: PropTypes.string
+    center: PropTypes.string,
+    useAppTitle: PropTypes.bool
 };
 
 /**
@@ -130,8 +131,9 @@ MapTemplate.propTypes = {
  * @param {boolean} [props.showExternalIDs] - Determine whether the location details on the map should have an external ID visible. The default value is set to false.
  * @param {boolean} [props.searchExternalLocations] - If you want to perform search for external locations in the Wayfinding mode. If set to true, Mapbox/Google places will be displayed depending on the Map Provider you are using. If set to false, the results returned will only be MapsIndoors results. The default is true.
  * @param {string} [props.center] - Specifies the coordinates where the map should load, represented as latitude and longitude values separated by a comma. If the specified coordinates intersect with a Venue, that Venue will be set as the current Venue.
+ * @param {string} [props.useAppTitle] - TODO
  */
-function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, primaryColor, logo, appUserRoles, directionsFrom, directionsTo, externalIDs, tileStyle, startZoomLevel, bearing, pitch, gmMapId, useMapProviderModule, kioskOriginLocationId, language, supportsUrlParameters, useKeyboard, timeout, miTransitionLevel, category, searchAllVenues, hideNonMatches, showRoadNames, showExternalIDs, searchExternalLocations, center }) {
+function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, primaryColor, logo, appUserRoles, directionsFrom, directionsTo, externalIDs, tileStyle, startZoomLevel, bearing, pitch, gmMapId, useMapProviderModule, kioskOriginLocationId, language, supportsUrlParameters, useKeyboard, timeout, miTransitionLevel, category, searchAllVenues, hideNonMatches, showRoadNames, showExternalIDs, searchExternalLocations, center, useAppTitle }) {
 
     const [mapOptions, setMapOptions] = useState({ brandingColor: primaryColor });
     const [, setApiKey] = useRecoilState(apiKeyState);
@@ -628,6 +630,13 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
     useEffect(() => {
         setCenter(center);
     }, [center]);
+
+    /**
+     * Sets app title.
+     */
+    useEffect(() => {
+        document.title = (useAppTitle && appConfig) ? appConfig?.appSettings?.title : 'MapsIndoors Web'
+    }, [useAppTitle, appConfig])
 
     /**
      * When map position is known while initializing the data,

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -635,8 +635,8 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
      * Sets app title.
      */
     useEffect(() => {
-        if (useAppTitle && appConfig) {
-            document.title = appConfig?.appSettings?.title;
+        if (useAppTitle && !isNullOrUndefined(appConfig?.appSettings?.title)) {
+            document.title = appConfig.appSettings.title;
         }
     }, [useAppTitle, appConfig])
 

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -631,8 +631,8 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
         setCenter(center);
     }, [center]);
 
-    /**
-     * Sets app title.
+    /*
+     * Sets document title based on useAppTitle and appConfig values.
      */
     useEffect(() => {
         if (useAppTitle === true && !isNullOrUndefined(appConfig?.appSettings?.title)) {

--- a/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
+++ b/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
@@ -73,7 +73,7 @@ MapsIndoorsMap.propTypes = {
  * @param {boolean} [props.showRoadNames] - A boolean parameter that dictates whether Mapbox road names should be shown. By default, Mapbox road names are hidden when MapsIndoors data is shown. It is dictated by `mi-transition-level` which default value is 17.
  * @param {boolean} [props.searchExternalLocations] - If you want to perform search for external results in the Wayfinding mode. If set to true, Mapbox/Google places will be displayed depending on the Map Provider you are using. If set to false, the results returned will only be MapsIndoors results. The default is true.
  * @param {string} [props.center] - Specifies the coordinates where the map should load, represented as latitude and longitude values separated by a comma. If the specified coordinates intersect with a Venue, that Venue will be set as the current Venue.
- * @param {boolean} [props.useAppTitle] - Specifies if the Map Template should set the document title as defined in the App Config.
+ * @param {boolean} [props.useAppTitle] - Specifies if the Map Template should set the document title as defined in the App Config. The default value is set to false.
  */
 function MapsIndoorsMap(props) {
 

--- a/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
+++ b/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
@@ -36,7 +36,8 @@ MapsIndoorsMap.propTypes = {
     showExternalIDs: PropTypes.bool,
     showRoadNames: PropTypes.bool,
     searchExternalLocations: PropTypes.bool,
-    center: PropTypes.string
+    center: PropTypes.string,
+    useAppTitle: PropTypes.bool
 };
 
 /**
@@ -72,6 +73,7 @@ MapsIndoorsMap.propTypes = {
  * @param {boolean} [props.showRoadNames] - A boolean parameter that dictates whether Mapbox road names should be shown. By default, Mapbox road names are hidden when MapsIndoors data is shown. It is dictated by `mi-transition-level` which default value is 17.
  * @param {boolean} [props.searchExternalLocations] - If you want to perform search for external results in the Wayfinding mode. If set to true, Mapbox/Google places will be displayed depending on the Map Provider you are using. If set to false, the results returned will only be MapsIndoors results. The default is true.
  * @param {string} [props.center] - Specifies the coordinates where the map should load, represented as latitude and longitude values separated by a comma. If the specified coordinates intersect with a Venue, that Venue will be set as the current Venue.
+ * @param {string} [props.useAppTitle] - TODO
  */
 function MapsIndoorsMap(props) {
 
@@ -96,6 +98,7 @@ function MapsIndoorsMap(props) {
             searchExternalLocations: true,
             showExternalIDs: false,
             hideNonMatches: false,
+            useAppTitle: false
         };
 
         const apiKeyQueryParameter = queryStringParams.get('apiKey');
@@ -128,6 +131,7 @@ function MapsIndoorsMap(props) {
         const showRoadNamesQueryParameter = queryStringParams.get('showRoadNames');
         const searchExternalLocationsQueryParameter = queryStringParams.get('searchExternalLocations');
         const centerQueryParameter = queryStringParams.get('center');
+        const useAppTitleQueryParameter = queryStringParams.get('useAppTitle');
 
         // Set the initial props on the Map Template component.
 
@@ -170,6 +174,7 @@ function MapsIndoorsMap(props) {
             showExternalIDs: getBooleanValue(props.supportsUrlParameters, defaultProps.showExternalIDs, props.showExternalIDs, showExternalIDsQueryParameter),
             searchExternalLocations: getBooleanValue(props.supportsUrlParameters, defaultProps.searchExternalLocations, props.searchExternalLocations, searchExternalLocationsQueryParameter),
             supportsUrlParameters: props.supportsUrlParameters,
+            useAppTitle: getBooleanValue(props.supportsUrlParameters, defaultProps.useAppTitle, props.useAppTitle, useAppTitleQueryParameter)
         });
 
     }, [props]);

--- a/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
+++ b/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
@@ -73,7 +73,7 @@ MapsIndoorsMap.propTypes = {
  * @param {boolean} [props.showRoadNames] - A boolean parameter that dictates whether Mapbox road names should be shown. By default, Mapbox road names are hidden when MapsIndoors data is shown. It is dictated by `mi-transition-level` which default value is 17.
  * @param {boolean} [props.searchExternalLocations] - If you want to perform search for external results in the Wayfinding mode. If set to true, Mapbox/Google places will be displayed depending on the Map Provider you are using. If set to false, the results returned will only be MapsIndoors results. The default is true.
  * @param {string} [props.center] - Specifies the coordinates where the map should load, represented as latitude and longitude values separated by a comma. If the specified coordinates intersect with a Venue, that Venue will be set as the current Venue.
- * @param {string} [props.useAppTitle] - TODO
+ * @param {boolean} [props.useAppTitle] - Specifices if the app should use title defined by appConfig object. Default to 'MapsIndoors Web'.
  */
 function MapsIndoorsMap(props) {
 

--- a/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
+++ b/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
@@ -73,7 +73,7 @@ MapsIndoorsMap.propTypes = {
  * @param {boolean} [props.showRoadNames] - A boolean parameter that dictates whether Mapbox road names should be shown. By default, Mapbox road names are hidden when MapsIndoors data is shown. It is dictated by `mi-transition-level` which default value is 17.
  * @param {boolean} [props.searchExternalLocations] - If you want to perform search for external results in the Wayfinding mode. If set to true, Mapbox/Google places will be displayed depending on the Map Provider you are using. If set to false, the results returned will only be MapsIndoors results. The default is true.
  * @param {string} [props.center] - Specifies the coordinates where the map should load, represented as latitude and longitude values separated by a comma. If the specified coordinates intersect with a Venue, that Venue will be set as the current Venue.
- * @param {boolean} [props.useAppTitle] - Specifices if the app should use title defined by appConfig object. Default to 'MapsIndoors Web'.
+ * @param {boolean} [props.useAppTitle] - Specifies if the Map Template should set the document title as defined in the App Config.
  */
 function MapsIndoorsMap(props) {
 


### PR DESCRIPTION
How: 
- Added useAppTitle prop to all the files necessary, as usual. 
- If `useAppTitle && appConfig` are true we set document.title to App Title, otherwise fallback to default. 

Working solution: 

https://github.com/user-attachments/assets/3d3f0787-42cf-4fde-97e1-584988abb1a4

