### PR TITLE
Bugfix: Prevent slow getRoute calls from overriding faster ones

### DIFF
--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.78.3] - 2025-06-12
+
+### Fixed
+
+- Fixed an issue where a slow route request would risk override a later, faster one, resulting in the shown route suddenly shifting to an unexpected one.
+
 ## [1.78.2] - 2025-06-12
 
 ### Fixed

--- a/packages/map-template/src/hooks/useDirectionsInfo.js
+++ b/packages/map-template/src/hooks/useDirectionsInfo.js
@@ -17,6 +17,7 @@ const useDirectionsInfo = (originLocation, destinationLocation, directionsServic
 
     useEffect(() => {
         setAreDirectionReady(false);
+        let isActive = true; // This flag will help us ignore outdated responses
         if (originLocation?.geometry && destinationLocation?.geometry) {
             directionsService.getRoute({
                 origin: getLocationPoint(originLocation),
@@ -24,6 +25,8 @@ const useDirectionsInfo = (originLocation, destinationLocation, directionsServic
                 travelMode: travelMode,
                 avoidStairs: accessibilityOn
             }).then(directionsResult => {
+                if (!isActive) return;
+
                 if (directionsResult && directionsResult.legs) {
                     // Calculate total distance and time
                     const totalDistance = directionsResult.legs.reduce((accumulator, current) => accumulator + current.distance.value, 0);
@@ -45,8 +48,13 @@ const useDirectionsInfo = (originLocation, destinationLocation, directionsServic
                     setHasFoundRoute(false);
                 }
             }, () => {
+                if (!isActive) return;
                 setHasFoundRoute(false);
             });
+        }
+
+        return () => {
+            isActive = false;
         }
     }, [originLocation, destinationLocation, directionsService, accessibilityOn, travelMode]);
 


### PR DESCRIPTION
# What

Prevent slower getRoute calls from overtaking faster ones.

# Why

In the case of eg. My Position being used, and the position is far away from the current venue, external directions responses can be extremely slow. This had the result of overriding a faster route call then the slow response finally resolved, leading to a sudden jump to an unexpected route.

# How

- Introduced an `isActive` flag to prevent older ones from overtaking. The cleanup function where `isActive` is set to false is always run before the effect runs again.