### PR TITLE
Upgrade mapbox-gl-js version for the Map Template to v3.15.0 and upgrade SDK version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "mapbox-gl": "3.8.0"
+        "mapbox-gl": "3.15.0"
       },
       "devDependencies": {
         "lerna": "^6.4.0"
@@ -3028,7 +3028,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@mapbox/point-geometry": {
-      "version": "0.1.0",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+      "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
       "license": "ISC"
     },
     "node_modules/@mapbox/tiny-sdf": {
@@ -3040,10 +3042,14 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/@mapbox/vector-tile": {
-      "version": "1.3.1",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.4.tgz",
+      "integrity": "sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@mapbox/point-geometry": "~0.1.0"
+        "@mapbox/point-geometry": "~1.1.0",
+        "@types/geojson": "^7946.0.16",
+        "pbf": "^4.0.1"
       }
     },
     "node_modules/@mapbox/whoots-js": {
@@ -6259,15 +6265,6 @@
     "node_modules/@types/mapbox__point-geometry": {
       "version": "0.1.4",
       "license": "MIT"
-    },
-    "node_modules/@types/mapbox__vector-tile": {
-      "version": "1.3.4",
-      "license": "MIT",
-      "dependencies": {
-        "@types/geojson": "*",
-        "@types/mapbox__point-geometry": "*",
-        "@types/pbf": "*"
-      }
     },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
@@ -11949,6 +11946,7 @@
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -15368,38 +15366,42 @@
       }
     },
     "node_modules/mapbox-gl": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.8.0.tgz",
-      "integrity": "sha512-7iQ6wxAf8UedbNYTzNsyr2J25ozIBA4vmKY0xUDXQlHEokulzPENwjjmLxHQGRylDpOmR0c8kPEbtHCaQE2eMw==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.15.0.tgz",
+      "integrity": "sha512-I42ffZpiXwt0PG3PO6gMYQnoz+AInkirLe/+zoHjcfBTFoFkKYtu5gFwT1WGeSvNrVTqG2Bwp9zUjPw0PFGY+w==",
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "workspaces": [
+        "src/style-spec",
+        "test/build/typings"
+      ],
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
         "@mapbox/mapbox-gl-supported": "^3.0.0",
-        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/point-geometry": "^1.1.0",
         "@mapbox/tiny-sdf": "^2.0.6",
         "@mapbox/unitbezier": "^0.0.1",
-        "@mapbox/vector-tile": "^1.3.1",
+        "@mapbox/vector-tile": "^2.0.4",
         "@mapbox/whoots-js": "^3.1.0",
-        "@types/geojson": "^7946.0.14",
+        "@types/geojson": "^7946.0.16",
         "@types/geojson-vt": "^3.2.5",
         "@types/mapbox__point-geometry": "^0.1.4",
-        "@types/mapbox__vector-tile": "^1.3.4",
         "@types/pbf": "^3.0.5",
         "@types/supercluster": "^7.1.3",
         "cheap-ruler": "^4.0.0",
         "csscolorparser": "~1.0.3",
-        "earcut": "^3.0.0",
+        "earcut": "^3.0.1",
         "geojson-vt": "^4.0.2",
-        "gl-matrix": "^3.4.3",
+        "gl-matrix": "^3.4.4",
         "grid-index": "^1.1.0",
         "kdbush": "^4.0.2",
+        "martinez-polygon-clipping": "^0.7.4",
         "murmurhash-js": "^1.0.0",
-        "pbf": "^3.2.1",
+        "pbf": "^4.0.1",
         "potpack": "^2.0.0",
         "quickselect": "^3.0.0",
         "serialize-to-js": "^3.1.2",
         "supercluster": "^8.0.1",
