### PR TITLE
Feature: Implement normalizeText for mi-dropdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -718,6 +718,12 @@
       "version": "0.2.3",
       "license": "MIT"
     },
+    "node_modules/@bitty/pipe": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@bitty/pipe/-/pipe-0.3.0.tgz",
+      "integrity": "sha512-Ft4tmMM8vfuQOD3jpmvCYPEXoLhWLXWh/Mkeql09d3+9FFMaQBdFdo8GBmhQ01z+D6P3NkqNq02rbb4oBkhjLw==",
+      "license": "MIT"
+    },
     "node_modules/@csstools/normalize.css": {
       "version": "12.0.0",
       "license": "CC0-1.0"
@@ -15078,6 +15084,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/normalize-text": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/normalize-text/-/normalize-text-2.6.0.tgz",
+      "integrity": "sha512-/nNYxjIiJFatuDBPeYxrLH3GWw4y6jyplxkP3YEiwXtEYkbC6xvMMvjy+Y9wvlij4BrsTPGb+qUefphcnAfaKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@bitty/pipe": "^0.3.0"
+      }
+    },
     "node_modules/normalize-url": {
       "version": "6.1.0",
       "dev": true,
@@ -21464,6 +21479,7 @@
         "fuzzysort": "^2.0.4",
         "jest": "^29.3.1",
         "jest-cli": "^29.7.0",
+        "normalize-text": "^2.6.0",
         "postcss": "^8.4.19",
         "puppeteer": "^19.6.3",
         "sass": "^1.77.2",
@@ -21495,7 +21511,7 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.74.5",
+      "version": "1.74.6",
       "devDependencies": {
         "@googlemaps/js-api-loader": "^1.15.1",
         "@mapsindoors/components": "*",
@@ -22039,6 +22055,11 @@
     },
     "@bcoe/v8-coverage": {
       "version": "0.2.3"
+    },
+    "@bitty/pipe": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@bitty/pipe/-/pipe-0.3.0.tgz",
+      "integrity": "sha512-Ft4tmMM8vfuQOD3jpmvCYPEXoLhWLXWh/Mkeql09d3+9FFMaQBdFdo8GBmhQ01z+D6P3NkqNq02rbb4oBkhjLw=="
     },
     "@csstools/normalize.css": {
       "version": "12.0.0"
@@ -23437,6 +23458,7 @@
         "fuzzysort": "^2.0.4",
         "jest": "^29.3.1",
         "jest-cli": "^29.7.0",
+        "normalize-text": "^2.6.0",
         "postcss": "^8.4.19",
         "puppeteer": "^19.6.3",
         "sass": "^1.77.2",
@@ -31637,6 +31659,14 @@
     },
     "normalize-range": {
       "version": "0.1.2"
+    },
+    "normalize-text": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/normalize-text/-/normalize-text-2.6.0.tgz",
+      "integrity": "sha512-/nNYxjIiJFatuDBPeYxrLH3GWw4y6jyplxkP3YEiwXtEYkbC6xvMMvjy+Y9wvlij4BrsTPGb+qUefphcnAfaKQ==",
+      "requires": {
+        "@bitty/pipe": "^0.3.0"
+      }
     },
     "normalize-url": {
       "version": "6.1.0",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,19 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [13.26.1] - 2024-04-29
+## [13.26.1] - 2025-04-29
 
 ### Changed
 
 - Improved filtering in mi-dropdown component.
 
-## [13.26.0] - 2024-02-20
+## [13.26.0] - 2025-02-20
 
 ### Changed
 
 - Removed code responsible for `You have arrived.` last destination step.
 
-## [13.25.0] - 2024-01-29
+## [13.25.0] - 2025-01-29
 
 ### Added
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.26.1] - 2024-04-29
+
+### Changed
+
+- Improved filtering in mi-dropdown component.
+
 ## [13.26.0] - 2024-02-20
 
 ### Changed

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -56,6 +56,7 @@
         "fuzzysort": "^2.0.4",
         "jest": "^29.3.1",
         "jest-cli": "^29.7.0",
+        "normalize-text": "^2.6.0",
         "postcss": "^8.4.19",
         "puppeteer": "^19.6.3",
         "sass": "^1.77.2",

--- a/packages/components/src/components/dropdown/dropdown.tsx
+++ b/packages/components/src/components/dropdown/dropdown.tsx
@@ -501,7 +501,8 @@ export class Dropdown {
                 threshold: -10000
             };
 
