### PR TITLE
Feat/disable right click is kiosk mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25955,7 +25955,7 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.97.3",
+      "version": "1.97.4",
       "dependencies": {
         "@mapsindoors/components": "*",
         "@mapsindoors/css": "^3.0.0",

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.97.5] - 2026-04-14
+
+### Added
+
+- Right click can be now disabled via App Config object.
+
 ## [1.97.4] - 2026-04-13
 
 ### Fixed

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Right click can be now disabled via App Config object.
+- **Kiosk right-click protection**: Added support for disabling right-click in kiosk mode via the App Config object using `appSettings.disableRightClick`. When enabled, the template prevents the browser context menu at runtime and disables text selection/touch callouts in the kiosk wrapper.
+
+### Fixed
+
+- **Kiosk right-click handling**: Added kiosk-level runtime event listeners for `contextmenu`, `mousedown`, `pointerdown`, and `auxclick` when `disableRightClick` is enabled, making right-click prevention more consistent across interactive elements and browsers.
 
 ## [1.97.4] - 2026-04-13
 

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -227,6 +227,7 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
 
     const mapType = useRecoilValue(mapTypeState);
     const isKiosk = useIsKioskContext();
+    const disableRightClick = isKiosk && (appConfig?.appSettings?.disableRightClick === true || appConfig?.appSettings?.disableRightClick === 'true');
 
     /**
      * Ensure that MapsIndoors Web SDK is available.
@@ -738,6 +739,26 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
         }
     }, [useAppTitle, appConfig])
 
+    /*
+     * In kiosk mode, optionally block the browser context menu to reduce the
+     * chance of users navigating away from the application shell.
+     */
+    useEffect(() => {
+        if (!disableRightClick) {
+            return;
+        }
+
+        const preventContextMenu = (event) => {
+            event.preventDefault();
+        };
+
+        document.addEventListener('contextmenu', preventContextMenu, true);
+
+        return () => {
+            document.removeEventListener('contextmenu', preventContextMenu, true);
+        };
+    }, [disableRightClick]);
+
     /**
      * When map position is known while initializing the data,
      * set map to be ready.
@@ -825,6 +846,7 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
             ${(venuesInSolution.length > 1 && showVenueSelector) ? '' : 'mapsindoors-map--hide-venue-selector'}
             ${showPositionControl ? 'mapsindoors-map--show-my-position' : 'mapsindoors-map--hide-my-position'}
             ${isKiosk ? 'mapsindoors-map--kiosk' : ''}
+            ${disableRightClick ? 'mapsindoors-map--disable-right-click' : ''}
             ${(currentAppView === appStates.CHAT && !isDesktop) ? 'mapsindoors-map--hide-map-controls' : ''}`}>
                 <Notification />
                 {!isMapReady && <SplashScreen />}

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -749,13 +749,27 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
         }
 
         const preventContextMenu = (event) => {
+            event.stopPropagation();
             event.preventDefault();
         };
 
+        const preventSecondaryAction = (event) => {
+            if (event.button === 2) {
+                event.stopPropagation();
+                event.preventDefault();
+            }
+        };
+
         document.addEventListener('contextmenu', preventContextMenu, true);
+        document.addEventListener('mousedown', preventSecondaryAction, true);
+        document.addEventListener('pointerdown', preventSecondaryAction, true);
+        document.addEventListener('auxclick', preventSecondaryAction, true);
 
         return () => {
             document.removeEventListener('contextmenu', preventContextMenu, true);
+            document.removeEventListener('mousedown', preventSecondaryAction, true);
+            document.removeEventListener('pointerdown', preventSecondaryAction, true);
+            document.removeEventListener('auxclick', preventSecondaryAction, true);
         };
     }, [disableRightClick]);
 

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.scss
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.scss
@@ -75,6 +75,17 @@
         }
     }
 
+    &--disable-right-click {
+        -webkit-touch-callout: none;
+
+        * {
+            -webkit-user-select: none;
+            -moz-user-select: none;
+            -ms-user-select: none;
+            user-select: none;
+        }
+    }
+
     .mi-floor-selector__list {
         box-sizing: unset;
     }

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.scss
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.scss
@@ -84,6 +84,13 @@
             -ms-user-select: none;
             user-select: none;
         }
+
+        button:disabled,
+        input:disabled,
+        select:disabled,
+        textarea:disabled {
+            pointer-events: none;
+        }
     }
 
     .mi-floor-selector__list {

--- a/packages/map-template/src/components/Search/Categories/Categories.scss
+++ b/packages/map-template/src/components/Search/Categories/Categories.scss
@@ -50,6 +50,7 @@
                 &:disabled {
                     opacity: 0.5;
                     cursor: not-allowed;
+                    pointer-events: none;
                 }
 
                 svg {

--- a/packages/map-template/src/components/Search/Categories/Categories.scss
+++ b/packages/map-template/src/components/Search/Categories/Categories.scss
@@ -50,7 +50,6 @@
                 &:disabled {
                     opacity: 0.5;
                     cursor: not-allowed;
-                    pointer-events: none;
                 }
 
                 svg {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Option to disable the browser right-click context menu in kiosk mode via app settings
  * Kiosk mode can prevent touch callouts and text selection for stricter interaction control
  * Configuration accepts boolean and string values for flexibility

* **Style**
  * Disabled kiosk chevron buttons now ignore pointer events to prevent interaction when disabled

* **Documentation**
  * Changelog updated with the new kiosk setting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->