### PR TITLE
Bugfix: Category selection disappears after click on right-hand side elements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22816,7 +22816,7 @@
     },
     "packages/components": {
       "name": "@mapsindoors/components",
-      "version": "13.27.3",
+      "version": "13.28.0",
       "license": "MIT",
       "dependencies": {
         "@11ty/eleventy": "^2.0.1",
@@ -22876,7 +22876,7 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.77.0",
+      "version": "1.78.1",
       "devDependencies": {
         "@googlemaps/js-api-loader": "^1.15.1",
         "@mapsindoors/components": "*",

--- a/packages/map-template/src/components/Search/Search.jsx
+++ b/packages/map-template/src/components/Search/Search.jsx
@@ -399,11 +399,17 @@ function Search({ onSetSize, isOpen }) {
      */
     useEffect(() => {
         const SEARCH_FOCUS_ELEMENTS = ['.search__info', '.search__back-button', '.categories', '.sheet__content'];
+        const IGNORE_CLOSE_ELEMENTS = ['.mi-floor-selector', '.view-mode-switch', '.mi-my-position'];
 
         const handleSearchFieldFocus = (event) => {
             const clickedInsideSearchArea = SEARCH_FOCUS_ELEMENTS.some(selector =>
                 event.target.closest(selector)
             );
+
+            const clickedInsideIgnoreArea = IGNORE_CLOSE_ELEMENTS.some(selector =>
+                event.target.closest(selector)
+            );
+
             const clickedInsideResults = event.target.closest('.search__results');
 
             if (clickedInsideSearchArea) {
@@ -411,7 +417,7 @@ function Search({ onSetSize, isOpen }) {
                 requestAnimationFrameId.current = requestAnimationFrame(() => { // we use a requestAnimationFrame to ensure that the size change is applied before the focus (meaning that categories are rendered)
                     setIsInputFieldInFocus(true);
                 });
-            } else if (!clickedInsideResults) {
+            } else if (!clickedInsideResults && !clickedInsideIgnoreArea) {
                 setIsInputFieldInFocus(false);
                 setSize(snapPoints.MIN);
                 setSelectedCategory(null);

--- a/packages/map-template/src/components/Search/Search.jsx
+++ b/packages/map-template/src/components/Search/Search.jsx
@@ -399,7 +399,9 @@ function Search({ onSetSize, isOpen }) {
      */
     useEffect(() => {
         const SEARCH_FOCUS_ELEMENTS = ['.search__info', '.search__back-button', '.categories', '.sheet__content'];
-        const IGNORE_CLOSE_ELEMENTS = ['.mi-floor-selector', '.view-mode-switch', '.mi-my-position'];
+
+        // We want to ignore: Floor Selector, View Mode Switch, My Position, Mapbox zoom controls and Google Maps zoom controls
+        const IGNORE_CLOSE_ELEMENTS = ['.mi-floor-selector', '.view-mode-switch', '.mi-my-position', '.mapboxgl-ctrl-bottom-right', '.gmnoprint'];
 
         const handleSearchFieldFocus = (event) => {
             const clickedInsideSearchArea = SEARCH_FOCUS_ELEMENTS.some(selector =>


### PR DESCRIPTION
What: It was reported that when categories are expanded, clicking at different UI elements triggers closing of categories.

How: I created a new array that ignores close event for specific elements.