### PR TITLE
Fix: startZoomLevel not working for kioskOriginLocationId and locationId

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21495,7 +21495,7 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.72.0",
+      "version": "1.72.3",
       "devDependencies": {
         "@googlemaps/js-api-loader": "^1.15.1",
         "@mapsindoors/components": "*",

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.74.3] - 2025-03-26
+
+### Fixed
+
+- An issue when `startZoomLevel` prop would not be respected when using `kioskOriginLocationId` or `locationId` props.
+
 ## [1.74.2] - 2025-03-25
 
 ### Fixed

--- a/packages/map-template/src/hooks/useMapBoundsDeterminer.js
+++ b/packages/map-template/src/hooks/useMapBoundsDeterminer.js
@@ -103,7 +103,7 @@ const useMapBoundsDeterminer = () => {
 
                             getDesktopPaddingBottom().then(desktopPaddingBottom => {
                                 setMapPositionKnown(kioskLocation.geometry);
-                                goTo(kioskLocation.geometry, mapsIndoorsInstance, desktopPaddingBottom, 0, undefined, currentPitch, bearing);
+                                goTo(kioskLocation.geometry, mapsIndoorsInstance, desktopPaddingBottom, 0, startZoomLevel ? getZoomLevel(startZoomLevel) : undefined, currentPitch, bearing);
                             });
                         }
                     });
@@ -134,12 +134,12 @@ const useMapBoundsDeterminer = () => {
                             if (isDesktop) {
                                 getDesktopPaddingLeft().then(desktopPaddingLeft => {
                                     setMapPositionKnown(location.geometry);
-                                    goTo(location.geometry, mapsIndoorsInstance, 0, desktopPaddingLeft, undefined, currentPitch, bearing);
+                                    goTo(location.geometry, mapsIndoorsInstance, 0, desktopPaddingLeft, startZoomLevel ? getZoomLevel(startZoomLevel) : undefined, currentPitch, bearing);
                                 });
                             } else {
                                 getMobilePaddingBottom().then(mobilePaddingBottom => {
                                     setMapPositionKnown(location.geometry);
-                                    goTo(location.geometry, mapsIndoorsInstance, mobilePaddingBottom, 0, undefined, currentPitch, bearing);
+                                    goTo(location.geometry, mapsIndoorsInstance, mobilePaddingBottom, 0, startZoomLevel ? getZoomLevel(startZoomLevel) : undefined, currentPitch, bearing);
                                 });
                             }
                         }


### PR DESCRIPTION
What:
- I found out that we set zoom level to `undefined` inside goTo() method for kiosk and locationId. It is because if we do not set it to undefined, we will be zoomed out too far from a desired location.

How:
- To fix it, I check if startZoomLevel prop is defined for kiosk or locationId. If it is, I let it zoom in to desired startZoomLevel. Otherwise I keep old functionality. 

Working solution:

https://github.com/user-attachments/assets/b27c5e83-3b17-4d15-965b-cb15ad259b81