-        "tinyqueue": "^3.0.0",
-        "vt-pbf": "^3.1.3"
+        "tinyqueue": "^3.0.0"
       }
     },
     "node_modules/mapbox-gl/node_modules/earcut": {
@@ -15448,7 +15450,6 @@
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/martinez-polygon-clipping/-/martinez-polygon-clipping-0.7.4.tgz",
       "integrity": "sha512-jBEwrKtA0jTagUZj2bnmb4Yg2s4KnJGRePStgI7bAVjtcipKiF39R4LZ2V/UT61jMYWrTcBhPazexeqd6JAVtw==",
-      "dev": true,
       "dependencies": {
         "robust-predicates": "^2.0.4",
         "splaytree": "^0.1.4",
@@ -15458,14 +15459,12 @@
     "node_modules/martinez-polygon-clipping/node_modules/splaytree": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/splaytree/-/splaytree-0.1.4.tgz",
-      "integrity": "sha512-D50hKrjZgBzqD3FT2Ek53f2dcDLAQT8SSGrzj3vidNH5ISRgceeGVJ2dQIthKOuayqFXfFjXheHNo4bbt9LhRQ==",
-      "dev": true
+      "integrity": "sha512-D50hKrjZgBzqD3FT2Ek53f2dcDLAQT8SSGrzj3vidNH5ISRgceeGVJ2dQIthKOuayqFXfFjXheHNo4bbt9LhRQ=="
     },
     "node_modules/martinez-polygon-clipping/node_modules/tinyqueue": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-1.2.3.tgz",
-      "integrity": "sha512-Qz9RgWuO9l8lT+Y9xvbzhPT2efIUIFd69N7eF7tJ9lnQl0iLj1M7peK7IoUGZL9DJHw9XftqLreccfxcQgYLxA==",
-      "dev": true
+      "integrity": "sha512-Qz9RgWuO9l8lT+Y9xvbzhPT2efIUIFd69N7eF7tJ9lnQl0iLj1M7peK7IoUGZL9DJHw9XftqLreccfxcQgYLxA=="
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -18061,10 +18060,11 @@
       }
     },
     "node_modules/pbf": {
-      "version": "3.2.1",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
+      "integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "ieee754": "^1.1.12",
         "resolve-protobuf-schema": "^2.1.0"
       },
       "bin": {
@@ -18456,6 +18456,8 @@
     },
     "node_modules/protocol-buffers-schema": {
       "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
+      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
       "license": "MIT"
     },
     "node_modules/protocols": {
@@ -19678,6 +19680,8 @@
     },
     "node_modules/resolve-protobuf-schema": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
       "license": "MIT",
       "dependencies": {
         "protocol-buffers-schema": "^3.3.1"
@@ -19751,7 +19755,6 @@
     },
     "node_modules/robust-predicates": {
       "version": "2.0.4",
-      "dev": true,
       "license": "Unlicense"
     },
     "node_modules/rollup": {
@@ -22763,15 +22766,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/vt-pbf": {
-      "version": "3.1.3",
-      "license": "MIT",
-      "dependencies": {
-        "@mapbox/point-geometry": "0.1.0",
-        "@mapbox/vector-tile": "^1.3.1",
-        "pbf": "^3.2.1"
-      }
-    },
     "node_modules/walk-up-path": {
       "version": "1.0.0",
       "dev": true,
@@ -23445,97 +23439,10 @@
         "web-vitals": "^2.1.4"
       }
     },
