### PR TITLE
Feature: Set error message when no tokens are present

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22876,7 +22876,7 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.78.4",
+      "version": "1.79.0",
       "devDependencies": {
         "@googlemaps/js-api-loader": "^1.15.1",
         "@mapsindoors/components": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22876,7 +22876,7 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.79.0",
+      "version": "1.79.1",
       "devDependencies": {
         "@googlemaps/js-api-loader": "^1.15.1",
         "@mapsindoors/components": "*",

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.79.2] - 2025-06-19
+
+### Fixed
+
+- Show error message when `mapboxAccessToken` and `gmApiKey` are not present in the App Config object and in query parameter.
+
 ## [1.79.1] - 2025-06-19
 
 ### Fixed

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -63,6 +63,7 @@ import centerState from '../../atoms/centerState.js';
 import PropTypes from 'prop-types';
 import { ZoomLevelValues } from '../../constants/zoomLevelValues.js';
 import { useOnRouteFinished } from '../../hooks/useOnRouteFinished.js';
+import notificationMessageState from '../../atoms/notificationMessageState.js';
 
 // Define the Custom Elements from our components package.
 defineCustomElements();
@@ -214,6 +215,8 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
 
     const finishRoute = useOnRouteFinished();
 
+    const [, setErrorMessage] = useRecoilState(notificationMessageState);
+
     /**
      * Ensure that MapsIndoors Web SDK is available.
      *
@@ -360,8 +363,17 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
      */
     useEffect(() => {
         if (mapsindoorsSDKAvailable && appConfig) {
-            setMapboxAccessToken(mapboxAccessToken || appConfig.appSettings?.mapboxAccessToken);
-            setGmApiKey(gmApiKey || appConfig.appSettings?.gmKey);
+            if (
+                isNullOrUndefined(mapboxAccessToken) &&
+                isNullOrUndefined(gmApiKey) &&
+                isNullOrUndefined(appConfig?.appSettings?.mapboxAccessToken) &&
+                isNullOrUndefined(appConfig?.appSettings?.gmKey)
+            ) {
+                setErrorMessage({ text: 'Please provide a Mapbox Access Token or Google Maps API key to show a map.', type: 'error' });
+            } else {
+                setMapboxAccessToken(mapboxAccessToken || appConfig.appSettings?.mapboxAccessToken);
+                setGmApiKey(gmApiKey || appConfig.appSettings?.gmKey);
+            }
         }
     }, [gmApiKey, mapboxAccessToken, mapsindoorsSDKAvailable, appConfig]);
 


### PR DESCRIPTION
It was discovered that when there are no tokens present, error message is not shown. 
I made sure to show it once no tokens are present.