### PR TITLE
Update bump-version-release.yml to node 18

### DIFF
--- a/.github/workflows/bump-version-release.yml
+++ b/.github/workflows/bump-version-release.yml
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/setup-node@v3
         if: steps.changed-files-midt.outputs.any_changed == 'true'
         with:
-          node-version: 16
+          node-version: 18
           registry-url: https://registry.npmjs.org/
           # Despite the package name including this scope, it's also necessary to set here
           scope: "@mapsindoors"
@@ -136,7 +136,7 @@ jobs:
       - uses: actions/setup-node@v3
         if: steps.changed-files-components.outputs.any_changed == 'true'
         with:
-          node-version: 16
+          node-version: 18
           registry-url: https://registry.npmjs.org/
           # Despite the package name including this scope, it's also necessary to set here
           scope: "@mapsindoors"
@@ -183,7 +183,7 @@ jobs:
       # Set up a node environment in the container.
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - run: npm ci
 
       # It is absolutely essential to use "CI=" as the first part of the lerna command, or it won't build properly.
@@ -246,7 +246,7 @@ jobs:
       - uses: actions/setup-node@v3
         if: steps.changed-files-map-template.outputs.any_changed == 'true'
         with:
-          node-version: 16
+          node-version: 18
           registry-url: https://registry.npmjs.org/
           # Despite the package name including this scope, it's also necessary to set here
           scope: "@mapsindoors"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and release pipeline to use Node.js 18 across the version bump/release workflow, aligning with supported runtime and improving performance, security, and long-term support. Ensures future dependency updates remain compatible, reduces deprecation warnings, and stabilizes automation. No user action required; app behavior remains the same. Release cadence unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->