-    "packages/map-template/node_modules/@mapbox/point-geometry": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
-      "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
-      "dev": true
-    },
-    "packages/map-template/node_modules/@mapbox/vector-tile": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.4.tgz",
-      "integrity": "sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==",
-      "dev": true,
-      "dependencies": {
-        "@mapbox/point-geometry": "~1.1.0",
-        "@types/geojson": "^7946.0.16",
-        "pbf": "^4.0.1"
-      }
-    },
     "packages/map-template/node_modules/@mapsindoors/css": {
       "version": "3.0.0",
       "dev": true,
       "license": "MIT"
-    },
-    "packages/map-template/node_modules/earcut": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
-      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
-      "dev": true
-    },
-    "packages/map-template/node_modules/mapbox-gl": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.15.0.tgz",
-      "integrity": "sha512-I42ffZpiXwt0PG3PO6gMYQnoz+AInkirLe/+zoHjcfBTFoFkKYtu5gFwT1WGeSvNrVTqG2Bwp9zUjPw0PFGY+w==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE.txt",
-      "workspaces": [
-        "src/style-spec",
-        "test/build/typings"
-      ],
-      "dependencies": {
-        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-        "@mapbox/mapbox-gl-supported": "^3.0.0",
-        "@mapbox/point-geometry": "^1.1.0",
-        "@mapbox/tiny-sdf": "^2.0.6",
-        "@mapbox/unitbezier": "^0.0.1",
-        "@mapbox/vector-tile": "^2.0.4",
-        "@mapbox/whoots-js": "^3.1.0",
-        "@types/geojson": "^7946.0.16",
-        "@types/geojson-vt": "^3.2.5",
-        "@types/mapbox__point-geometry": "^0.1.4",
-        "@types/pbf": "^3.0.5",
-        "@types/supercluster": "^7.1.3",
-        "cheap-ruler": "^4.0.0",
-        "csscolorparser": "~1.0.3",
-        "earcut": "^3.0.1",
-        "geojson-vt": "^4.0.2",
-        "gl-matrix": "^3.4.4",
-        "grid-index": "^1.1.0",
-        "kdbush": "^4.0.2",
-        "martinez-polygon-clipping": "^0.7.4",
-        "murmurhash-js": "^1.0.0",
-        "pbf": "^4.0.1",
-        "potpack": "^2.0.0",
-        "quickselect": "^3.0.0",
-        "serialize-to-js": "^3.1.2",
-        "supercluster": "^8.0.1",
-        "tinyqueue": "^3.0.0"
-      }
-    },
-    "packages/map-template/node_modules/pbf": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
-      "integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
-      "dev": true,
-      "dependencies": {
-        "resolve-protobuf-schema": "^2.1.0"
-      },
-      "bin": {
-        "pbf": "bin/pbf"
-      }
-    },
-    "packages/map-template/node_modules/quickselect": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
-      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
-      "dev": true
-    },
-    "packages/map-template/node_modules/tinyqueue": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
-      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
-      "dev": true
     },
     "packages/map-template/node_modules/uuid": {
       "version": "9.0.1",
@@ -23573,7 +23480,7 @@
         "eslint": "^8.39.0",
         "eslint-plugin-react": "^7.37.3",
         "eslint-plugin-react-hooks": "^5.1.0",
-        "mapbox-gl": "3.8.0",
+        "mapbox-gl": "3.15.0",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -25613,7 +25520,9 @@
       "version": "3.0.0"
     },
     "@mapbox/point-geometry": {
-      "version": "0.1.0"
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+      "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ=="
     },
     "@mapbox/tiny-sdf": {
       "version": "2.0.6"
@@ -25622,9 +25531,13 @@
       "version": "0.0.1"
     },
     "@mapbox/vector-tile": {
-      "version": "1.3.1",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.4.tgz",
+      "integrity": "sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==",
       "requires": {
-        "@mapbox/point-geometry": "~0.1.0"
+        "@mapbox/point-geometry": "~1.1.0",
+        "@types/geojson": "^7946.0.16",
+        "pbf": "^4.0.1"
       }
     },
     "@mapbox/whoots-js": {
@@ -25718,87 +25631,8 @@
         "web-vitals": "^2.1.4"
       },
       "dependencies": {
-        "@mapbox/point-geometry": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
-          "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
-          "dev": true
-        },
-        "@mapbox/vector-tile": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.4.tgz",
-          "integrity": "sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==",
-          "dev": true,
-          "requires": {
-            "@mapbox/point-geometry": "~1.1.0",
-            "@types/geojson": "^7946.0.16",
-            "pbf": "^4.0.1"
-          }
-        },
         "@mapsindoors/css": {
           "version": "3.0.0",
-          "dev": true
-        },
-        "earcut": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
-          "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
-          "dev": true
-        },
-        "mapbox-gl": {
-          "version": "3.15.0",
-          "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.15.0.tgz",
-          "integrity": "sha512-I42ffZpiXwt0PG3PO6gMYQnoz+AInkirLe/+zoHjcfBTFoFkKYtu5gFwT1WGeSvNrVTqG2Bwp9zUjPw0PFGY+w==",
-          "dev": true,
-          "requires": {
-            "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-            "@mapbox/mapbox-gl-supported": "^3.0.0",
-            "@mapbox/point-geometry": "^1.1.0",
-            "@mapbox/tiny-sdf": "^2.0.6",
-            "@mapbox/unitbezier": "^0.0.1",
-            "@mapbox/vector-tile": "^2.0.4",
-            "@mapbox/whoots-js": "^3.1.0",
-            "@types/geojson": "^7946.0.16",
-            "@types/geojson-vt": "^3.2.5",
-            "@types/mapbox__point-geometry": "^0.1.4",
-            "@types/pbf": "^3.0.5",
-            "@types/supercluster": "^7.1.3",
-            "cheap-ruler": "^4.0.0",
-            "csscolorparser": "~1.0.3",
-            "earcut": "^3.0.1",
-            "geojson-vt": "^4.0.2",
-            "gl-matrix": "^3.4.4",
-            "grid-index": "^1.1.0",
-            "kdbush": "^4.0.2",
-            "martinez-polygon-clipping": "^0.7.4",
-            "murmurhash-js": "^1.0.0",
-            "pbf": "^4.0.1",
-            "potpack": "^2.0.0",
-            "quickselect": "^3.0.0",
-            "serialize-to-js": "^3.1.2",
-            "supercluster": "^8.0.1",
-            "tinyqueue": "^3.0.0"
-          }
-        },
-        "pbf": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
-          "integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
-          "dev": true,
-          "requires": {
-            "resolve-protobuf-schema": "^2.1.0"
-          }
-        },
-        "quickselect": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
-          "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
-          "dev": true
-        },
-        "tinyqueue": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
-          "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
           "dev": true
         },
         "uuid": {
@@ -25828,7 +25662,7 @@
         "eslint": "^8.39.0",
         "eslint-plugin-react": "^7.37.3",
         "eslint-plugin-react-hooks": "^5.1.0",
-        "mapbox-gl": "3.8.0",
+        "mapbox-gl": "3.15.0",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -27931,14 +27765,6 @@
     },
     "@types/mapbox__point-geometry": {
       "version": "0.1.4"
-    },
-    "@types/mapbox__vector-tile": {
-      "version": "1.3.4",
-      "requires": {
-        "@types/geojson": "*",
-        "@types/mapbox__point-geometry": "*",
-        "@types/pbf": "*"
-      }
     },
     "@types/minimatch": {
       "version": "3.0.5",
@@ -31621,7 +31447,8 @@
       }
     },
     "ieee754": {
-      "version": "1.2.1"
+      "version": "1.2.1",
+      "dev": true
     },
     "ignore": {
       "version": "5.2.4"
@@ -33778,38 +33605,37 @@
       "dev": true
     },
     "mapbox-gl": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.8.0.tgz",
