### PR TITLE
Fix/qr code in directions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25955,7 +25955,7 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.97.0",
+      "version": "1.97.2",
       "dependencies": {
         "@mapsindoors/components": "*",
         "@mapsindoors/css": "^3.0.0",

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.97.3] - 2026-04-10
+
+### Fixed
+
+- **Kiosk QR dialog (desktop)**: Clear `qrCodeLink` when directions closes or route data is cleared in kiosk mode, so the overlay does not remain visible after reset.
+
 ## [1.97.2] - 2026-04-09
 
 ### Fixed

--- a/packages/map-template/src/components/Directions/Directions.jsx
+++ b/packages/map-template/src/components/Directions/Directions.jsx
@@ -204,11 +204,22 @@ function Directions({ isOpen, onBack, onSetSize, onRouteFinished }) {
      * Make sure directions stop rendering on the map when the Directions view is not active anymore.
      */
     useEffect(() => {
-        if (!isOpen && directionsRenderer) {
-            stopRendering();
-            setMinZoom(appConfig?.appSettings?.minZoom ?? ZoomLevelValues.minZoom);
+        if (!isOpen) {
+            if (isKioskContext) {
+                setQRCodeLink(null);
+            }
+            if (directionsRenderer) {
+                stopRendering();
+                setMinZoom(appConfig?.appSettings?.minZoom ?? ZoomLevelValues.minZoom);
+            }
         }
-    }, [isOpen, appConfig]);
+    }, [isOpen, appConfig, setQRCodeLink, isKioskContext]);
+
+    useEffect(() => {
+        if (isKioskContext && !directions) {
+            setQRCodeLink(null);
+        }
+    }, [directions, isKioskContext, setQRCodeLink]);
 
 
     /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed desktop kiosk QR dialog overlay remaining visible after directions close or kiosk-mode route data is cleared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->