### PR TITLE
Display package versions in Sentry instead of commit hashes

### DIFF
--- a/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
+++ b/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
@@ -189,6 +189,7 @@ function MapsIndoorsMap(props) {
 Sentry.init({
     dsn: "https://0ee7fa162023d958c96db25e99c8ff6c@o351128.ingest.sentry.io/4506851619831808",
     // Set environment to localhost if the url includes it. Otherwise, set to production.
+    release: `map-template@${process.env.npm_package_version}`, // This will use version from /packages/map-template/package.json
     environment: window.location.hostname === 'localhost' ? 'localhost' : 'production',
     integrations: [
         // See docs for support of different versions of variation of react router

--- a/packages/map-template/vite.config.js
+++ b/packages/map-template/vite.config.js
@@ -8,6 +8,9 @@ import svgr from 'vite-plugin-svgr';
 
 export default defineConfig(() => {
     return {
+        define: {
+            'process.env.npm_package_version': JSON.stringify(process.env.npm_package_version)
+        },
         server: {
             port: 3000
         },
@@ -23,7 +26,7 @@ export default defineConfig(() => {
             sentryVitePlugin({
                 org: process.env.SENTRY_ORG,
                 project: process.env.SENTRY_PROJECT,
-          
+
                 // Auth tokens can be obtained from https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/
                 authToken: process.env.SENTRY_AUTH_TOKEN,
                 reactComponentAnnotation: { enabled: true },

--- a/packages/map-template/vite.config.js
+++ b/packages/map-template/vite.config.js
@@ -26,7 +26,6 @@ export default defineConfig(() => {
             sentryVitePlugin({
                 org: process.env.SENTRY_ORG,
                 project: process.env.SENTRY_PROJECT,
-
                 // Auth tokens can be obtained from https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/
                 authToken: process.env.SENTRY_AUTH_TOKEN,
                 reactComponentAnnotation: { enabled: true },


### PR DESCRIPTION
# What
- Display map-template package versions instead of commit hashes for Sentry
# How
- Modify the sentry initialization to include the latest version in the package.json