-      "integrity": "sha512-7iQ6wxAf8UedbNYTzNsyr2J25ozIBA4vmKY0xUDXQlHEokulzPENwjjmLxHQGRylDpOmR0c8kPEbtHCaQE2eMw==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.15.0.tgz",
+      "integrity": "sha512-I42ffZpiXwt0PG3PO6gMYQnoz+AInkirLe/+zoHjcfBTFoFkKYtu5gFwT1WGeSvNrVTqG2Bwp9zUjPw0PFGY+w==",
       "requires": {
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
         "@mapbox/mapbox-gl-supported": "^3.0.0",
-        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/point-geometry": "^1.1.0",
         "@mapbox/tiny-sdf": "^2.0.6",
         "@mapbox/unitbezier": "^0.0.1",
-        "@mapbox/vector-tile": "^1.3.1",
+        "@mapbox/vector-tile": "^2.0.4",
         "@mapbox/whoots-js": "^3.1.0",
-        "@types/geojson": "^7946.0.14",
+        "@types/geojson": "^7946.0.16",
         "@types/geojson-vt": "^3.2.5",
         "@types/mapbox__point-geometry": "^0.1.4",
-        "@types/mapbox__vector-tile": "^1.3.4",
         "@types/pbf": "^3.0.5",
         "@types/supercluster": "^7.1.3",
         "cheap-ruler": "^4.0.0",
         "csscolorparser": "~1.0.3",
-        "earcut": "^3.0.0",
+        "earcut": "^3.0.1",
         "geojson-vt": "^4.0.2",
-        "gl-matrix": "^3.4.3",
+        "gl-matrix": "^3.4.4",
         "grid-index": "^1.1.0",
         "kdbush": "^4.0.2",
+        "martinez-polygon-clipping": "^0.7.4",
         "murmurhash-js": "^1.0.0",
-        "pbf": "^3.2.1",
+        "pbf": "^4.0.1",
         "potpack": "^2.0.0",
         "quickselect": "^3.0.0",
         "serialize-to-js": "^3.1.2",
         "supercluster": "^8.0.1",
-        "tinyqueue": "^3.0.0",
-        "vt-pbf": "^3.1.3"
+        "tinyqueue": "^3.0.0"
       },
       "dependencies": {
         "earcut": {
@@ -33849,7 +33675,6 @@
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/martinez-polygon-clipping/-/martinez-polygon-clipping-0.7.4.tgz",
       "integrity": "sha512-jBEwrKtA0jTagUZj2bnmb4Yg2s4KnJGRePStgI7bAVjtcipKiF39R4LZ2V/UT61jMYWrTcBhPazexeqd6JAVtw==",
-      "dev": true,
       "requires": {
         "robust-predicates": "^2.0.4",
         "splaytree": "^0.1.4",
@@ -33859,14 +33684,12 @@
         "splaytree": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/splaytree/-/splaytree-0.1.4.tgz",
-          "integrity": "sha512-D50hKrjZgBzqD3FT2Ek53f2dcDLAQT8SSGrzj3vidNH5ISRgceeGVJ2dQIthKOuayqFXfFjXheHNo4bbt9LhRQ==",
-          "dev": true
+          "integrity": "sha512-D50hKrjZgBzqD3FT2Ek53f2dcDLAQT8SSGrzj3vidNH5ISRgceeGVJ2dQIthKOuayqFXfFjXheHNo4bbt9LhRQ=="
         },
         "tinyqueue": {
           "version": "1.2.3",
           "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-1.2.3.tgz",
-          "integrity": "sha512-Qz9RgWuO9l8lT+Y9xvbzhPT2efIUIFd69N7eF7tJ9lnQl0iLj1M7peK7IoUGZL9DJHw9XftqLreccfxcQgYLxA==",
-          "dev": true
+          "integrity": "sha512-Qz9RgWuO9l8lT+Y9xvbzhPT2efIUIFd69N7eF7tJ9lnQl0iLj1M7peK7IoUGZL9DJHw9XftqLreccfxcQgYLxA=="
         }
       }
     },
