### PR TITLE
Listen to the app config latitude and longitude values 

### DIFF
--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -62,7 +62,6 @@ import isNullOrUndefined from '../../helpers/isNullOrUndefined.js';
 import centerState from '../../atoms/centerState.js';
 import PropTypes from 'prop-types';
 import { ZoomLevelValues } from '../../constants/zoomLevelValues.js';
-import mapTypeState from '../../atoms/mapTypeState.js';
 
 // Define the Custom Elements from our components package.
 defineCustomElements();

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -227,8 +227,8 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
 
             const miSdkApiTag = document.createElement('script');
             miSdkApiTag.setAttribute('type', 'text/javascript');
-            miSdkApiTag.setAttribute('src', 'https://app.mapsindoors.com/mapsindoors/js/sdk/4.39.2/mapsindoors-4.39.2.js.gz');
-            miSdkApiTag.setAttribute('integrity', 'sha384-+Lvi/laUwP/QZixVuIXpTn6ckln8itxc4ErCg9xwYY/QSyTqPTgGGqnLkfnhS2zo');
+            miSdkApiTag.setAttribute('src', 'https://app.mapsindoors.com/mapsindoors/js/sdk/4.39.0/mapsindoors-4.39.0.js.gz');
+            miSdkApiTag.setAttribute('integrity', 'sha384-3S9Jvub8zrQ8mn1GlIvVw+LQTsvSF9tz/1e+mr18/rHZfAjUsQ7Vy6cnzidMoyq7');
             miSdkApiTag.setAttribute('crossorigin', 'anonymous');
             document.body.appendChild(miSdkApiTag);
             miSdkApiTag.onload = () => {
@@ -631,10 +631,25 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
 
     /*
      * React on changes to the center prop.
+     * This sets the center position from either:
+     * 1. The center URL parameter (if supportsUrlParameters is true)
+     * 2. The center prop passed directly to the component
+     * The coordinates are formatted based on the map provider:
+     * - For Google Maps: "latitude,longitude"
+     * - For Mapbox: "longitude,latitude"
      */
     useEffect(() => {
-        setCenter(center);
-    }, [center]);
+        if (center) {
+            const [latitude, longitude] = center.split(',');
+            let formattedCenter;
+            if (mapType === 'mapbox') {
+                formattedCenter = `${longitude},${latitude}`;  // Convert to longitude,latitude for Mapbox
+            } else {
+                formattedCenter = `${latitude},${longitude}`; // Keep as latitude,longitude for Google Maps
+            }
+            setCenter(formattedCenter);
+        }
+    }, [center, mapType]);
 
     /*
      * Fallback mechanism for setting the center position.

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -212,8 +212,6 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
 
     const [setCurrentVenueName, updateCategories] = useCurrentVenue();
 
-    const mapType = useRecoilValue(mapTypeState);
-
     /**
      * Ensure that MapsIndoors Web SDK is available.
      *
@@ -393,7 +391,7 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
     }, [externalIDs, mapsindoorsSDKAvailable]);
 
     /*
-     * React on changes to the locationId prop.
+     * React to changes in the locationId prop.
      * Set as current location and change the venue according to the venue that the location belongs to.
      */
     useEffect(() => {
@@ -631,46 +629,23 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
 
     /*
      * React on changes to the center prop.
-     * This sets the center position from either:
-     * 1. The center URL parameter (if supportsUrlParameters is true)
-     * 2. The center prop passed directly to the component
-     * The coordinates are formatted based on the map provider:
-     * - For Google Maps: "latitude,longitude"
-     * - For Mapbox: "longitude,latitude"
      */
     useEffect(() => {
-        if (center) {
-            const [latitude, longitude] = center.split(',');
-            let formattedCenter;
-            if (mapType === 'mapbox') {
-                formattedCenter = longitude + ',' + latitude;  // Convert to longitude,latitude for Mapbox
-            } else {
-                formattedCenter = latitude + ',' + longitude; // Keep as latitude,longitude for Google Maps
-            }
-            setCenter(formattedCenter);
-        }
-    }, [center, mapType]);
+        setCenter(center);
+    }, [center]);
 
     /*
      * Fallback mechanism for setting the center position.
      * If no center is specified (neither through URL parameter nor prop),
      * and the appSettings contains both latitude and longitude,
-     * use those coordinates as the center position.
-     * The coordinates are formatted based on the map provider:
-     * - For Google Maps: "latitude,longitude"
-     * - For Mapbox: "longitude,latitude"
+     * use those coordinates in longitude,latitude format
      */
     useEffect(() => {
         if (!center && appConfig?.appSettings?.latitude && appConfig?.appSettings?.longitude) {
-            let formattedCenter;
-            if (mapType === 'mapbox') {
-                formattedCenter = appConfig.appSettings.longitude + ',' + appConfig.appSettings.latitude;
-            } else {
-                formattedCenter = appConfig.appSettings.latitude + ',' + appConfig.appSettings.longitude;
-            }
+            const formattedCenter = appConfig.appSettings.longitude + ',' + appConfig.appSettings.latitude;
             setCenter(formattedCenter);
         }
-    }, [center, appConfig, mapType]);
+    }, [center, appConfig]);
 
     /*
      * Sets document title based on useAppTitle and appConfig values.

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -643,9 +643,9 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
             const [latitude, longitude] = center.split(',');
             let formattedCenter;
             if (mapType === 'mapbox') {
-                formattedCenter = `${longitude},${latitude}`;  // Convert to longitude,latitude for Mapbox
+                formattedCenter = longitude + ',' + latitude;  // Convert to longitude,latitude for Mapbox
             } else {
-                formattedCenter = `${latitude},${longitude}`; // Keep as latitude,longitude for Google Maps
+                formattedCenter = latitude + ',' + longitude; // Keep as latitude,longitude for Google Maps
             }
             setCenter(formattedCenter);
         }
@@ -664,9 +664,9 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
         if (!center && appConfig?.appSettings?.latitude && appConfig?.appSettings?.longitude) {
             let formattedCenter;
             if (mapType === 'mapbox') {
-                formattedCenter = `${appConfig.appSettings.longitude},${appConfig.appSettings.latitude}`;
+                formattedCenter = appConfig.appSettings.longitude + ',' + appConfig.appSettings.latitude;
             } else {
-                formattedCenter = `${appConfig.appSettings.latitude},${appConfig.appSettings.longitude}`;
+                formattedCenter = appConfig.appSettings.latitude + ',' + appConfig.appSettings.longitude;
             }
             setCenter(formattedCenter);
         }

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -227,8 +227,8 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
 
             const miSdkApiTag = document.createElement('script');
             miSdkApiTag.setAttribute('type', 'text/javascript');
-            miSdkApiTag.setAttribute('src', 'https://app.mapsindoors.com/mapsindoors/js/sdk/4.39.0/mapsindoors-4.39.0.js.gz');
-            miSdkApiTag.setAttribute('integrity', 'sha384-3S9Jvub8zrQ8mn1GlIvVw+LQTsvSF9tz/1e+mr18/rHZfAjUsQ7Vy6cnzidMoyq7');
+            miSdkApiTag.setAttribute('src', 'https://app.mapsindoors.com/mapsindoors/js/sdk/4.39.2/mapsindoors-4.39.2.js.gz');
+            miSdkApiTag.setAttribute('integrity', 'sha384-+Lvi/laUwP/QZixVuIXpTn6ckln8itxc4ErCg9xwYY/QSyTqPTgGGqnLkfnhS2zo');
             miSdkApiTag.setAttribute('crossorigin', 'anonymous');
             document.body.appendChild(miSdkApiTag);
             miSdkApiTag.onload = () => {

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -640,9 +640,8 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
      * use those coordinates in longitude,latitude format
      */
     useEffect(() => {
-        if (!center && appConfig?.appSettings?.latitude && appConfig?.appSettings?.longitude) {
-            const formattedCenter = appConfig.appSettings.longitude + ',' + appConfig.appSettings.latitude;
-            setCenter(formattedCenter);
+        if (!center && appConfig?.appSettings?.center) {
+            setCenter(appConfig.appSettings.center);
         }
     }, [center, appConfig]);
 

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -558,7 +558,7 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
     }, [kioskOriginLocationId, mapsindoorsSDKAvailable]);
 
     /*
-     * React on changes to the timout prop
+     * React on changes to the timeout prop
      */
     useEffect(() => {
         setTimeoutValue(timeout);


### PR DESCRIPTION
## What 
- Two new app config keys were added in the CMS, 'latitude' and 'longitude'
- We need to listen for those values in the map template and react accordingly

## How
- Set up a fallback useEffect that will set the center based on app config's latitude and longitude, if present
- Enhance current useEffect to set center based on map type, since google maps and mapbox order latitude and longitude differently 