### PR TITLE
Prevent broken image placeholder on Splash Screen

### DIFF
--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.79.6] - 2025-06-26
+
+### Fixed
+
+- Timing issue in Splash Screen component that could result in a brief appearance of a broken image placeholder.
+
 ## [1.79.5] - 2025-06-25
 
 ### Fixed

--- a/packages/map-template/src/components/SplashScreen/SplashScreen.jsx
+++ b/packages/map-template/src/components/SplashScreen/SplashScreen.jsx
@@ -15,9 +15,9 @@ function SplashScreen() {
     return (
         <div className="splash-screen">
             <div className="splash-screen__container">
-                <img className="splash-screen__logo"
+                <img className={'splash-screen__logo ' + (logo ? 'splash-screen__logo--visible' : '')}
                     src={logo}
-                    alt="logo"
+                    alt=""
                 />
                 {/* The border value is set based on the #rrggbbaa and includes an
                         opacity level of around 20%, which translates to the value of 33. */}

--- a/packages/map-template/src/components/SplashScreen/SplashScreen.scss
+++ b/packages/map-template/src/components/SplashScreen/SplashScreen.scss
@@ -10,6 +10,12 @@
     &__logo {
         width: 100%;
         max-height: 100%;
+        visibility: hidden;
+
+        // This class is used to show the logo only when the logo is known. Otherwise we would risk a broken image placeholder.
+        &--visible {
+            visibility: visible;
+        }
     }
 
     &__loader {


### PR DESCRIPTION
# What

Mitigate the risk of showing a broken image placeholder in the Splash Screen component while the logo is not known.

# How

- Default visibility of the logo is now set to hidden.
- It is toggled to visible as soon as the logo has a value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved splash screen logo visibility by only displaying the logo when an image source is available, preventing broken image placeholders.
  - Updated logo image styling to ensure it is hidden until a valid logo is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->