### PR TITLE
Add sentry error boundary for map template

### DIFF
--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.74.7] - 2025-04-30
+
+### Fixed
+
+- Fixed Sentry error boundaries for MapsIndoorsMap.
+
 ## [1.74.6] - 2025-03-31
 
 ### Fixed

--- a/packages/map-template/src/App.jsx
+++ b/packages/map-template/src/App.jsx
@@ -4,13 +4,15 @@ import MapsIndoorsMap from './components/MapsIndoorsMap/MapsIndoorsMap';
 
 function App() {
     return (
-        <div className="app">
-            {/* This is the Map Template component */}
-            <MapsIndoorsMap supportsUrlParameters={true}
-                gmApiKey={import.meta.env.VITE_GOOGLE_MAPS_API_KEY}
-                mapboxAccessToken={import.meta.env.VITE_MAPBOX_ACCESS_TOKEN}
+        <Sentry.ErrorBoundary>
+            <div className="app">
+                {/* This is the Map Template component */}
+                <MapsIndoorsMap supportsUrlParameters={true}
+                    gmApiKey={import.meta.env.VITE_GOOGLE_MAPS_API_KEY}
+                    mapboxAccessToken={import.meta.env.VITE_MAPBOX_ACCESS_TOKEN}
                 />
-        </div>
+            </div>
+        </Sentry.ErrorBoundary>
     );
 }
 

--- a/packages/map-template/src/App.jsx
+++ b/packages/map-template/src/App.jsx
@@ -1,19 +1,16 @@
-import * as Sentry from "@sentry/react";
 import './App.css';
 import MapsIndoorsMap from './components/MapsIndoorsMap/MapsIndoorsMap';
 
 function App() {
     return (
-        <Sentry.ErrorBoundary>
-            <div className="app">
-                {/* This is the Map Template component */}
-                <MapsIndoorsMap supportsUrlParameters={true}
-                    gmApiKey={import.meta.env.VITE_GOOGLE_MAPS_API_KEY}
-                    mapboxAccessToken={import.meta.env.VITE_MAPBOX_ACCESS_TOKEN}
-                />
-            </div>
-        </Sentry.ErrorBoundary>
+        <div className="app">
+            {/* This is the Map Template component */}
+            <MapsIndoorsMap supportsUrlParameters={true}
+                gmApiKey={import.meta.env.VITE_GOOGLE_MAPS_API_KEY}
+                mapboxAccessToken={import.meta.env.VITE_MAPBOX_ACCESS_TOKEN}
+            />
+        </div>
     );
 }
 
-export default Sentry.withProfiler(App, { name: "App" });
+export default App;

--- a/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
+++ b/packages/map-template/src/components/MapsIndoorsMap/MapsIndoorsMap.jsx
@@ -181,7 +181,9 @@ function MapsIndoorsMap(props) {
 
     return (
         <RecoilRoot>
-            {mapTemplateProps && <MapTemplate {...mapTemplateProps}></MapTemplate>}
+            <Sentry.ErrorBoundary>
+                {mapTemplateProps && <MapTemplate {...mapTemplateProps}></MapTemplate>}
+            </Sentry.ErrorBoundary>
         </RecoilRoot>
     )
 }
@@ -218,4 +220,4 @@ Sentry.init({
     replaysOnErrorSampleRate: 1.0,
 });
 
-export default MapsIndoorsMap;
+export default Sentry.withProfiler(MapsIndoorsMap, { name: "MapsIndoorsMap" });

--- a/packages/map-template/vite.config.js
+++ b/packages/map-template/vite.config.js
@@ -23,10 +23,11 @@ export default defineConfig(() => {
             sentryVitePlugin({
                 org: process.env.SENTRY_ORG,
                 project: process.env.SENTRY_PROJECT,
-          
+
                 // Auth tokens can be obtained from https://sentry.io/orgredirect/organizations/:orgslug/settings/auth-tokens/
                 authToken: process.env.SENTRY_AUTH_TOKEN,
                 reactComponentAnnotation: { enabled: true },
+                denyUrls: [/https?:\/\/app\.mapsindoors\.com\/mapsindoors\/js\/sdk\//], // Exclude the MapsIndoors SDK from Sentry error tracking
             }),
         ]
     }


### PR DESCRIPTION
## What
- Improve sentry error logging
## How
-  Add sentry error boundary around our mapsindoors map component
- Add rule to ignore sdk in error logging