@@ -35519,9 +35342,10 @@
       "version": "4.0.0"
     },
     "pbf": {
-      "version": "3.2.1",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
+      "integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
       "requires": {
-        "ieee754": "^1.1.12",
         "resolve-protobuf-schema": "^2.1.0"
       }
     },
@@ -35754,7 +35578,9 @@
       "dev": true
     },
     "protocol-buffers-schema": {
-      "version": "3.6.0"
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
+      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
     },
     "protocols": {
       "version": "2.0.1",
@@ -36554,6 +36380,8 @@
     },
     "resolve-protobuf-schema": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
       "requires": {
         "protocol-buffers-schema": "^3.3.1"
       }
@@ -36596,8 +36424,7 @@
       }
     },
     "robust-predicates": {
-      "version": "2.0.4",
-      "dev": true
+      "version": "2.0.4"
     },
     "rollup": {
       "version": "2.79.1",
@@ -38474,14 +38301,6 @@
     "void-elements": {
       "version": "3.1.0",
       "dev": true
-    },
-    "vt-pbf": {
-      "version": "3.1.3",
-      "requires": {
-        "@mapbox/point-geometry": "0.1.0",
-        "@mapbox/vector-tile": "^1.3.1",
-        "pbf": "^3.2.1"
-      }
     },
     "walk-up-path": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15442,6 +15442,29 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/martinez-polygon-clipping": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/martinez-polygon-clipping/-/martinez-polygon-clipping-0.7.4.tgz",
+      "integrity": "sha512-jBEwrKtA0jTagUZj2bnmb4Yg2s4KnJGRePStgI7bAVjtcipKiF39R4LZ2V/UT61jMYWrTcBhPazexeqd6JAVtw==",
+      "dev": true,
+      "dependencies": {
+        "robust-predicates": "^2.0.4",
+        "splaytree": "^0.1.4",
+        "tinyqueue": "^1.2.0"
+      }
+    },
+    "node_modules/martinez-polygon-clipping/node_modules/splaytree": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/splaytree/-/splaytree-0.1.4.tgz",
+      "integrity": "sha512-D50hKrjZgBzqD3FT2Ek53f2dcDLAQT8SSGrzj3vidNH5ISRgceeGVJ2dQIthKOuayqFXfFjXheHNo4bbt9LhRQ==",
+      "dev": true
+    },
+    "node_modules/martinez-polygon-clipping/node_modules/tinyqueue": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-1.2.3.tgz",
+      "integrity": "sha512-Qz9RgWuO9l8lT+Y9xvbzhPT2efIUIFd69N7eF7tJ9lnQl0iLj1M7peK7IoUGZL9DJHw9XftqLreccfxcQgYLxA==",
+      "dev": true
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -23381,7 +23404,7 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.82.1",
+      "version": "1.83.0",
       "devDependencies": {
         "@googlemaps/js-api-loader": "^1.15.1",
         "@mapsindoors/components": "*",
@@ -23399,7 +23422,7 @@
         "eslint-plugin-react-hooks": "^4.6.2",
         "i18next": "^23.7.7",
         "jest": "^29.7.0",
-        "mapbox-gl": "^3.8.0",
+        "mapbox-gl": "^3.11.1",
         "prop-types": "^15.8.1",
         "qrcode": "^1.5.3",
         "react": "^18.2.0",
@@ -23420,10 +23443,92 @@
         "web-vitals": "^2.1.4"
       }
     },
