### PR TITLE
Feature: Fix Finish Route button ending up in initial venue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21451,7 +21451,7 @@
     },
     "packages/components": {
       "name": "@mapsindoors/components",
-      "version": "13.27.0",
+      "version": "13.27.1",
       "license": "MIT",
       "dependencies": {
         "@11ty/eleventy": "^2.0.1",
@@ -21511,7 +21511,7 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.76.4",
+      "version": "1.76.5",
       "devDependencies": {
         "@googlemaps/js-api-loader": "^1.15.1",
         "@mapsindoors/components": "*",

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.76.6] - 2025-05-27
+
+### Fixed
+
+- Fixed an issue where clicking 'Finish Route' would unexpectedly switch the venue.
+
 ## [1.76.5] - 2025-05-22
 
 ### Fixed

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -62,6 +62,7 @@ import isNullOrUndefined from '../../helpers/isNullOrUndefined.js';
 import centerState from '../../atoms/centerState.js';
 import PropTypes from 'prop-types';
 import { ZoomLevelValues } from '../../constants/zoomLevelValues.js';
+import { useOnRouteFinished } from '../../hooks/useOnRouteFinished.js';
 
 // Define the Custom Elements from our components package.
 defineCustomElements();
@@ -210,6 +211,8 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
     const [resetCount, setResetCount] = useState(0);
 
     const [setCurrentVenueName, updateCategories] = useCurrentVenue();
+
+    const finishRoute = useOnRouteFinished();
 
     /**
      * Ensure that MapsIndoors Web SDK is available.
@@ -686,6 +689,16 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
         setSelectedCategory(null); // unselect category when route is finished
     }
 
+    /**
+     * Function that handles the finishing of route.
+     */
+    function onRouteFinish() {
+        finishRoute();
+        resetAppHistory();
+        setResetCount(curr => curr + 1);
+        setSelectedCategory(null); // unselect category when route is finished
+    }
+
     /*
      * React on changes in the category prop.
      * Check if the category property matches with any of the existing categories.
@@ -720,7 +733,7 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
                         pushAppView={pushAppView}
                         currentAppView={currentAppView}
                         appViews={appStates}
-                        onRouteFinished={() => resetStateAndUI()}
+                        onRouteFinished={() => onRouteFinish()}
                     />
                 }
                 {isMobile &&
@@ -730,7 +743,7 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
                         pushAppView={pushAppView}
                         currentAppView={currentAppView}
                         appViews={appStates}
-                        onRouteFinished={() => resetStateAndUI()}
+                        onRouteFinished={() => onRouteFinish()}
                     />
                 }
             </Fragment>

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -695,7 +695,7 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
     function onRouteFinish() {
         finishRoute();
         resetAppHistory();
-        setResetCount(curr => curr + 1);
+        setResetCount(curr => curr + 1); // will force a re-render of bottom sheet and sidebar.
         setSelectedCategory(null); // unselect category when route is finished
     }
 

--- a/packages/map-template/src/hooks/useOnRouteFinished.js
+++ b/packages/map-template/src/hooks/useOnRouteFinished.js
@@ -1,0 +1,37 @@
+import { useResetRecoilState } from 'recoil';
+import activeStepState from '../atoms/activeStep';
+import currentLocationState from '../atoms/currentLocationState';
+import directionsResponseState from '../atoms/directionsResponseState';
+import hasFoundRouteState from '../atoms/hasFoundRouteState';
+import isLocationClickedState from '../atoms/isLocationClickedState';
+import notificationMessageState from '../atoms/notificationMessageState';
+import travelModeState from '../atoms/travelModeState';
+import accessibilityOnState from '../atoms/accessibilityOnState';
+
+/**
+ * Reset a number of Recoil atoms to initial values when route is finished.
+ *
+ * @returns {function}
+ */
+export function useOnRouteFinished() {
+
+    const activeStep = useResetRecoilState(activeStepState);
+    const currentLocation = useResetRecoilState(currentLocationState);
+    const directionsResponse = useResetRecoilState(directionsResponseState);
+    const hasFoundRoute = useResetRecoilState(hasFoundRouteState);
+    const isLocationClicked = useResetRecoilState(isLocationClickedState);
+    const notificationMessage = useResetRecoilState(notificationMessageState);
+    const travelMode = useResetRecoilState(travelModeState);
+    const accessibilityOn = useResetRecoilState(accessibilityOnState);
+
+    return () => {
+        activeStep();
+        currentLocation();
+        directionsResponse();
+        hasFoundRoute();
+        isLocationClicked();
+        notificationMessage();
+        travelMode();
+        accessibilityOn();
+    };
+}


### PR DESCRIPTION
What: There is an issue that when you run the Map Template, change the Venue, create a route and click Finish Route - you would end up in initial Venue (they one that loaded initially)

How: I fixed it by creating a hook that handles onRouteFinished and I used it inside MapTemple.jsx. 

Solution is similar to previous one, but it's simplified. It also covers the issues that Andrei found: https://mapspeople.atlassian.net/browse/SCE-437