### PR TITLE
fix: localize "Level" word based on MapsIndoors SDK language

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27205,7 +27205,7 @@
     },
     "packages/components": {
       "name": "@mapsindoors/components",
-      "version": "13.36.0",
+      "version": "13.36.1",
       "license": "MIT",
       "dependencies": {
         "@11ty/eleventy": "^3.1.0",
@@ -27269,7 +27269,7 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.99.1",
+      "version": "1.99.2",
       "dependencies": {
         "@mapsindoors/components": "*",
         "@mapsindoors/css": "^3.0.0",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.36.3] - 2026-06-09
+
+### Fixed
+
+- **mi-location-info** / **mi-list-item-location**: the "Level" word now localizes to the MapsIndoors SDK's current language when the `level` prop is not passed. Falls back to English for unsupported languages.
+
 ## [13.36.2] - 2026-06-05
 
 ### Fixed

--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -463,7 +463,7 @@ export namespace Components {
         /**
           * @description The word used for "Level" when showing level info. When not passed, falls back to a localized default resolved from the current MapsIndoors SDK language (e.g. "楼层" for `zh-Hans`, "Etage" for `de`/`da`).
          */
-        "level": string;
+        "level"?: string;
         /**
           * @description Location object.
          */

--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -396,8 +396,7 @@ export namespace Components {
          */
         "iconBadgeValue": string;
         /**
-          * @description The word used for "Level" when showing level info. Default is "Level".
-          * @default 'Level'
+          * @description The word used for "Level" when showing level info. When not passed, the nested `mi-location-info` resolves a localized default from the current MapsIndoors SDK language.
          */
         "level": string;
         /**
@@ -462,8 +461,7 @@ export namespace Components {
     }
     interface MiLocationInfo {
         /**
-          * @description The word used for "Level" when showing level info. Default is "Level".
-          * @default 'Level'
+          * @description The word used for "Level" when showing level info. When not passed, falls back to a localized default resolved from the current MapsIndoors SDK language (e.g. "楼层" for `zh-Hans`, "Etage" for `de`/`da`).
          */
         "level": string;
         /**
@@ -2170,8 +2168,7 @@ declare namespace LocalJSX {
          */
         "iconBadgeValue"?: string;
         /**
-          * @description The word used for "Level" when showing level info. Default is "Level".
-          * @default 'Level'
+          * @description The word used for "Level" when showing level info. When not passed, the nested `mi-location-info` resolves a localized default from the current MapsIndoors SDK language.
          */
         "level"?: string;
         /**
@@ -2268,8 +2265,7 @@ declare namespace LocalJSX {
     }
     interface MiLocationInfo {
         /**
-          * @description The word used for "Level" when showing level info. Default is "Level".
-          * @default 'Level'
+          * @description The word used for "Level" when showing level info. When not passed, falls back to a localized default resolved from the current MapsIndoors SDK language (e.g. "楼层" for `zh-Hans`, "Etage" for `de`/`da`).
          */
         "level"?: string;
         /**

--- a/packages/components/src/components/list-item-location/list-item-location.tsx
+++ b/packages/components/src/components/list-item-location/list-item-location.tsx
@@ -35,9 +35,11 @@ export class ListItemLocation {
     @Prop() icon: string;
 
     /**
-     * @description The word used for "Level" when showing level info. Default is "Level".
+     * @description The word used for "Level" when showing level info. When not
+     * passed, the nested `mi-location-info` resolves a localized default from
+     * the current MapsIndoors SDK language.
      */
-    @Prop() level: string = 'Level';
+    @Prop() level: string;
 
     @Watch('icon')
     iconChanged(): void {

--- a/packages/components/src/components/list-item-location/readme.md
+++ b/packages/components/src/components/list-item-location/readme.md
@@ -86,7 +86,7 @@ A `listItemDidRender` event is emitted from the `<mi-list-item-location>` elemen
 | `icon`           | `icon`             |                                  | `string`                                   | `undefined` |
 | `iconBadge`      | `icon-badge`       |                                  | `string`                                   | `undefined` |
 | `iconBadgeValue` | `icon-badge-value` |                                  | `string`                                   | `undefined` |
-| `level`          | `level`            |                                  | `string`                                   | `'Level'`   |
+| `level`          | `level`            |                                  | `string`                                   | `undefined` |
 | `location`       | `location`         |                                  | `any`                                      | `undefined` |
 | `showExternalId` | `show-external-id` | Whether to show the External ID. | `boolean`                                  | `true`      |
 | `unit`           | `unit`             |                                  | `UnitSystem.Imperial \| UnitSystem.Metric` | `undefined` |

--- a/packages/components/src/components/location-info/location-info.spec.ts
+++ b/packages/components/src/components/location-info/location-info.spec.ts
@@ -1,7 +1,65 @@
 import { LocationInfo } from './location-info';
 
 describe('mi-location-info', () => {
+    afterEach(() => {
+        // Reset the global `mapsindoors` mock between tests.
+        delete (globalThis as any).mapsindoors;
+    });
+
     it('builds', () => {
         expect(new LocationInfo()).toBeTruthy();
+    });
+
+    describe('level word fallback', () => {
+        const locationOnFloor1 = {
+            properties: {
+                floorName: '1',
+                externalId: null,
+                building: null,
+                venue: null,
+                subtitle: null,
+            },
+        };
+
+        it('uses the explicit level prop when provided', () => {
+            const component = new LocationInfo();
+            component.location = locationOnFloor1;
+            component.level = 'Custom';
+            expect(component.getInfoString()).toBe('Custom 1');
+        });
+
+        it('falls back to a localized default based on the SDK language', () => {
+            (globalThis as any).mapsindoors = {
+                MapsIndoors: { getLanguage: () => 'zh-Hans' },
+            };
+            const component = new LocationInfo();
+            component.location = locationOnFloor1;
+            expect(component.getInfoString()).toBe('楼层 1');
+        });
+
+        it('falls back to English when the SDK language is unsupported', () => {
+            (globalThis as any).mapsindoors = {
+                MapsIndoors: { getLanguage: () => 'jp' },
+            };
+            const component = new LocationInfo();
+            component.location = locationOnFloor1;
+            expect(component.getInfoString()).toBe('Level 1');
+        });
+
+        it('falls back to English when the global mapsindoors is unavailable', () => {
+            const component = new LocationInfo();
+            component.location = locationOnFloor1;
+            expect(component.getInfoString()).toBe('Level 1');
+        });
+
+        it('lets an explicit level override take precedence over the SDK language', () => {
+            (globalThis as any).mapsindoors = {
+                MapsIndoors: { getLanguage: () => 'zh-Hans' },
+            };
+            const component = new LocationInfo();
+            component.location = locationOnFloor1;
+            component.level = 'Etage';
+            expect(component.getInfoString()).toBe('Etage 1');
+        });
     });
 });

--- a/packages/components/src/components/location-info/location-info.tsx
+++ b/packages/components/src/components/location-info/location-info.tsx
@@ -1,4 +1,5 @@
 import { Component, ComponentInterface, Prop, JSX } from '@stencil/core';
+import { getLevelDefault } from '../../utils/levelDefaults';
 
 @Component({
     tag: 'mi-location-info',
@@ -13,9 +14,19 @@ export class LocationInfo implements ComponentInterface {
     @Prop() location;
 
     /**
-     * @description The word used for "Level" when showing level info. Default is "Level".
+     * @description The word used for "Level" when showing level info. When not
+     * passed, falls back to a localized default resolved from the current
+     * MapsIndoors SDK language (e.g. "楼层" for `zh-Hans`, "Etage" for `de`/`da`).
      */
-    @Prop() level: string = 'Level';
+    @Prop() level?: string;
+
+    /**
+     * Resolves the effective level word: the explicit `level` prop when provided,
+     * otherwise the SDK-language-aware default from `getLevelDefault()`.
+     */
+    private get effectiveLevel(): string {
+        return this.level ?? getLevelDefault();
+    }
 
     /**
      * @description Whether to show the External ID.
@@ -41,7 +52,7 @@ export class LocationInfo implements ComponentInterface {
         }
         // Floor name
         if (this.location.properties.floorName && this.showFloor) {
-            details.push(`${this.level} ${this.location.properties.floorName}`);
+            details.push(`${this.effectiveLevel} ${this.location.properties.floorName}`);
         }
         // Building
         if (this.location.properties.building) {

--- a/packages/components/src/components/location-info/readme.md
+++ b/packages/components/src/components/location-info/readme.md
@@ -63,7 +63,7 @@ If false, the component will not show the location's floor name. The attribute i
 
 | Property         | Attribute          | Description | Type      | Default     |
 | ---------------- | ------------------ | ----------- | --------- | ----------- |
-| `level`          | `level`            |             | `string`  | `'Level'`   |
+| `level`          | `level`            |             | `string`  | `undefined` |
 | `location`       | `location`         |             | `any`     | `undefined` |
 | `showExternalId` | `show-external-id` |             | `boolean` | `true`      |
 | `showFloor`      | `show-floor`       |             | `boolean` | `true`      |

--- a/packages/components/src/utils/levelDefaults.ts
+++ b/packages/components/src/utils/levelDefaults.ts
@@ -1,0 +1,31 @@
+declare const mapsindoors;
+
+/**
+ * Built-in fallback translations for the "Level" word used by location-info and
+ * list-item-location web components when the consumer does not pass an explicit
+ * `level` prop. Keys must match the canonical BCP-47 tags returned by the
+ * MapsIndoors SDK after normalization (e.g. `zh-CN` is normalized to `zh-Hans`).
+ */
+const LEVEL_TRANSLATIONS: Record<string, string> = {
+    en: 'Level',
+    da: 'Etage',
+    de: 'Etage',
+    fr: 'Niveau',
+    it: 'Livello',
+    es: 'Nivel',
+    nl: 'Niveau',
+    'zh-Hans': '楼层',
+    'zh-Hant': '樓層',
+};
+
+/**
+ * Returns the localized default for the "Level" word based on the language
+ * currently configured on the MapsIndoors SDK. Falls back to English when the
+ * global `mapsindoors` is unavailable or the language has no entry.
+ */
+export function getLevelDefault(): string {
+    const lang = typeof mapsindoors !== 'undefined'
+        ? mapsindoors?.MapsIndoors?.getLanguage?.()
+        : undefined;
+    return LEVEL_TRANSLATIONS[lang] ?? LEVEL_TRANSLATIONS.en;
+}

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.99.3] - 2026-06-09
+
+### Fixed
+
+- Runtime language switch now refreshes categories, venue list, and the currently-selected location so their display text matches the newly selected language.
+
 ## [1.99.2] - 2026-06-01
 
 ### Added

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -331,28 +331,27 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
             // Set the language on the MapsIndoors SDK in order to get eg. Mapbox and Google directions in that language.
             window.mapsindoors.MapsIndoors.setLanguage(languageToUse);
 
-            // If relevant, fetch venues, categories and the current location again to get them in the new language
-            window.mapsindoors.services.LocationsService.once('update_completed', () => {
-                if (categories.length > 0) {
-                    updateCategories();
-                }
+            // Refetch categories, venues and the current location so their data renders in the new language.
+            // `setLanguage` updates `config.language` synchronously so subsequent SDK requests pick up the new `lr`.
+            if (categories.length > 0) {
+                updateCategories();
+            }
 
-                if (venueList.length > 0) {
-                    window.mapsindoors.services.VenuesService.getVenueList().then(venueListResult => {
-                        const augmented = venueListResult.map(venue => ({
-                            ...venue,
-                            image: appConfig.venueImages?.[venue.name.toLowerCase()]
-                        }));
-                        setVenueList(augmented);
-                        // Clear full venue objects so they are re-fetched on demand in the new language
-                        setVenuesInSolution([]);
-                    });
-                }
+            if (venueList.length > 0) {
+                window.mapsindoors.services.VenuesService.getVenueList().then(venueListResult => {
+                    const augmented = venueListResult.map(venue => ({
+                        ...venue,
+                        image: appConfig.venueImages?.[venue.name.toLowerCase()]
+                    }));
+                    setVenueList(augmented);
+                    // Clear full venue objects so they are re-fetched on demand in the new language
+                    setVenuesInSolution([]);
+                });
+            }
 
-                if (currentLocation) {
-                    window.mapsindoors.services.LocationsService.getLocation(currentLocation.id).then(location => setCurrentLocation(location));
-                }
-            });
+            if (currentLocation) {
+                window.mapsindoors.services.LocationsService.getLocation(currentLocation.id).then(location => setCurrentLocation(location));
+            }
 
             // Ensure MapsIndoors uses the user's selected language if supported,
             // so all map content and UI are localized accordingly.


### PR DESCRIPTION
## Summary
- `mi-location-info` and `mi-list-item-location` now fall back to a localized "Level" word based on the active MapsIndoors SDK language when the `level` prop isn't set explicitly (e.g. "楼层" for `zh-Hans`, "Etage" for `de`/`da`). An explicit `level` prop still wins. Default English fallback for unsupported languages and when the SDK global isn't available.
- New `getLevelDefault()` utility in `packages/components/src/utils/levelDefaults.ts` centralizes the language → word mapping.
- `MapTemplate` refetches categories, venues, and the current location directly after `setLanguage()` rather than waiting on `LocationsService`'s `update_completed` event — `setLanguage` updates `config.language` synchronously, so subsequent SDK requests already pick up the new `lr`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * "Level" text in location displays now uses the MapsIndoors SDK language when not explicitly provided, with English fallback for unsupported or missing languages.
  * Changing the runtime language now refreshes categories, the venue list, and the selected location so displayed text updates immediately.

* **Documentation**
  * Updated component docs and changelogs to reflect the localized "Level" behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->