### PR TITLE
feat: button to share route

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25148,7 +25148,7 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.98.0",
+      "version": "1.98.1",
       "dependencies": {
         "@mapsindoors/components": "*",
         "@mapsindoors/css": "^3.0.0",

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added a Share Route button to the Wayfinding panel. Triggers the native share sheet on mobile and copies the route link to the clipboard on desktop.
+
 ## [1.98.1] - 2026-05-13
 
 ### Added

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added a Share Route button to the Wayfinding panel. Triggers the native share sheet on mobile and copies the route link to the clipboard on desktop.
+- Added a Share Route button to the Wayfinding panel. Configurable via app settings, hidden when iframed, and falls back to copying the link when the native share sheet is unavailable.
 
 ## [1.98.1] - 2026-05-13
 

--- a/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
+++ b/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
@@ -38,6 +38,11 @@ import PropTypes from 'prop-types';
 import wayfindingLocationState from '../../atoms/wayfindingLocation';
 import appConfigState from '../../atoms/appConfigState';
 import mapsIndoorsInstanceState from '../../atoms/mapsIndoorsInstanceState';
+import ShareIcon from '../../assets/share.svg?react';
+import { useIsDesktop } from '../../hooks/useIsDesktop';
+import apiKeyState from '../../atoms/apiKeyState';
+import kioskLocationState from '../../atoms/kioskLocationState';
+import supportsUrlParametersState from '../../atoms/supportsUrlParametersState';
 
 const searchFieldIdentifiers = {
     TO: 'TO',
@@ -123,6 +128,10 @@ function Wayfinding({ onStartDirections, onBack, directionsToLocation, direction
 
     const appConfig = useRecoilValue(appConfigState);
     const mapsIndoorsInstance = useRecoilValue(mapsIndoorsInstanceState);
+    const apiKey = useRecoilValue(apiKeyState);
+    const kioskLocation = useRecoilValue(kioskLocationState);
+    const supportsUrlParameters = useRecoilValue(supportsUrlParametersState);
+    const isDesktop = useIsDesktop();
 
     /**
      * Decorates location with data that is required for wayfinding to work.
@@ -351,6 +360,16 @@ function Wayfinding({ onStartDirections, onBack, directionsToLocation, direction
         setShowMyPositionOption(false);
     }
 
+    function shareRoute() {
+        const base = `${window.location.origin}${window.location.pathname.replace(/\/$/, '')}`;
+        const url = `${base}?apiKey=${apiKey}&directionsFrom=${originLocation.id}&directionsTo=${destinationLocation.id}`;
+        if (!isDesktop && typeof navigator.share === 'function') {
+            navigator.share({ url });
+        } else {
+            navigator.clipboard.writeText(url);
+        }
+    }
+
     useEffect(() => {
         return () => {
             setSearchResults([]);
@@ -527,6 +546,16 @@ function Wayfinding({ onStartDirections, onBack, directionsToLocation, direction
                                 {t('Bike')}
                             </mi-dropdown-item>
                         </Dropdown>}
+                        {!kioskLocation && supportsUrlParameters && (
+                            <button
+                                className="wayfinding__share"
+                                onClick={() => shareRoute()}
+                                title={t('Share')}
+                                aria-label={t('Share')}
+                            >
+                                <ShareIcon />
+                            </button>
+                        )}
                     </div>
                 </div>
                 <hr></hr>

--- a/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
+++ b/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
@@ -42,7 +42,6 @@ import ShareIcon from '../../assets/share.svg?react';
 import { useIsDesktop } from '../../hooks/useIsDesktop';
 import apiKeyState from '../../atoms/apiKeyState';
 import kioskLocationState from '../../atoms/kioskLocationState';
-import supportsUrlParametersState from '../../atoms/supportsUrlParametersState';
 
 const searchFieldIdentifiers = {
     TO: 'TO',
@@ -130,7 +129,6 @@ function Wayfinding({ onStartDirections, onBack, directionsToLocation, direction
     const mapsIndoorsInstance = useRecoilValue(mapsIndoorsInstanceState);
     const apiKey = useRecoilValue(apiKeyState);
     const kioskLocation = useRecoilValue(kioskLocationState);
-    const supportsUrlParameters = useRecoilValue(supportsUrlParametersState);
     const isDesktop = useIsDesktop();
 
     /**
@@ -546,7 +544,7 @@ function Wayfinding({ onStartDirections, onBack, directionsToLocation, direction
                                 {t('Bike')}
                             </mi-dropdown-item>
                         </Dropdown>}
-                        {!kioskLocation && supportsUrlParameters && (
+                        {!kioskLocation && appConfig?.appSettings?.enableWayfindingShareButton === 'true' && (
                             <button
                                 className="wayfinding__share"
                                 onClick={() => shareRoute()}

--- a/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
+++ b/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
@@ -629,8 +629,7 @@ function Wayfinding({ onStartDirections, onBack, directionsToLocation, direction
                             && !kioskLocation
                             && supportsUrlParameters
                             && (canShare || canCopy)
-                            // TEMP: bypass app-setting gate for local testing — restore before commit
-                            // && appConfig?.appSettings?.enableWayfindingShareButton === 'true'
+                            && appConfig?.appSettings?.enableWayfindingShareButton === 'true'
                             && (
                             <button
                                 className="wayfinding__share"

--- a/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
+++ b/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
@@ -407,7 +407,16 @@ function Wayfinding({ onStartDirections, onBack, directionsToLocation, direction
      */
     function shareRoute() {
         const base = `${window.location.origin}${window.location.pathname.replace(/\/$/, '')}`;
-        const url = `${base}?apiKey=${apiKey}&directionsFrom=${originLocation.id}&directionsTo=${destinationLocation.id}`;
+        const params = new URLSearchParams({
+            directionsFrom: originLocation.id,
+            directionsTo: destinationLocation.id
+        });
+
+        if (apiKey) {
+            params.set('apiKey', apiKey);
+        }
+
+        const url = `${base}?${params.toString()}`;
 
         if (canShare && prefersShareSheet) {
             navigator.share({ url }).catch((err) => {

--- a/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
+++ b/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
@@ -39,9 +39,11 @@ import wayfindingLocationState from '../../atoms/wayfindingLocation';
 import appConfigState from '../../atoms/appConfigState';
 import mapsIndoorsInstanceState from '../../atoms/mapsIndoorsInstanceState';
 import ShareIcon from '../../assets/share.svg?react';
-import { useIsDesktop } from '../../hooks/useIsDesktop';
 import apiKeyState from '../../atoms/apiKeyState';
 import kioskLocationState from '../../atoms/kioskLocationState';
+import supportsUrlParametersState from '../../atoms/supportsUrlParametersState';
+import notificationMessageState from '../../atoms/notificationMessageState';
+import useMediaQuery from '../../hooks/useMediaQuery';
 
 const searchFieldIdentifiers = {
     TO: 'TO',
@@ -129,7 +131,22 @@ function Wayfinding({ onStartDirections, onBack, directionsToLocation, direction
     const mapsIndoorsInstance = useRecoilValue(mapsIndoorsInstanceState);
     const apiKey = useRecoilValue(apiKeyState);
     const kioskLocation = useRecoilValue(kioskLocationState);
-    const isDesktop = useIsDesktop();
+    const supportsUrlParameters = useRecoilValue(supportsUrlParametersState);
+    const setNotificationMessage = useSetRecoilState(notificationMessageState);
+
+    // Capability flags for the Share Route button. Checked at render time so the
+    // button is hidden when neither API is available (e.g. insecure context,
+    // iframe without `web-share`/`clipboard-write` Permissions Policy delegation).
+    const canShare = typeof navigator.share === 'function';
+    const canCopy = typeof navigator.clipboard?.writeText === 'function';
+
+    // Pointer-type heuristic for choosing between the native share sheet and
+    // clipboard copy when both are available. Touch-primary devices (phones,
+    // tablets) report `pointer: coarse` and benefit from the OS share sheet.
+    // Desktops with mice/trackpads report `pointer: fine`; copy-to-clipboard
+    // is the more idiomatic affordance there, even when `navigator.share`
+    // exists (e.g. Chromium-based desktops like Vivaldi/Chrome/Edge).
+    const prefersShareSheet = useMediaQuery('(pointer: coarse)');
 
     /**
      * Decorates location with data that is required for wayfinding to work.
@@ -358,13 +375,42 @@ function Wayfinding({ onStartDirections, onBack, directionsToLocation, direction
         setShowMyPositionOption(false);
     }
 
+    /**
+     * Write the given URL to the clipboard and show a confirmation toast only
+     * after the write actually resolves. A rejection (cross-origin iframe
+     * without `clipboard-write`, denied permission, etc.) is swallowed so we
+     * don't surface a false success.
+     */
+    function copyToClipboardWithFeedback(url) {
+        navigator.clipboard.writeText(url).then(
+            () => setNotificationMessage({ text: t('Link copied'), type: 'success', sticky: false }),
+            () => { /* write rejected — do not show success */ }
+        );
+    }
+
+    /**
+     * Share the current route. Routes to the native share sheet on touch
+     * devices (`pointer: coarse`) and to clipboard copy on pointer-fine
+     * devices like desktops, even when `navigator.share` is available. Web
+     * Share rejections are discriminated: `AbortError` means the user
+     * cancelled and we leave the clipboard alone; any other rejection (e.g.
+     * Permissions Policy block in an iframe) falls back to clipboard.
+     */
     function shareRoute() {
         const base = `${window.location.origin}${window.location.pathname.replace(/\/$/, '')}`;
         const url = `${base}?apiKey=${apiKey}&directionsFrom=${originLocation.id}&directionsTo=${destinationLocation.id}`;
-        if (!isDesktop && typeof navigator.share === 'function') {
-            navigator.share({ url });
-        } else {
-            navigator.clipboard.writeText(url);
+
+        if (canShare && prefersShareSheet) {
+            navigator.share({ url }).catch((err) => {
+                if (err?.name !== 'AbortError' && canCopy) {
+                    copyToClipboardWithFeedback(url);
+                }
+            });
+        } else if (canCopy) {
+            copyToClipboardWithFeedback(url);
+        } else if (canShare) {
+            // No clipboard available — last resort, use the share sheet even on pointer-fine devices.
+            navigator.share({ url }).catch(() => {});
         }
     }
 
@@ -544,12 +590,17 @@ function Wayfinding({ onStartDirections, onBack, directionsToLocation, direction
                                 {t('Bike')}
                             </mi-dropdown-item>
                         </Dropdown>}
-                        {!kioskLocation && appConfig?.appSettings?.enableWayfindingShareButton === 'true' && (
+                        {!kioskLocation
+                            && supportsUrlParameters
+                            && (canShare || canCopy)
+                            // TEMP: bypass app-setting gate for local testing — restore before commit
+                            // && appConfig?.appSettings?.enableWayfindingShareButton === 'true'
+                            && (
                             <button
                                 className="wayfinding__share"
                                 onClick={() => shareRoute()}
-                                title={t('Share')}
-                                aria-label={t('Share')}
+                                title={t('Share route')}
+                                aria-label={t('Share route')}
                             >
                                 <ShareIcon />
                             </button>

--- a/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
+++ b/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
@@ -418,8 +418,16 @@ function Wayfinding({ onStartDirections, onBack, directionsToLocation, direction
 
         const url = `${base}?${params.toString()}`;
 
+        const originName = originLocation.properties?.name ?? '';
+        const destinationName = destinationLocation.properties?.name ?? '';
+        const sharePayload = {
+            title: t('Share route'),
+            text: originName && destinationName ? `${originName} → ${destinationName}` : undefined,
+            url,
+        };
+
         if (canShare && prefersShareSheet) {
-            navigator.share({ url }).catch((err) => {
+            navigator.share(sharePayload).catch((err) => {
                 if (err?.name !== 'AbortError' && canCopy) {
                     copyToClipboardWithFeedback(url);
                 }
@@ -428,7 +436,7 @@ function Wayfinding({ onStartDirections, onBack, directionsToLocation, direction
             copyToClipboardWithFeedback(url);
         } else if (canShare) {
             // No clipboard available — last resort, use the share sheet even on pointer-fine devices.
-            navigator.share({ url }).catch(() => {});
+            navigator.share(sharePayload).catch(() => {});
         }
     }
 
@@ -618,7 +626,6 @@ function Wayfinding({ onStartDirections, onBack, directionsToLocation, direction
                             <button
                                 className="wayfinding__share"
                                 onClick={() => shareRoute()}
-                                title={t('Share route')}
                                 aria-label={t('Share route')}
                             >
                                 <ShareIcon />

--- a/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
+++ b/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
@@ -50,6 +50,16 @@ const searchFieldIdentifiers = {
     FROM: 'FROM'
 };
 
+// The embedding context is fixed for the lifetime of this document; changing
+// from framed to top-level requires navigation/reload, so no React state is needed.
+const isEmbedded = (() => {
+    try {
+        return window.self !== window.top;
+    } catch {
+        return true;
+    }
+})();
+
 const externalLocationIcon = 'data:image/svg+xml,%3Csvg width=\'10\' height=\'10\' viewBox=\'0 0 14 20\' fill=\'none\' xmlns=\'http://www.w3.org/2000/svg\'%3E%3Cpath d=\'M7 0C3.13 0 0 3.13 0 7C0 12.25 7 20 7 20C7 20 14 12.25 14 7C14 3.13 10.87 0 7 0ZM7 9.5C5.62 9.5 4.5 8.38 4.5 7C4.5 5.62 5.62 4.5 7 4.5C8.38 4.5 9.5 5.62 9.5 7C9.5 8.38 8.38 9.5 7 9.5Z\' fill=\'black\' fill-opacity=\'0.88\'/%3E%3C/svg%3E%0A'
 
 Wayfinding.propTypes = {
@@ -134,9 +144,8 @@ function Wayfinding({ onStartDirections, onBack, directionsToLocation, direction
     const supportsUrlParameters = useRecoilValue(supportsUrlParametersState);
     const setNotificationMessage = useSetRecoilState(notificationMessageState);
 
-    // Capability flags for the Share Route button. Checked at render time so the
-    // button is hidden when neither API is available (e.g. insecure context,
-    // iframe without `web-share`/`clipboard-write` Permissions Policy delegation).
+    // API availability checks only. Framed embeds are gated separately because
+    // browser Permissions Policy can still block share/copy at call time.
     const canShare = typeof navigator.share === 'function';
     const canCopy = typeof navigator.clipboard?.writeText === 'function';
 
@@ -590,7 +599,8 @@ function Wayfinding({ onStartDirections, onBack, directionsToLocation, direction
                                 {t('Bike')}
                             </mi-dropdown-item>
                         </Dropdown>}
-                        {!kioskLocation
+                        {!isEmbedded
+                            && !kioskLocation
                             && supportsUrlParameters
                             && (canShare || canCopy)
                             // TEMP: bypass app-setting gate for local testing — restore before commit

--- a/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
+++ b/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
@@ -44,6 +44,11 @@ import kioskLocationState from '../../atoms/kioskLocationState';
 import supportsUrlParametersState from '../../atoms/supportsUrlParametersState';
 import notificationMessageState from '../../atoms/notificationMessageState';
 import useMediaQuery from '../../hooks/useMediaQuery';
+import {
+    buildRouteShareUrl,
+    shareRouteResults,
+    shareRouteWithFallback
+} from './shareRouteHelpers';
 
 const searchFieldIdentifiers = {
     TO: 'TO',
@@ -95,6 +100,7 @@ function Wayfinding({ onStartDirections, onBack, directionsToLocation, direction
 
     const toFieldRef = useRef();
     const fromFieldRef = useRef();
+    const sharingInProgressRef = useRef(false);
 
     const directionsService = useRecoilValue(directionsServiceState);
     const userPosition = useRecoilValue(userPositionState);
@@ -104,6 +110,7 @@ function Wayfinding({ onStartDirections, onBack, directionsToLocation, direction
     const [wayfindingLocation, setWayfindingLocation] = useRecoilState(wayfindingLocationState);
 
     const [activeSearchField, setActiveSearchField] = useState();
+    const [isSharing, setIsSharing] = useState(false);
 
     /** Indicate if a route has been found */
     const setHasFoundRoute = useSetRecoilState(hasFoundRouteState);
@@ -285,7 +292,7 @@ function Wayfinding({ onStartDirections, onBack, directionsToLocation, direction
         setHasFoundRoute(true);
         setHasGooglePlaces(false);
         showMyPositionOptionButton(searchFieldIdentifier);
-        
+
         // Don't clear selection pins here - keep destination visible until route is created
     }
 
@@ -365,12 +372,12 @@ function Wayfinding({ onStartDirections, onBack, directionsToLocation, direction
     function closeWayfinding() {
         setOriginLocation();
         fromFieldRef.current?.setDisplayText('');
-        
+
         // Clear selection when routing dialog closes (SDK recommendation)
         if (mapsIndoorsInstance) {
             mapsIndoorsInstance.deselectLocation();
         }
-        
+
         onBack();
     }
 
@@ -384,59 +391,61 @@ function Wayfinding({ onStartDirections, onBack, directionsToLocation, direction
         setShowMyPositionOption(false);
     }
 
-    /**
-     * Write the given URL to the clipboard and show a confirmation toast only
-     * after the write actually resolves. A rejection (cross-origin iframe
-     * without `clipboard-write`, denied permission, etc.) is swallowed so we
-     * don't surface a false success.
-     */
-    function copyToClipboardWithFeedback(url) {
-        navigator.clipboard.writeText(url).then(
-            () => setNotificationMessage({ text: t('Link copied'), type: 'success', sticky: false }),
-            () => { /* write rejected — do not show success */ }
-        );
+    function showCopiedMessage() {
+        setNotificationMessage({ text: t('Link copied'), type: 'success', sticky: false });
+    }
+
+    function showShareFailedMessage() {
+        setNotificationMessage({ text: t('Could not share route'), type: 'error', sticky: false });
     }
 
     /**
      * Share the current route. Routes to the native share sheet on touch
      * devices (`pointer: coarse`) and to clipboard copy on pointer-fine
-     * devices like desktops, even when `navigator.share` is available. Web
-     * Share rejections are discriminated: `AbortError` means the user
-     * cancelled and we leave the clipboard alone; any other rejection (e.g.
-     * Permissions Policy block in an iframe) falls back to clipboard.
+     * devices like desktops, even when `navigator.share` is available. Native
+     * share success and cancellation stay silent; native share failures fall
+     * back to clipboard copy. Clipboard copy success shows a notification, and
+     * terminal failures show an error notification.
      */
-    function shareRoute() {
-        const base = `${window.location.origin}${window.location.pathname.replace(/\/$/, '')}`;
-        const params = new URLSearchParams({
-            directionsFrom: originLocation.id,
-            directionsTo: destinationLocation.id
-        });
+    async function shareRoute() {
+        if (sharingInProgressRef.current) return;
 
-        if (apiKey) {
-            params.set('apiKey', apiKey);
-        }
+        sharingInProgressRef.current = true;
+        setIsSharing(true);
 
-        const url = `${base}?${params.toString()}`;
-
-        const originName = originLocation.properties?.name ?? '';
-        const destinationName = destinationLocation.properties?.name ?? '';
-        const sharePayload = {
-            title: t('Share route'),
-            text: originName && destinationName ? `${originName} → ${destinationName}` : undefined,
-            url,
-        };
-
-        if (canShare && prefersShareSheet) {
-            navigator.share(sharePayload).catch((err) => {
-                if (err?.name !== 'AbortError' && canCopy) {
-                    copyToClipboardWithFeedback(url);
-                }
+        try {
+            const base = `${window.location.origin}${window.location.pathname.replace(/\/$/, '')}`;
+            const url = buildRouteShareUrl({
+                base,
+                apiKey,
+                originId: originLocation.id,
+                destinationId: destinationLocation.id
             });
-        } else if (canCopy) {
-            copyToClipboardWithFeedback(url);
-        } else if (canShare) {
-            // No clipboard available — last resort, use the share sheet even on pointer-fine devices.
-            navigator.share(sharePayload).catch(() => {});
+
+            const originName = originLocation.properties?.name ?? '';
+            const destinationName = destinationLocation.properties?.name ?? '';
+            const sharePayload = {
+                title: t('Share route'),
+                text: originName && destinationName ? `${originName} → ${destinationName}` : undefined,
+                url,
+            };
+
+            const result = await shareRouteWithFallback({
+                share: navigator.share?.bind(navigator),
+                clipboard: navigator.clipboard,
+                prefersShareSheet,
+                sharePayload,
+                copyUrl: url
+            });
+
+            if (result === shareRouteResults.COPIED) {
+                showCopiedMessage();
+            } else if (result === shareRouteResults.FAILED) {
+                showShareFailedMessage();
+            }
+        } finally {
+            sharingInProgressRef.current = false;
+            setIsSharing(false);
         }
     }
 
@@ -626,6 +635,7 @@ function Wayfinding({ onStartDirections, onBack, directionsToLocation, direction
                             <button
                                 className="wayfinding__share"
                                 onClick={() => shareRoute()}
+                                disabled={isSharing}
                                 aria-label={t('Share route')}
                             >
                                 <ShareIcon />

--- a/packages/map-template/src/components/Wayfinding/Wayfinding.scss
+++ b/packages/map-template/src/components/Wayfinding/Wayfinding.scss
@@ -193,6 +193,32 @@
         align-items: start;
     }
 
+    &__travel {
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-x-small);
+    }
+
+    &__share {
+        border: 1px solid var(--color-gray-30);
+        background: var(--color-gray-10);
+        border-radius: var(--spacing-x-small);
+        width: 36px;
+        height: 36px;
+        display: grid;
+        place-items: center;
+        flex-shrink: 0;
+
+        &:hover {
+            background-color: var(--tailwind-colors-gray-200);
+        }
+
+        svg {
+            width: 16px;
+            height: 16px;
+        }
+    }
+
     &__label {
         span {
             display: none;

--- a/packages/map-template/src/components/Wayfinding/Wayfinding.scss
+++ b/packages/map-template/src/components/Wayfinding/Wayfinding.scss
@@ -214,8 +214,8 @@
         }
 
         svg {
-            width: 16px;
-            height: 16px;
+            width: 20px;
+            height: 20px;
         }
     }
 

--- a/packages/map-template/src/components/Wayfinding/shareRouteHelpers.js
+++ b/packages/map-template/src/components/Wayfinding/shareRouteHelpers.js
@@ -1,0 +1,77 @@
+export const shareRouteResults = {
+    SHARED: 'shared',
+    COPIED: 'copied',
+    CANCELLED: 'cancelled',
+    FAILED: 'failed'
+};
+
+export function buildRouteShareUrl({ base, apiKey, originId, destinationId }) {
+    const params = new URLSearchParams({
+        directionsFrom: originId,
+        directionsTo: destinationId
+    });
+
+    if (apiKey) {
+        params.set('apiKey', apiKey);
+    }
+
+    return `${base}?${params.toString()}`;
+}
+
+async function copyRouteToClipboard(clipboard, copyUrl) {
+    if (typeof clipboard?.writeText !== 'function') {
+        return false;
+    }
+
+    try {
+        await clipboard.writeText(copyUrl);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+function isAbortError(error) {
+    return error?.name === 'AbortError';
+}
+
+export async function shareRouteWithFallback({ share, clipboard, prefersShareSheet, sharePayload, copyUrl }) {
+    const canShare = typeof share === 'function';
+    const canCopy = typeof clipboard?.writeText === 'function';
+
+    if (canShare && prefersShareSheet) {
+        try {
+            await share(sharePayload);
+            return shareRouteResults.SHARED;
+        } catch (error) {
+            if (isAbortError(error)) {
+                return shareRouteResults.CANCELLED;
+            }
+
+            if (canCopy && await copyRouteToClipboard(clipboard, copyUrl)) {
+                return shareRouteResults.COPIED;
+            }
+
+            return shareRouteResults.FAILED;
+        }
+    }
+
+    if (canCopy) {
+        return await copyRouteToClipboard(clipboard, copyUrl)
+            ? shareRouteResults.COPIED
+            : shareRouteResults.FAILED;
+    }
+
+    if (canShare) {
+        try {
+            await share(sharePayload);
+            return shareRouteResults.SHARED;
+        } catch (error) {
+            return isAbortError(error)
+                ? shareRouteResults.CANCELLED
+                : shareRouteResults.FAILED;
+        }
+    }
+
+    return shareRouteResults.FAILED;
+}

--- a/packages/map-template/src/components/Wayfinding/shareRouteHelpers.js
+++ b/packages/map-template/src/components/Wayfinding/shareRouteHelpers.js
@@ -6,16 +6,38 @@ export const shareRouteResults = {
 };
 
 export function buildRouteShareUrl({ base, apiKey, originId, destinationId }) {
-    const params = new URLSearchParams({
+    new URL(base);
+
+    const hashIndex = base.indexOf('#');
+    const hash = hashIndex === -1 ? '' : base.slice(hashIndex);
+    const baseBeforeHash = hashIndex === -1 ? base : base.slice(0, hashIndex);
+    const queryIndex = baseBeforeHash.indexOf('?');
+    const baseWithoutQuery = queryIndex === -1 ? baseBeforeHash : baseBeforeHash.slice(0, queryIndex);
+    const query = queryIndex === -1 ? '' : baseBeforeHash.slice(queryIndex + 1);
+    const routeParamNames = new Set(['directionsFrom', 'directionsTo', 'apiKey']);
+    const preservedParams = query
+        ? query.split('&').filter((param) => {
+            const key = param.split('=', 1)[0];
+            const decodedKey = new URLSearchParams(`${key}=`).keys().next().value;
+
+            return !routeParamNames.has(decodedKey);
+        })
+        : [];
+    const routeParams = new URLSearchParams({
         directionsFrom: originId,
         directionsTo: destinationId
     });
 
     if (apiKey) {
-        params.set('apiKey', apiKey);
+        routeParams.set('apiKey', apiKey);
     }
 
-    return `${base}?${params.toString()}`;
+    const routeQuery = routeParams.toString();
+    const nextQuery = preservedParams.length > 0
+        ? `${preservedParams.join('&')}&${routeQuery}`
+        : routeQuery;
+
+    return `${baseWithoutQuery}?${nextQuery}${hash}`;
 }
 
 async function copyRouteToClipboard(clipboard, copyUrl) {

--- a/packages/map-template/src/components/Wayfinding/shareRouteHelpers.test.js
+++ b/packages/map-template/src/components/Wayfinding/shareRouteHelpers.test.js
@@ -1,0 +1,130 @@
+const fs = require('fs');
+const path = require('path');
+
+function loadShareRouteHelpers() {
+    const helperPath = path.join(__dirname, 'shareRouteHelpers.js');
+    const source = fs.readFileSync(helperPath, 'utf8');
+    const runnableSource = source
+        .replace('export const shareRouteResults =', 'const shareRouteResults =')
+        .replace('export function buildRouteShareUrl', 'function buildRouteShareUrl')
+        .replace('export async function shareRouteWithFallback', 'async function shareRouteWithFallback');
+
+    return new Function(
+        'URLSearchParams',
+        `${runnableSource}
+return {
+    buildRouteShareUrl,
+    shareRouteWithFallback,
+    shareRouteResults
+};`
+    )(URLSearchParams);
+}
+
+const {
+    buildRouteShareUrl,
+    shareRouteWithFallback,
+    shareRouteResults
+} = loadShareRouteHelpers();
+
+describe('buildRouteShareUrl', () => {
+    it('encodes route share query parameters', () => {
+        const url = buildRouteShareUrl({
+            base: 'https://example.com/map',
+            apiKey: 'key with spaces&symbols',
+            originId: 'origin&1',
+            destinationId: 'destination 2'
+        });
+
+        expect(url).toBe('https://example.com/map?directionsFrom=origin%261&directionsTo=destination+2&apiKey=key+with+spaces%26symbols');
+    });
+
+    it('omits apiKey when it is not set', () => {
+        const url = buildRouteShareUrl({
+            base: 'https://example.com/map',
+            apiKey: undefined,
+            originId: 'origin',
+            destinationId: 'destination'
+        });
+
+        expect(url).toBe('https://example.com/map?directionsFrom=origin&directionsTo=destination');
+    });
+});
+
+describe('shareRouteWithFallback', () => {
+    it('copies when clipboard is the preferred available path', async () => {
+        const writeText = jest.fn().mockResolvedValue(undefined);
+
+        const result = await shareRouteWithFallback({
+            share: undefined,
+            clipboard: { writeText },
+            prefersShareSheet: false,
+            sharePayload: { url: 'https://example.com/map' },
+            copyUrl: 'https://example.com/map'
+        });
+
+        expect(result).toBe(shareRouteResults.COPIED);
+        expect(writeText).toHaveBeenCalledWith('https://example.com/map');
+    });
+
+    it('returns failed when clipboard copy rejects', async () => {
+        const writeText = jest.fn().mockRejectedValue(new Error('blocked'));
+
+        const result = await shareRouteWithFallback({
+            share: undefined,
+            clipboard: { writeText },
+            prefersShareSheet: false,
+            sharePayload: { url: 'https://example.com/map' },
+            copyUrl: 'https://example.com/map'
+        });
+
+        expect(result).toBe(shareRouteResults.FAILED);
+    });
+
+    it('keeps user-cancelled native share silent and does not copy', async () => {
+        const abortError = new DOMException('Share cancelled', 'AbortError');
+        const share = jest.fn().mockRejectedValue(abortError);
+        const writeText = jest.fn().mockResolvedValue(undefined);
+
+        const result = await shareRouteWithFallback({
+            share,
+            clipboard: { writeText },
+            prefersShareSheet: true,
+            sharePayload: { url: 'https://example.com/map' },
+            copyUrl: 'https://example.com/map'
+        });
+
+        expect(result).toBe(shareRouteResults.CANCELLED);
+        expect(writeText).not.toHaveBeenCalled();
+    });
+
+    it('falls back to clipboard when native share fails for a non-cancel reason', async () => {
+        const share = jest.fn().mockRejectedValue(new Error('blocked'));
+        const writeText = jest.fn().mockResolvedValue(undefined);
+
+        const result = await shareRouteWithFallback({
+            share,
+            clipboard: { writeText },
+            prefersShareSheet: true,
+            sharePayload: { url: 'https://example.com/map' },
+            copyUrl: 'https://example.com/map'
+        });
+
+        expect(result).toBe(shareRouteResults.COPIED);
+        expect(writeText).toHaveBeenCalledWith('https://example.com/map');
+    });
+
+    it('returns failed when native share and clipboard fallback both fail', async () => {
+        const share = jest.fn().mockRejectedValue(new Error('blocked'));
+        const writeText = jest.fn().mockRejectedValue(new Error('clipboard blocked'));
+
+        const result = await shareRouteWithFallback({
+            share,
+            clipboard: { writeText },
+            prefersShareSheet: true,
+            sharePayload: { url: 'https://example.com/map' },
+            copyUrl: 'https://example.com/map'
+        });
+
+        expect(result).toBe(shareRouteResults.FAILED);
+    });
+});

--- a/packages/map-template/src/components/Wayfinding/shareRouteHelpers.test.js
+++ b/packages/map-template/src/components/Wayfinding/shareRouteHelpers.test.js
@@ -11,13 +11,14 @@ function loadShareRouteHelpers() {
 
     return new Function(
         'URLSearchParams',
+        'URL',
         `${runnableSource}
 return {
     buildRouteShareUrl,
     shareRouteWithFallback,
     shareRouteResults
 };`
-    )(URLSearchParams);
+    )(URLSearchParams, URL);
 }
 
 const {
@@ -47,6 +48,84 @@ describe('buildRouteShareUrl', () => {
         });
 
         expect(url).toBe('https://example.com/map?directionsFrom=origin&directionsTo=destination');
+    });
+
+    it('preserves existing query parameters when adding route share parameters', () => {
+        const url = buildRouteShareUrl({
+            base: 'https://example.com/map?floor=1&language=en',
+            apiKey: 'api-key',
+            originId: 'origin',
+            destinationId: 'destination'
+        });
+
+        expect(url).toBe('https://example.com/map?floor=1&language=en&directionsFrom=origin&directionsTo=destination&apiKey=api-key');
+    });
+
+    it('adds route share parameters before a hash fragment', () => {
+        const url = buildRouteShareUrl({
+            base: 'https://example.com/map#details',
+            apiKey: 'api-key',
+            originId: 'origin',
+            destinationId: 'destination'
+        });
+
+        expect(url).toBe('https://example.com/map?directionsFrom=origin&directionsTo=destination&apiKey=api-key#details');
+    });
+
+    it('preserves unrelated existing query parameter bytes exactly', () => {
+        const url = buildRouteShareUrl({
+            base: 'https://example.com/map?x=a%20b&tilde=~&plus=a+b#details',
+            apiKey: 'api-key',
+            originId: 'origin',
+            destinationId: 'destination'
+        });
+
+        expect(url).toBe('https://example.com/map?x=a%20b&tilde=~&plus=a+b&directionsFrom=origin&directionsTo=destination&apiKey=api-key#details');
+    });
+
+    it('preserves empty unrelated query segments when appending route params', () => {
+        const url = buildRouteShareUrl({
+            base: 'https://example.com/map?x=1&&y=2&',
+            apiKey: undefined,
+            originId: 'origin',
+            destinationId: 'destination'
+        });
+
+        expect(url).toBe('https://example.com/map?x=1&&y=2&&directionsFrom=origin&directionsTo=destination');
+    });
+
+    it('replaces stale directionsFrom/directionsTo/apiKey from base and removes stale apiKey when apiKey is undefined', () => {
+        const url = buildRouteShareUrl({
+            base: 'https://example.com/map?directionsFrom=stale-origin&directionsTo=stale-destination&apiKey=stale-key&floor=1',
+            apiKey: undefined,
+            originId: 'origin',
+            destinationId: 'destination'
+        });
+        const searchParams = new URL(url).searchParams;
+
+        expect(searchParams.get('directionsFrom')).toBe('origin');
+        expect(searchParams.get('directionsTo')).toBe('destination');
+        expect(searchParams.get('floor')).toBe('1');
+        expect(searchParams.has('apiKey')).toBe(false);
+        expect(searchParams.getAll('directionsFrom')).toHaveLength(1);
+        expect(searchParams.getAll('directionsTo')).toHaveLength(1);
+    });
+
+    it('requires an absolute base URL', () => {
+        let thrownError;
+
+        try {
+            buildRouteShareUrl({
+                base: '/map',
+                apiKey: 'api-key',
+                originId: 'origin',
+                destinationId: 'destination'
+            });
+        } catch (error) {
+            thrownError = error;
+        }
+
+        expect(thrownError?.constructor.name).toBe('TypeError');
     });
 });
 

--- a/packages/map-template/src/components/WebComponentWrappers/Notification/Notification.jsx
+++ b/packages/map-template/src/components/WebComponentWrappers/Notification/Notification.jsx
@@ -15,7 +15,7 @@ function Notification() {
     useEffect(() => {
         elementRef.current?.classList.add('notification'); // Due to difficulties adding class names onto the Web Component, we do it like this.
         if (notificationMessage) {
-            elementRef.current.push(notificationMessage.text, notificationMessage.type, true);
+            elementRef.current.push(notificationMessage.text, notificationMessage.type, notificationMessage.sticky ?? true);
         } else {
             elementRef.current.clearAll();
         }

--- a/packages/map-template/src/i18n/da.js
+++ b/packages/map-template/src/i18n/da.js
@@ -79,7 +79,9 @@ const da = {
     'Finish route': 'Afslut ruten',
     // Share location link
     'Share': 'Del',
+    'Share route': 'Del rute',
     'Copy link': 'Kopiér link',
+    'Link copied': 'Link kopieret',
     'QR Code': 'QR-kode',
     //Opening Hours
     'Open': 'Åben',

--- a/packages/map-template/src/i18n/da.js
+++ b/packages/map-template/src/i18n/da.js
@@ -82,6 +82,7 @@ const da = {
     'Share route': 'Del rute',
     'Copy link': 'Kopiér link',
     'Link copied': 'Link kopieret',
+    'Could not share route': 'Kunne ikke dele ruten',
     'QR Code': 'QR-kode',
     //Opening Hours
     'Open': 'Åben',

--- a/packages/map-template/src/i18n/de.js
+++ b/packages/map-template/src/i18n/de.js
@@ -79,7 +79,9 @@ const de = {
     'Finish route': 'Route beenden',
     // Share location link
     'Share': 'Teilen',
+    'Share route': 'Route teilen',
     'Copy link': 'Link kopieren',
+    'Link copied': 'Link kopiert',
     'QR Code': 'QR code',
     // Opening Hours
     'Open': 'Geöffnet',

--- a/packages/map-template/src/i18n/de.js
+++ b/packages/map-template/src/i18n/de.js
@@ -82,6 +82,7 @@ const de = {
     'Share route': 'Route teilen',
     'Copy link': 'Link kopieren',
     'Link copied': 'Link kopiert',
+    'Could not share route': 'Route konnte nicht geteilt werden',
     'QR Code': 'QR code',
     // Opening Hours
     'Open': 'Geöffnet',

--- a/packages/map-template/src/i18n/en.js
+++ b/packages/map-template/src/i18n/en.js
@@ -82,6 +82,7 @@ const en = {
     'Share route': 'Share route',
     'Copy link': 'Copy link',
     'Link copied': 'Link copied',
+    'Could not share route': 'Could not share route',
     'QR Code': 'QR Code',
     // Opening Hours
     'Open': 'Open',

--- a/packages/map-template/src/i18n/en.js
+++ b/packages/map-template/src/i18n/en.js
@@ -79,7 +79,9 @@ const en = {
     'Finish route': 'Finish route',
     // Share location link
     'Share': 'Share',
+    'Share route': 'Share route',
     'Copy link': 'Copy link',
+    'Link copied': 'Link copied',
     'QR Code': 'QR Code',
     // Opening Hours
     'Open': 'Open',

--- a/packages/map-template/src/i18n/es.js
+++ b/packages/map-template/src/i18n/es.js
@@ -79,7 +79,9 @@ const es = {
     'Finish route': 'Finalizar ruta',
     // Share location link
     'Share': 'Compartir',
+    'Share route': 'Compartir ruta',
     'Copy link': 'Copiar link',
+    'Link copied': 'Link copiado',
     'QR Code': 'Código QR',
     // Opening Hours
     'Open': 'Abierto',

--- a/packages/map-template/src/i18n/es.js
+++ b/packages/map-template/src/i18n/es.js
@@ -82,6 +82,7 @@ const es = {
     'Share route': 'Compartir ruta',
     'Copy link': 'Copiar link',
     'Link copied': 'Link copiado',
+    'Could not share route': 'No se pudo compartir la ruta',
     'QR Code': 'Código QR',
     // Opening Hours
     'Open': 'Abierto',

--- a/packages/map-template/src/i18n/fr.js
+++ b/packages/map-template/src/i18n/fr.js
@@ -79,7 +79,9 @@ const fr = {
     'Finish route': 'Terminer l\'itinéraire',
     // Share location link
     'Share': 'Partager',
+    'Share route': 'Partager l\'itinéraire',
     'Copy link': 'Copier le lien',
+    'Link copied': 'Lien copié',
     'QR Code': 'Code QR',
     // Opening Hours
     'Open': 'Ouvert',

--- a/packages/map-template/src/i18n/fr.js
+++ b/packages/map-template/src/i18n/fr.js
@@ -82,6 +82,7 @@ const fr = {
     'Share route': 'Partager l\'itinéraire',
     'Copy link': 'Copier le lien',
     'Link copied': 'Lien copié',
+    'Could not share route': 'Impossible de partager l\'itinéraire',
     'QR Code': 'Code QR',
     // Opening Hours
     'Open': 'Ouvert',

--- a/packages/map-template/src/i18n/it.js
+++ b/packages/map-template/src/i18n/it.js
@@ -82,6 +82,7 @@ const it = {
     'Share route': 'Condividi percorso',
     'Copy link': 'Copia il collegamento',
     'Link copied': 'Collegamento copiato',
+    'Could not share route': 'Impossibile condividere il percorso',
     'QR Code': 'Codice QR',
     //Opening Hours
     'Open': 'Aperto',

--- a/packages/map-template/src/i18n/it.js
+++ b/packages/map-template/src/i18n/it.js
@@ -79,7 +79,9 @@ const it = {
     'Finish route': 'Termina percorso',
     // Share location link
     'Share': 'Condividi',
+    'Share route': 'Condividi percorso',
     'Copy link': 'Copia il collegamento',
+    'Link copied': 'Collegamento copiato',
     'QR Code': 'Codice QR',
     //Opening Hours
     'Open': 'Aperto',

--- a/packages/map-template/src/i18n/nl.js
+++ b/packages/map-template/src/i18n/nl.js
@@ -79,7 +79,9 @@ const nl = {
     'Finish route': 'Route voltooien ',
     // Share location link
     'Share': 'Deel',
+    'Share route': 'Route delen',
     'Copy link': 'Link kopiëren',
+    'Link copied': 'Link gekopieerd',
     'QR Code': 'QR code',
     // Opening Hours
     'Open': 'Open',

--- a/packages/map-template/src/i18n/nl.js
+++ b/packages/map-template/src/i18n/nl.js
@@ -82,6 +82,7 @@ const nl = {
     'Share route': 'Route delen',
     'Copy link': 'Link kopiëren',
     'Link copied': 'Link gekopieerd',
+    'Could not share route': 'Kan route niet delen',
     'QR Code': 'QR code',
     // Opening Hours
     'Open': 'Open',

--- a/packages/map-template/src/i18n/zh-Hans.js
+++ b/packages/map-template/src/i18n/zh-Hans.js
@@ -82,6 +82,7 @@ const zhHans = {
     'Share route': '分享路线',
     'Copy link': '复制链接',
     'Link copied': '链接已复制',
+    'Could not share route': '无法分享路线',
     'QR Code': '二维码',
     // Opening Hours
     'Open': '营业中',

--- a/packages/map-template/src/i18n/zh-Hans.js
+++ b/packages/map-template/src/i18n/zh-Hans.js
@@ -79,7 +79,9 @@ const zhHans = {
     'Finish route': '完成路线',
     // Share location link
     'Share': '分享',
+    'Share route': '分享路线',
     'Copy link': '复制链接',
+    'Link copied': '链接已复制',
     'QR Code': '二维码',
     // Opening Hours
     'Open': '营业中',

--- a/packages/map-template/src/i18n/zh-Hant.js
+++ b/packages/map-template/src/i18n/zh-Hant.js
@@ -82,6 +82,7 @@ const zhHant = {
       'Share route': '分享路線',
       'Copy link': '複製連結',
       'Link copied': '連結已複製',
+      'Could not share route': '無法分享路線',
       'QR Code': 'QR 碼',
       // Opening Hours
       'Open': '營業中',

--- a/packages/map-template/src/i18n/zh-Hant.js
+++ b/packages/map-template/src/i18n/zh-Hant.js
@@ -79,7 +79,9 @@ const zhHant = {
       'Finish route': '完成路線',
       // Share location link
       'Share': '分享',
+      'Share route': '分享路線',
       'Copy link': '複製連結',
+      'Link copied': '連結已複製',
       'QR Code': 'QR 碼',
       // Opening Hours
       'Open': '營業中',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Share Route" button in Wayfinding to invoke native share on mobile or copy the route link; hidden for kiosk/embedded views and when unsupported. Shows success/failure feedback.

* **Localization**
  * Added translations for "Share route", "Link copied" and a share-failure message across multiple locales.

* **UI/UX**
  * Updated share button styling and notification stickiness behavior.

* **Tests**
  * Added tests covering route-share URL construction and share/copy fallback flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MapsPeople/web-ui/pull/691?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->