### PR TITLE
Add lazy load when loading Map Components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23381,7 +23381,7 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.81.5",
+      "version": "1.81.6",
       "devDependencies": {
         "@googlemaps/js-api-loader": "^1.15.1",
         "@mapsindoors/components": "*",

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.82.0] - 2025-08-19
+
+### Added
+
+- Added lazy loading for Mapbox and Google Maps providers to improve initial page load performance
+
 ## [1.81.6] - 2025-08-18
 
 ### Fixed

--- a/packages/react-components/src/components/MIMap/GoogleMapsMap/GoogleMapsMap.jsx
+++ b/packages/react-components/src/components/MIMap/GoogleMapsMap/GoogleMapsMap.jsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Loader as GoogleMapsApiLoader } from '@googlemaps/js-api-loader';
-import 'mapbox-gl/dist/mapbox-gl.css';
 import './GoogleMapsMap.scss';
 import { useIsDesktop } from '../../../hooks/useIsDesktop';
 import isNullOrUndefined from '../../../../../map-template/src/helpers/isNullOrUndefined';

--- a/packages/react-components/src/components/MIMap/MIMap.jsx
+++ b/packages/react-components/src/components/MIMap/MIMap.jsx
@@ -1,10 +1,12 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, Suspense, lazy } from 'react';
 import PropTypes from 'prop-types';
-import MapboxMap from './MapboxMap/MapboxMap';
-import GoogleMapsMap from './GoogleMapsMap/GoogleMapsMap';
 import MapControls from './MapControls/MapControls';
 import { defineCustomElements } from '@mapsindoors/components/dist/esm/loader.js';
 import './MIMap.scss';
+
+// Lazy load Mapbox and Google Maps components
+const MapboxMap = lazy(() => import('./MapboxMap/MapboxMap'));
+const GoogleMapsMap = lazy(() => import('./GoogleMapsMap/GoogleMapsMap'));
 
 const mapTypes = {
     Google: 'google',
@@ -149,34 +151,38 @@ function MIMap({ apiKey, gmApiKey, mapboxAccessToken, center, zoom, bounds, bear
 
     return <>
         {mapType === mapTypes.Google && (
-            <GoogleMapsMap
-                mapsIndoorsInstance={mapsIndoorsInstance}
-                apiKey={gmApiKey}
-                onInitialized={onMapViewInitialized}
-                center={center}
-                zoom={zoom}
-                mapOptions={mapOptions}
-                heading={bearing}
-                tilt={pitch}
-                bounds={bounds}
-                gmMapId={gmMapId}
-            />
+            <Suspense>
+                <GoogleMapsMap
+                    mapsIndoorsInstance={mapsIndoorsInstance}
+                    apiKey={gmApiKey}
+                    onInitialized={onMapViewInitialized}
+                    center={center}
+                    zoom={zoom}
+                    mapOptions={mapOptions}
+                    heading={bearing}
+                    tilt={pitch}
+                    bounds={bounds}
+                    gmMapId={gmMapId}
+                />
+            </Suspense>
         )}
         {mapType === mapTypes.Mapbox && (
-            <MapboxMap
-                mapsIndoorsInstance={mapsIndoorsInstance}
-                accessToken={mapboxAccessToken}
-                onInitialized={onMapViewInitialized}
-                center={center}
-                zoom={zoom}
-                mapOptions={mapOptions}
-                bearing={bearing}
-                pitch={pitch}
-                bounds={bounds}
-                resetViewMode={resetUICounter}
-                viewModeSwitchVisible={viewModeSwitchVisible}
-                appConfig={appConfig}
-            />
+            <Suspense>
+                <MapboxMap
+                    mapsIndoorsInstance={mapsIndoorsInstance}
+                    accessToken={mapboxAccessToken}
+                    onInitialized={onMapViewInitialized}
+                    center={center}
+                    zoom={zoom}
+                    mapOptions={mapOptions}
+                    bearing={bearing}
+                    pitch={pitch}
+                    bounds={bounds}
+                    resetViewMode={resetUICounter}
+                    viewModeSwitchVisible={viewModeSwitchVisible}
+                    appConfig={appConfig}
+                />
+            </Suspense>
         )}
         {mapsIndoorsInstance && mapViewInstance && mapType && (
             <MapControls

--- a/packages/react-components/src/components/MIMap/MapboxMap/ViewModeSwitch/ViewModeSwitch.jsx
+++ b/packages/react-components/src/components/MIMap/MapboxMap/ViewModeSwitch/ViewModeSwitch.jsx
@@ -97,6 +97,11 @@ function ViewModeSwitch({ mapView, pitch, reset, activeColor = '#005655', show2D
         }
     }, [viewMode, mapView]);
 
+    // Don't render if the portal target doesn't exist
+    if (!portalTarget) {
+        return null;
+    }
+
     return createPortal(
         <div className="view-mode-switch">
             <button className="view-mode-switch__button"


### PR DESCRIPTION
## What
- Added code splitting for MapboxMap and GoogleMapsMap components to reduce initial bundle size
- Implemented React lazy() method to load map provider dependencies only when needed

## How
- Converted MapboxMap and GoogleMapsMap imports to use React's lazy() dynamic import function
- Wrapped lazy components with Suspense boundaries (without fallback for simplicity)
- Maintained portal compatibility by keeping MapControls rendering containers before lazy components load
- Bundle now splits into separate chunks one for the Mapbox chunk and one for the Google Maps chunk
- Users only download the map provider code they actually use, reducing initial load time

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None.

- Refactor
  - Lazy-load map providers to improve initial page load and defer heavy assets.
  - Remove a global map CSS import from one provider to avoid loading unnecessary styles.

- Bug Fixes
  - Make the view-mode switch resilient when its portal target is missing to prevent render errors.

- Documentation
  - Add changelog entry for version 1.82.0 noting lazy-loading of map providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->