+    "packages/map-template/node_modules/@mapbox/point-geometry": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+      "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
+      "dev": true
+    },
+    "packages/map-template/node_modules/@mapbox/vector-tile": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.4.tgz",
+      "integrity": "sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==",
+      "dev": true,
+      "dependencies": {
+        "@mapbox/point-geometry": "~1.1.0",
+        "@types/geojson": "^7946.0.16",
+        "pbf": "^4.0.1"
+      }
+    },
     "packages/map-template/node_modules/@mapsindoors/css": {
       "version": "3.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "packages/map-template/node_modules/earcut": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
+      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
+      "dev": true
+    },
+    "packages/map-template/node_modules/mapbox-gl": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.14.0.tgz",
+      "integrity": "sha512-KYhi9ZOQL4BB0J061admPH8O5ZZhhxsyiJ6DQCOkCaps0JEB4HF3SbJwu8S0pJKaQUxNS33sSbzW8iDSSauHPQ==",
+      "dev": true,
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/mapbox-gl-supported": "^3.0.0",
+        "@mapbox/point-geometry": "^1.1.0",
+        "@mapbox/tiny-sdf": "^2.0.6",
+        "@mapbox/unitbezier": "^0.0.1",
+        "@mapbox/vector-tile": "^2.0.4",
+        "@mapbox/whoots-js": "^3.1.0",
+        "@types/geojson": "^7946.0.16",
+        "@types/geojson-vt": "^3.2.5",
+        "@types/mapbox__point-geometry": "^0.1.4",
+        "@types/pbf": "^3.0.5",
+        "@types/supercluster": "^7.1.3",
+        "cheap-ruler": "^4.0.0",
+        "csscolorparser": "~1.0.3",
+        "earcut": "^3.0.1",
+        "geojson-vt": "^4.0.2",
+        "gl-matrix": "^3.4.3",
+        "grid-index": "^1.1.0",
+        "kdbush": "^4.0.2",
+        "martinez-polygon-clipping": "^0.7.4",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^4.0.1",
+        "potpack": "^2.0.0",
+        "quickselect": "^3.0.0",
+        "serialize-to-js": "^3.1.2",
+        "supercluster": "^8.0.1",
+        "tinyqueue": "^3.0.0"
+      }
+    },
+    "packages/map-template/node_modules/pbf": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
+      "integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
+      "dev": true,
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
+    "packages/map-template/node_modules/quickselect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "dev": true
+    },
+    "packages/map-template/node_modules/tinyqueue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
+      "dev": true
     },
     "packages/map-template/node_modules/uuid": {
       "version": "9.0.1",
@@ -25585,7 +25690,7 @@
         "eslint-plugin-react-hooks": "^4.6.2",
         "i18next": "^23.7.7",
         "jest": "^29.7.0",
-        "mapbox-gl": "^3.8.0",
+        "mapbox-gl": "^3.11.1",
         "prop-types": "^15.8.1",
         "qrcode": "^1.5.3",
         "react": "^18.2.0",
@@ -25606,8 +25711,87 @@
         "web-vitals": "^2.1.4"
       },
       "dependencies": {
+        "@mapbox/point-geometry": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+          "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
+          "dev": true
+        },
+        "@mapbox/vector-tile": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.4.tgz",
+          "integrity": "sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==",
+          "dev": true,
+          "requires": {
+            "@mapbox/point-geometry": "~1.1.0",
+            "@types/geojson": "^7946.0.16",
+            "pbf": "^4.0.1"
+          }
+        },
         "@mapsindoors/css": {
           "version": "3.0.0",
+          "dev": true
+        },
+        "earcut": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
+          "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
+          "dev": true
+        },
+        "mapbox-gl": {
+          "version": "3.14.0",
+          "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.14.0.tgz",
+          "integrity": "sha512-KYhi9ZOQL4BB0J061admPH8O5ZZhhxsyiJ6DQCOkCaps0JEB4HF3SbJwu8S0pJKaQUxNS33sSbzW8iDSSauHPQ==",
+          "dev": true,
+          "requires": {
+            "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+            "@mapbox/mapbox-gl-supported": "^3.0.0",
+            "@mapbox/point-geometry": "^1.1.0",
+            "@mapbox/tiny-sdf": "^2.0.6",
+            "@mapbox/unitbezier": "^0.0.1",
+            "@mapbox/vector-tile": "^2.0.4",
+            "@mapbox/whoots-js": "^3.1.0",
+            "@types/geojson": "^7946.0.16",
+            "@types/geojson-vt": "^3.2.5",
+            "@types/mapbox__point-geometry": "^0.1.4",
+            "@types/pbf": "^3.0.5",
+            "@types/supercluster": "^7.1.3",
+            "cheap-ruler": "^4.0.0",
+            "csscolorparser": "~1.0.3",
+            "earcut": "^3.0.1",
+            "geojson-vt": "^4.0.2",
+            "gl-matrix": "^3.4.3",
+            "grid-index": "^1.1.0",
+            "kdbush": "^4.0.2",
+            "martinez-polygon-clipping": "^0.7.4",
+            "murmurhash-js": "^1.0.0",
+            "pbf": "^4.0.1",
+            "potpack": "^2.0.0",
+            "quickselect": "^3.0.0",
+            "serialize-to-js": "^3.1.2",
+            "supercluster": "^8.0.1",
+            "tinyqueue": "^3.0.0"
+          }
+        },
+        "pbf": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
+          "integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
+          "dev": true,
+          "requires": {
+            "resolve-protobuf-schema": "^2.1.0"
+          }
+        },
+        "quickselect": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+          "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+          "dev": true
+        },
+        "tinyqueue": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+          "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
           "dev": true
         },
         "uuid": {
@@ -33649,6 +33833,31 @@
           "version": "4.5.0",
           "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
           "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
+        }
+      }
+    },
+    "martinez-polygon-clipping": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/martinez-polygon-clipping/-/martinez-polygon-clipping-0.7.4.tgz",
+      "integrity": "sha512-jBEwrKtA0jTagUZj2bnmb4Yg2s4KnJGRePStgI7bAVjtcipKiF39R4LZ2V/UT61jMYWrTcBhPazexeqd6JAVtw==",
+      "dev": true,
+      "requires": {
+        "robust-predicates": "^2.0.4",
+        "splaytree": "^0.1.4",
+        "tinyqueue": "^1.2.0"
+      },
+      "dependencies": {
+        "splaytree": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/splaytree/-/splaytree-0.1.4.tgz",
+          "integrity": "sha512-D50hKrjZgBzqD3FT2Ek53f2dcDLAQT8SSGrzj3vidNH5ISRgceeGVJ2dQIthKOuayqFXfFjXheHNo4bbt9LhRQ==",
+          "dev": true
+        },
+        "tinyqueue": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-1.2.3.tgz",
+          "integrity": "sha512-Qz9RgWuO9l8lT+Y9xvbzhPT2efIUIFd69N7eF7tJ9lnQl0iLj1M7peK7IoUGZL9DJHw9XftqLreccfxcQgYLxA==",
+          "dev": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11422,7 +11422,9 @@
       "license": "MIT"
     },
     "node_modules/gl-matrix": {
-      "version": "3.4.3",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
       "license": "MIT"
     },
     "node_modules/glob": {
@@ -23422,7 +23424,7 @@
         "eslint-plugin-react-hooks": "^4.6.2",
         "i18next": "^23.7.7",
         "jest": "^29.7.0",
-        "mapbox-gl": "^3.11.1",
+        "mapbox-gl": "^3.15.0",
         "prop-types": "^15.8.1",
         "qrcode": "^1.5.3",
         "react": "^18.2.0",
@@ -23472,10 +23474,15 @@
       "dev": true
     },
     "packages/map-template/node_modules/mapbox-gl": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.14.0.tgz",