-            // Normalize text for search terms
+            // Normalize text by trimming whitespace, converting to lowercase, and removing diacritics.
+            // This ensures consistent matching/comparison of dropdown items.
             const fuzzyResults = fuzzysort.go(normalizeText(inputQuery), miDropdownItemTexts, searchResultsOptions);
             const filteredItems = fuzzyResults.map(result => this.items.find(item => (normalizeText(item.text) || normalizeText(item.innerText)) === normalizeText(result.target)));
 

--- a/packages/components/src/components/dropdown/dropdown.tsx
+++ b/packages/components/src/components/dropdown/dropdown.tsx
@@ -481,7 +481,8 @@ export class Dropdown {
     filter(): void {
         if (this.filterElement) {
             const inputQuery: string = this.filterElement.value;
-            // Normalize text for all the items in the dropdown
+            // Normalize text by trimming whitespace, converting to lowercase, and removing diacritics.
+            // This ensures consistent matching/comparison of dropdown items.
             const miDropdownItemTexts: string[] = this.items.map(item => (normalizeText(item.text) || normalizeText(item.innerText)));
             const numberOfItemsDisplayed = this.currentItems.length;
 

--- a/packages/components/src/components/dropdown/dropdown.tsx
+++ b/packages/components/src/components/dropdown/dropdown.tsx
@@ -1,6 +1,7 @@
 import { Component, Element, Event, EventEmitter, Host, JSX, Prop, State, Watch, Listen, h, Method } from '@stencil/core';
 import fuzzysort from 'fuzzysort';
 import { SortOrder } from '../../enums/sort-order.enum';
+import { normalizeText } from 'normalize-text';
 
 enum KeyCode {
     ArrowDown = 'ArrowDown',
@@ -147,7 +148,7 @@ export class Dropdown {
      *
      * @type {('right' | 'left')}
      */
-    @Prop({attribute: 'alignment'}) dropdownAlignment: 'right' | 'left' = 'left';
+    @Prop({ attribute: 'alignment' }) dropdownAlignment: 'right' | 'left' = 'left';
 
     @State() currentItems: Array<HTMLMiDropdownItemElement> = [];
 
@@ -480,7 +481,8 @@ export class Dropdown {
     filter(): void {
         if (this.filterElement) {
             const inputQuery: string = this.filterElement.value;
-            const miDropdownItemTexts: string[] = this.items.map(item => (item.text || item.innerText));
+            // Normalize text for all the items in the dropdown
+            const miDropdownItemTexts: string[] = this.items.map(item => (normalizeText(item.text) || normalizeText(item.innerText)));
             const numberOfItemsDisplayed = this.currentItems.length;
 
             if (inputQuery === '') {
@@ -497,8 +499,10 @@ export class Dropdown {
                 allowTypo: false,
                 threshold: -10000
             };
-            const fuzzyResults = fuzzysort.go(inputQuery, miDropdownItemTexts, searchResultsOptions);
-            const filteredItems = fuzzyResults.map(result => this.items.find(item => (item.text || item.innerText) === result.target));
+
+            // Normalize text for search terms
+            const fuzzyResults = fuzzysort.go(normalizeText(inputQuery), miDropdownItemTexts, searchResultsOptions);
+            const filteredItems = fuzzyResults.map(result => this.items.find(item => (normalizeText(item.text) || normalizeText(item.innerText)) === normalizeText(result.target)));
 
             this.currentItems = filteredItems;
 

--- a/packages/components/src/components/dropdown/test.html
+++ b/packages/components/src/components/dropdown/test.html
@@ -56,6 +56,8 @@
         <mi-dropdown-item value="Labore vel2" text="Labore vel-2"></mi-dropdown-item>
         <mi-dropdown-item value="Labore vel3" text="Labore vel-3"></mi-dropdown-item>
         <mi-dropdown-item value="Labore vel4" text="Labore vel-4"></mi-dropdown-item>
+        <mi-dropdown-item value="Caffę" text="Caffę"></mi-dropdown-item>
+        <mi-dropdown-item value="illy Caffè" text="illy Caffè"></mi-dropdown-item>
     </mi-dropdown>
 
     <p>Filterable select with checkboxes</p>


### PR DESCRIPTION
What:
- It is hard to search for terms like `illy Caffè` using word caffe, because mi-dropdown does not return any results. 

How: 
- Used normalizeText package. 
- It is applied for items in the list and search term so we can find exact matches, without worrying that our keyboard does not support specific symbols/letters.

Testing:
- I added a few test inside components text.html page.