### PR TITLE
fix: ui change for locations scroll which was not working

### DIFF
--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.97.8] - 2026-04-30
+
+### Fixed
+
+- **Locations list scroll**: Restored scrolling in the locations list and made the list header sticky at the top while scrolling. Removed the unused `__scrollable` modifier and the redundant `overflow: auto` on `__list`.
+
 ## [1.97.7] - 2026-04-30
 
 ### Changed

--- a/packages/map-template/src/components/LocationsList/LocationsList.scss
+++ b/packages/map-template/src/components/LocationsList/LocationsList.scss
@@ -3,9 +3,14 @@
 .locations-list {
     display: grid;
     grid-template-rows: 50px 1fr;
+    
 
-    &__header {
+      &__header {
         padding: var(--spacing-medium);
+        position: sticky;
+        top: 0;
+        z-index: 1;
+        background-color: var(--color-white-white);
     }
 
     &__title {
@@ -26,13 +31,8 @@
     &__list {
         display: grid;
         gap: var(--spacing-x-small);
-        overflow: auto;
         grid-auto-rows: min-content;
         padding: var(--spacing-x-small);
-    }
-
-    &__scrollable {
-        overflow: auto;
     }
 
     @media (max-width: variables.$desktop-breakpoint) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Locations list header now remains visible (sticky) at the top while scrolling, improving navigation and readability.
* **Bug Fixes**
  * Restored consistent scrolling behavior for the locations list by simplifying conflicting styles, preventing visual overlap and ensuring stable header/background rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->