-      "integrity": "sha512-KYhi9ZOQL4BB0J061admPH8O5ZZhhxsyiJ6DQCOkCaps0JEB4HF3SbJwu8S0pJKaQUxNS33sSbzW8iDSSauHPQ==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.15.0.tgz",
+      "integrity": "sha512-I42ffZpiXwt0PG3PO6gMYQnoz+AInkirLe/+zoHjcfBTFoFkKYtu5gFwT1WGeSvNrVTqG2Bwp9zUjPw0PFGY+w==",
       "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "workspaces": [
+        "src/style-spec",
+        "test/build/typings"
+      ],
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
         "@mapbox/mapbox-gl-supported": "^3.0.0",
@@ -23493,7 +23500,7 @@
         "csscolorparser": "~1.0.3",
         "earcut": "^3.0.1",
         "geojson-vt": "^4.0.2",
-        "gl-matrix": "^3.4.3",
+        "gl-matrix": "^3.4.4",
         "grid-index": "^1.1.0",
         "kdbush": "^4.0.2",
         "martinez-polygon-clipping": "^0.7.4",
@@ -25690,7 +25697,7 @@
         "eslint-plugin-react-hooks": "^4.6.2",
         "i18next": "^23.7.7",
         "jest": "^29.7.0",
-        "mapbox-gl": "^3.11.1",
+        "mapbox-gl": "^3.15.0",
         "prop-types": "^15.8.1",
         "qrcode": "^1.5.3",
         "react": "^18.2.0",
