### PR TITLE
Add kiosk specific styles 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23400,7 +23400,7 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.84.0",
+      "version": "1.84.1",
       "devDependencies": {
         "@googlemaps/js-api-loader": "^1.15.1",
         "@mapsindoors/components": "*",

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.85.0] - 2025-09-24
+
+### Added
+
+- Added horizontal category style for kiosk
+- Added functionality to switch between horizontal and vertical style categories for kiosks
+
 ## [1.84.1] - 2025-09-16
 
 ### Fixed

--- a/packages/map-template/src/components/Search/Categories/Categories.jsx
+++ b/packages/map-template/src/components/Search/Categories/Categories.jsx
@@ -15,6 +15,7 @@ import useOutsideMapsIndoorsDataClick from '../../../hooks/useOutsideMapsIndoors
 import mapsIndoorsInstanceState from '../../../atoms/mapsIndoorsInstanceState';
 import PropTypes from 'prop-types';
 import { ReactComponent as ChevronLeft } from '../../../assets/chevron-left.svg';
+import { useIsKioskContext } from '../../../hooks/useIsKioskContext';
 import { useTranslation } from 'react-i18next';
 
 Categories.propTypes = {
@@ -68,6 +69,11 @@ function Categories({ onSetSize, getFilteredLocations, searchFieldRef, isOpen, t
     const [selectedCategoryDisplayName, setSelectedCategoryDisplayName] = useState([])
 
     const { t } = useTranslation();
+
+    const isKiosk = useIsKioskContext();
+
+    // Determines the main container class for Categories, dictating the look for kiosk mode or desktop mode
+    const categoriesContainerClassName = `categories prevent-scroll${isKiosk ? ' categories--kiosk' : ''}`;
 
     /**
     * Communicate size change to parent component.
@@ -181,9 +187,10 @@ function Categories({ onSetSize, getFilteredLocations, searchFieldRef, isOpen, t
     }, [categories])
 
     return (
-        <div className="categories prevent-scroll" {...scrollableContentSwipePrevent}>
+        <div className={categoriesContainerClassName} {...scrollableContentSwipePrevent}>
             {categories.length > 0 && (
-                <div className="categories__list">
+                <>
+                    {/* Show nav above subcategories row if not topLevelCategory */}
                     {!topLevelCategory && (
                         <div className="categories__nav">
                             <button
@@ -196,27 +203,27 @@ function Categories({ onSetSize, getFilteredLocations, searchFieldRef, isOpen, t
                             <div>{selectedCategoryDisplayName}</div>
                         </div>
                     )}
+                    <div className="categories__list">
+                        {categoriesToShow.map(([category, categoryInfo]) => {
+                            if (!topLevelCategory && selectedCategoriesArray.current.length !== 1) {
+                                return null;
+                            }
 
-                    {categoriesToShow.map(([category, categoryInfo]) => {
-                        if (!topLevelCategory && selectedCategoriesArray.current.length !== 1) {
-                            return null;
-                        }
-
-                        return (
-                            <div key={category} className="categories__category">
-                                <button
-                                    onClick={() =>
-                                        topLevelCategory
+                            return (
+                                <div key={category} className="categories__category">
+                                    <button
+                                        onClick={() => topLevelCategory
                                             ? categoryClicked(category)
                                             : getFilteredLocations(category)
-                                    }>
-                                    <img src={categoryInfo.iconUrl} alt="" />
-                                    {categoryInfo.displayName}
-                                </button>
-                            </div>
-                        );
-                    })}
-                </div>
+                                        }>
+                                        <img src={categoryInfo.iconUrl} alt="" />
+                                        {categoryInfo.displayName}
+                                    </button>
+                                </div>
+                            );
+                        })}
+                    </div>
+                </>
             )}
         </div>
     );

--- a/packages/map-template/src/components/Search/Categories/Categories.jsx
+++ b/packages/map-template/src/components/Search/Categories/Categories.jsx
@@ -26,7 +26,8 @@ Categories.propTypes = {
     isOpen: PropTypes.bool,
     topLevelCategory: PropTypes.bool,
     handleBack: PropTypes.func,
-    selectedCategoriesArray: PropTypes.object
+    selectedCategoriesArray: PropTypes.object,
+    kioskOrientation: PropTypes.oneOf(['horizontal', 'vertical'])
 };
 
 /**
@@ -40,8 +41,9 @@ Categories.propTypes = {
  * @param {boolean} props.topLevelCategory - If true, renders top-level categories; otherwise, renders sub-categories.
  * @param {function} props.handleBack - Callback function to handle back navigation between categories.
  * @param {Array<string>} props.selectedCategoriesArray - Array containing selected categories (e.g., top-level and sub-category).
+ * @param {string} props.kioskOrientation - Orientation for kiosk mode: 'horizontal' or 'vertical'.
  */
-function Categories({ onSetSize, getFilteredLocations, searchFieldRef, isOpen, topLevelCategory, handleBack, selectedCategoriesArray }) {
+function Categories({ onSetSize, getFilteredLocations, searchFieldRef, isOpen, topLevelCategory, handleBack, selectedCategoriesArray, kioskOrientation }) {
 
     const categories = useRecoilValue(categoriesState);
 
@@ -88,7 +90,9 @@ function Categories({ onSetSize, getFilteredLocations, searchFieldRef, isOpen, t
     };
 
     // Determines the main container class for Categories, dictating the look for kiosk mode or desktop mode
-    const categoriesContainerClassName = `categories prevent-scroll${isKiosk ? ' categories--kiosk' : ''}`;
+    // Based on the kioskOrientation prop, it will apply different styles for horizontal or vertical layouts
+    // Default to horizontal if no orientation is provided
+    const categoriesContainerClassName = `categories prevent-scroll${isKiosk ? ` categories--kiosk-${kioskOrientation || 'vertical'}` : ''}`;
 
     /**
     * Communicate size change to parent component.
@@ -205,6 +209,11 @@ function Categories({ onSetSize, getFilteredLocations, searchFieldRef, isOpen, t
     // We don't show chevrons if we are at the end of the subcategory chain
     const atEndOfSubcategories = !topLevelCategory && categoriesToShow.length === 0;
 
+    // Determine if we should show chevrons (only in horizontal kiosk mode)
+    // Only visible in horizontal layout
+    // They do not render if we are at the end of the subcategory chain
+    const shouldShowChevrons = isKiosk && kioskOrientation === 'horizontal' && !atEndOfSubcategories;
+
     return (
         <div className={categoriesContainerClassName} {...scrollableContentSwipePrevent}>
             {categories.length > 0 && (
@@ -223,7 +232,7 @@ function Categories({ onSetSize, getFilteredLocations, searchFieldRef, isOpen, t
                         </div>
                     )}
                     <div className="categories__row">
-                        {isKiosk && !atEndOfSubcategories && (
+                        {shouldShowChevrons && (
                             <div className="categories__chevron categories__chevron--left">
                                 <button
                                     aria-label={t('Previous categories')}
@@ -253,7 +262,7 @@ function Categories({ onSetSize, getFilteredLocations, searchFieldRef, isOpen, t
                                 );
                             })}
                         </div>
-                        {isKiosk && !atEndOfSubcategories && (
+                        {shouldShowChevrons && (
                             <div className="categories__chevron categories__chevron--right">
                                 <button
                                     aria-label={t('Next categories')}

--- a/packages/map-template/src/components/Search/Categories/Categories.scss
+++ b/packages/map-template/src/components/Search/Categories/Categories.scss
@@ -8,7 +8,7 @@
     margin-top: var(--spacing-x-small);
 
     // Kiosk mode styles
-    &--kiosk {
+    &--kiosk-horizontal {
         .categories__row {
             display: flex;
             flex-direction: row;
@@ -65,6 +65,8 @@
             flex: 0 0 auto;
         }
     }
+
+    // Note: &--kiosk-vertical uses the default vertical styles defined in &__list and &__category
 
     &__list {
         display: flex;

--- a/packages/map-template/src/components/Search/Categories/Categories.scss
+++ b/packages/map-template/src/components/Search/Categories/Categories.scss
@@ -47,6 +47,11 @@
                     border-color: var(--tailwind-colors-gray-200);
                 }
 
+                &:disabled {
+                    opacity: 0.5;
+                    cursor: not-allowed;
+                }
+
                 svg {
                     width: var(--spacing-medium);
                     height: var(--spacing-medium);

--- a/packages/map-template/src/components/Search/Categories/Categories.scss
+++ b/packages/map-template/src/components/Search/Categories/Categories.scss
@@ -7,6 +7,25 @@
     gap: var(--spacing-x-small);
     margin-top: var(--spacing-x-small);
 
+    // Kiosk mode styles
+    &--kiosk {
+        .categories__list {
+            flex-direction: row;
+            gap: var(--spacing-large);
+            overflow-x: auto;
+            overflow-y: hidden;
+            scrollbar-width: auto;
+            justify-content: center;
+        }
+
+        .categories__list:not(:empty) {
+            padding: 0 var(--spacing-small) var(--spacing-small) var(--spacing-small);
+        }
+        .categories__category {
+            width: auto;
+        }
+    }
+
     &__list {
         display: flex;
         flex-direction: column;

--- a/packages/map-template/src/components/Search/Categories/Categories.scss
+++ b/packages/map-template/src/components/Search/Categories/Categories.scss
@@ -9,20 +9,60 @@
 
     // Kiosk mode styles
     &--kiosk {
-        .categories__list {
+        .categories__row {
+            display: flex;
             flex-direction: row;
-            gap: var(--spacing-large);
-            overflow-x: auto;
-            overflow-y: hidden;
-            scrollbar-width: auto;
-            justify-content: center;
+            align-items: center;
+            justify-content: space-between;
+            gap: var(--spacing-x-small);
         }
 
-        .categories__list:not(:empty) {
-            padding: 0 var(--spacing-small) var(--spacing-small) var(--spacing-small);
+        .categories__chevron {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            height: 100%;
+            flex: 0 0 auto;
+
+            &--left {
+                margin-right: auto;
+            }
+            &--right {
+                margin-left: auto;
+            }
+
+            button {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                border: 1px solid var(--color-gray-30);
+                border-radius: var(--spacing-x-small);
+                background: none;
+                cursor: pointer;
+                color: var(--color-gray-90);
+                padding: var(--spacing-medium);
+
+                &:hover {
+                    background-color: var(--tailwind-colors-gray-50);
+                    border-color: var(--tailwind-colors-gray-200);
+                }
+
+                svg {
+                    width: var(--spacing-medium);
+                    height: var(--spacing-medium);
+                }
+            }
         }
+
+        .categories__list {
+            flex-direction: row;
+            gap: var(--spacing-xx-small);
+            scrollbar-width: hidden;
+        }
+
         .categories__category {
             width: auto;
+            flex: 0 0 auto;
         }
     }
 

--- a/packages/map-template/src/components/Search/Search.jsx
+++ b/packages/map-template/src/components/Search/Search.jsx
@@ -607,7 +607,7 @@ function Search({ onSetSize, isOpen }) {
                     getFilteredLocations={(category) => getFilteredLocations(category)}
                     isOpen={!!selectedCategory}
                     topLevelCategory={true}
-                    kioskOrientation={areHorizontalCategoriesEnabled ? 'horizontal' : 'vertical'}
+                    categoryOrientation={areHorizontalCategoriesEnabled ? 'horizontal' : 'vertical'}
                 />
             )}
 
@@ -627,7 +627,7 @@ function Search({ onSetSize, isOpen }) {
                             childKeys={childKeys}
                             topLevelCategory={false}
                             selectedCategoriesArray={selectedCategoriesArray}
-                            kioskOrientation={areHorizontalCategoriesEnabled ? 'horizontal' : 'vertical'}
+                            categoryOrientation={areHorizontalCategoriesEnabled ? 'horizontal' : 'vertical'}
                         />
                     )}
 

--- a/packages/map-template/src/components/Search/Search.jsx
+++ b/packages/map-template/src/components/Search/Search.jsx
@@ -123,7 +123,7 @@ function Search({ onSetSize, isOpen }) {
 
     const [childKeys, setChildKeys] = useState([]);
 
-    const [showCategoriesUnderSearch, setShowCategoriesUnderSearch] = useState(false);
+    const [areHorizontalCategoriesEnabled, setAreHorizontalCategoriesEnabled] = useState(false);
 
     /**
      * Handles go back function.
@@ -404,7 +404,9 @@ function Search({ onSetSize, isOpen }) {
      * @returns {boolean} True if in kiosk context and showCategoriesUnderSearch is enabled, otherwise false.
      */
     function shouldShowCategoriesUnderSearch() {
-        return isKioskContext && showCategoriesUnderSearch;
+        // We determine wether to show categories horizontally or vertically based on the areHorizontalCategoriesEnabled setting.
+        // Each layout has different styling and thus needs to be treated as separate options.
+        return isKioskContext && areHorizontalCategoriesEnabled;
     }
 
     /*
@@ -566,7 +568,7 @@ function Search({ onSetSize, isOpen }) {
      * Get app config and determine if categories should be shown under the search field in kiosk mode.
      */
     useEffect(() => {
-        setShowCategoriesUnderSearch(appConfig?.appSettings?.showCategoriesUnderSearch === true || appConfig?.appSettings?.showCategoriesUnderSearch === 'true');
+        setAreHorizontalCategoriesEnabled(appConfig?.appSettings?.areHorizontalCategoriesEnabled === true || appConfig?.appSettings?.areHorizontalCategoriesEnabled === 'true');
     }, [appConfig]);
 
 
@@ -605,6 +607,7 @@ function Search({ onSetSize, isOpen }) {
                     getFilteredLocations={(category) => getFilteredLocations(category)}
                     isOpen={!!selectedCategory}
                     topLevelCategory={true}
+                    kioskOrientation={areHorizontalCategoriesEnabled ? 'horizontal' : 'vertical'}
                 />
             )}
 
@@ -624,6 +627,7 @@ function Search({ onSetSize, isOpen }) {
                             childKeys={childKeys}
                             topLevelCategory={false}
                             selectedCategoriesArray={selectedCategoriesArray}
+                            kioskOrientation={areHorizontalCategoriesEnabled ? 'horizontal' : 'vertical'}
                         />
                     )}
 

--- a/packages/map-template/src/components/Search/Search.jsx
+++ b/packages/map-template/src/components/Search/Search.jsx
@@ -1,6 +1,7 @@
 import './Search.scss';
 import { useRef, useState, useEffect } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
+import appConfigState from '../../atoms/appConfigState';
 import categoriesState from '../../atoms/categoriesState';
 import currentVenueNameState from '../../atoms/currentVenueNameState';
 import { snapPoints } from '../../constants/snapPoints';
@@ -51,6 +52,7 @@ Search.propTypes = {
  * @returns
  */
 function Search({ onSetSize, isOpen }) {
+    const appConfig = useRecoilValue(appConfigState);
 
     const { t } = useTranslation();
 
@@ -120,6 +122,8 @@ function Search({ onSetSize, isOpen }) {
     const selectedCategoriesArray = useRef([]);
 
     const [childKeys, setChildKeys] = useState([]);
+
+    const [showCategoriesUnderSearch, setShowCategoriesUnderSearch] = useState(false);
 
     /**
      * Handles go back function.
@@ -394,6 +398,15 @@ function Search({ onSetSize, isOpen }) {
         }
     }
 
+    /**
+     * Determines if categories should be shown under the search field in kiosk mode.
+     *
+     * @returns {boolean} True if in kiosk context and showCategoriesUnderSearch is enabled, otherwise false.
+     */
+    function shouldShowCategoriesUnderSearch() {
+        return isKioskContext && showCategoriesUnderSearch;
+    }
+
     /*
      * Monitors clicks to manage sheet size and input focus state
      */
@@ -547,7 +560,14 @@ function Search({ onSetSize, isOpen }) {
     useEffect(() => {
         const childKeys = categories.find(([key]) => key === selectedCategory)?.[1]?.childKeys || [];
         setChildKeys(childKeys)
-    }, [categories, selectedCategory])
+    }, [categories, selectedCategory]);
+
+    /*
+     * Get app config and determine if categories should be shown under the search field in kiosk mode.
+     */
+    useEffect(() => {
+        setShowCategoriesUnderSearch(appConfig?.appSettings?.showCategoriesUnderSearch === true || appConfig?.appSettings?.showCategoriesUnderSearch === 'true');
+    }, [appConfig]);
 
 
     return (
@@ -577,8 +597,8 @@ function Search({ onSetSize, isOpen }) {
             </div>
 
             {/* Vertical list of Categories */}
-            {/* Show full category list only when searchResults are empty */}
-            {isInputFieldInFocus && !showNotFoundMessage && categories.length > 0 && searchResults.length === 0 && (
+            {/* Show full category list if (kiosk mode and showCategoriesUnderSearch is true) OR input is in focus, and only when searchResults are empty */}
+            {(shouldShowCategoriesUnderSearch() || isInputFieldInFocus) && !showNotFoundMessage && categories.length > 0 && searchResults.length === 0 && (
                 <Categories
                     onSetSize={onSetSize}
                     searchFieldRef={searchFieldRef}


### PR DESCRIPTION
## What:

Categories can now shown under the search field if (1) kiosk mode is active and the app config option is enabled, or (2) the search input is in focus, and only when there are no search results.

##How:

Introduced a helper function, shouldShowCategoriesUnderSearch, to encapsulate the kiosk/config logic.
Updated the conditional rendering in the JSX to use shouldShowCategoriesUnderSearch() or isInputFieldInFocus.
Renamed the function and all usages for clarity and React best practices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Kiosk mode: categories can appear under search and switch between horizontal/vertical via app settings; horizontal mode supports left/right chevrons with accessible labels and scroll behavior.
  - Category items display icons alongside names and preserve selection/filter behavior.

- **Style**
  - Added kiosk-specific styling for horizontal rows, chevrons, spacing, and hidden scrollbar.

- **Refactor**
  - Reworked category layout and search display logic for kiosk flows and clearer subcategory navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->