@@ -25739,9 +25746,9 @@
           "dev": true
         },
         "mapbox-gl": {
-          "version": "3.14.0",
-          "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.14.0.tgz",
-          "integrity": "sha512-KYhi9ZOQL4BB0J061admPH8O5ZZhhxsyiJ6DQCOkCaps0JEB4HF3SbJwu8S0pJKaQUxNS33sSbzW8iDSSauHPQ==",
+          "version": "3.15.0",
+          "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.15.0.tgz",
+          "integrity": "sha512-I42ffZpiXwt0PG3PO6gMYQnoz+AInkirLe/+zoHjcfBTFoFkKYtu5gFwT1WGeSvNrVTqG2Bwp9zUjPw0PFGY+w==",
           "dev": true,
           "requires": {
             "@mapbox/jsonlint-lines-primitives": "^2.0.2",
@@ -25760,7 +25767,7 @@
             "csscolorparser": "~1.0.3",
             "earcut": "^3.0.1",
             "geojson-vt": "^4.0.2",
-            "gl-matrix": "^3.4.3",
+            "gl-matrix": "^3.4.4",
             "grid-index": "^1.1.0",
             "kdbush": "^4.0.2",
             "martinez-polygon-clipping": "^0.7.4",
@@ -31279,7 +31286,9 @@
       "dev": true
     },
     "gl-matrix": {
-      "version": "3.4.3"
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ=="
     },
     "glob": {
       "version": "8.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23340,7 +23340,7 @@
     },
     "packages/components": {
       "name": "@mapsindoors/components",
-      "version": "13.28.2",
+      "version": "13.29.0",
       "license": "MIT",
       "dependencies": {
         "@11ty/eleventy": "^3.1.0",
@@ -23400,7 +23400,7 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.83.0",
+      "version": "1.84.0",
       "devDependencies": {
         "@googlemaps/js-api-loader": "^1.15.1",
         "@mapsindoors/components": "*",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "lerna": "^6.4.0"
   },
   "dependencies": {
-    "mapbox-gl": "3.8.0"
+    "mapbox-gl": "3.15.0"
   }
 }

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.84.1] - 2025-09-16
+
+### Fixed
+
+- Upgraded to Mapbox GL JS version 3.15.0.
+- Upgraded to Web SDK version 4.42.2.
+
 ## [1.84.0] - 2025-09-16
 
 ### Added

--- a/packages/map-template/package.json
+++ b/packages/map-template/package.json
@@ -24,7 +24,7 @@
     "eslint-plugin-react-hooks": "^4.6.2",
     "i18next": "^23.7.7",
     "jest": "^29.7.0",
-    "mapbox-gl": "^3.8.0",
+    "mapbox-gl": "^3.11.1",
     "prop-types": "^15.8.1",
     "qrcode": "^1.5.3",
     "react": "^18.2.0",

--- a/packages/map-template/package.json
+++ b/packages/map-template/package.json
@@ -24,7 +24,7 @@
     "eslint-plugin-react-hooks": "^4.6.2",
     "i18next": "^23.7.7",
     "jest": "^29.7.0",
-    "mapbox-gl": "^3.11.1",
+    "mapbox-gl": "^3.15.0",
     "prop-types": "^15.8.1",
     "qrcode": "^1.5.3",
     "react": "^18.2.0",

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -233,8 +233,8 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
 
             const miSdkApiTag = document.createElement('script');
             miSdkApiTag.setAttribute('type', 'text/javascript');
-            miSdkApiTag.setAttribute('src', 'https://app.mapsindoors.com/mapsindoors/js/sdk/4.42.0/mapsindoors-4.42.0.js.gz');
-            miSdkApiTag.setAttribute('integrity', 'sha384-K7OSiO1zZZKdjCQCKlzzLLcu3hz/532y8aKaQv44US4K7SZkKmXHrQSP+fqc9Lj0');
+            miSdkApiTag.setAttribute('src', 'https://app.mapsindoors.com/mapsindoors/js/sdk/4.42.2/mapsindoors-4.42.2.js.gz');
+            miSdkApiTag.setAttribute('integrity', 'sha384-gYbnh5YkNO6cKVUSbfz3M7DlHCe7rr2/MJHS5ltfrP+B4kU16uTko8NN697JCrsZ');
             miSdkApiTag.setAttribute('crossorigin', 'anonymous');
             document.body.appendChild(miSdkApiTag);
             miSdkApiTag.onload = () => {

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -17,7 +17,7 @@
         "eslint": "^8.39.0",
         "eslint-plugin-react": "^7.37.3",
         "eslint-plugin-react-hooks": "^5.1.0",
-        "mapbox-gl": "3.8.0",
+        "mapbox-gl": "3.15.0",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Mapbox GL to v3.15.0 across the project—may improve map rendering, performance, browser compatibility, and reduce console warnings.
  * Upgraded MapsIndoors SDK to a newer patch release—minor runtime/stability and asset loading improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->