### PR TITLE
Fix/share route venue and floor selector reconnect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27269,7 +27269,7 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.98.4",
+      "version": "1.98.5",
       "dependencies": {
         "@mapsindoors/components": "*",
         "@mapsindoors/css": "^3.0.0",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [13.34.0] - 2026-05-28
 
 ### Fixed
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **mi-floor-selector**: Fixed floors not rendering when the component is reconnected to the DOM while a building is already active. `connectedCallback` now calls `buildingChangedHandler` immediately when a building is present.
 - **mi-floor-selector**: Fixed a memory leak where rapidly resizing the window could stack multiple `floor_changed` and `building_changed` listeners. Handlers are now stored as arrow class fields and cleaned up in `disconnectedCallback`.
 - **mi-my-position**: Fixed a memory leak where rapidly resizing the window could stack multiple `rotateend` listeners. Handler is now stored and cleaned up in `disconnectedCallback`.
 

--- a/packages/components/src/components/floor-selector/floor-selector.tsx
+++ b/packages/components/src/components/floor-selector/floor-selector.tsx
@@ -224,6 +224,9 @@ export class FloorSelector {
         if (!this.mapsindoors) return;
         this.mapsindoors.addListener('building_changed', this.buildingChangedHandler);
         this.mapsindoors.addListener('floor_changed', this.floorChangedHandler);
+        if (this.mapsindoors.getBuilding()) {
+            this.buildingChangedHandler();
+        }
     }
 
     disconnectedCallback(): void {

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed the shared route URL not including a `venue` parameter when the user navigated to a venue different from the default one.
+
 ## [1.98.5] - 2026-05-22
 
 ### Fixed

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.98.6] - 2026-05-28
 
 ### Fixed
 

--- a/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
+++ b/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
@@ -42,6 +42,8 @@ import ShareIcon from '../../assets/share.svg?react';
 import apiKeyState from '../../atoms/apiKeyState';
 import kioskLocationState from '../../atoms/kioskLocationState';
 import supportsUrlParametersState from '../../atoms/supportsUrlParametersState';
+import currentVenueNameState from '../../atoms/currentVenueNameState';
+import initialVenueNameState from '../../atoms/initialVenueNameState';
 import notificationMessageState from '../../atoms/notificationMessageState';
 import useMediaQuery from '../../hooks/useMediaQuery';
 import {
@@ -149,6 +151,8 @@ function Wayfinding({ onStartDirections, onBack, directionsToLocation, direction
     const apiKey = useRecoilValue(apiKeyState);
     const kioskLocation = useRecoilValue(kioskLocationState);
     const supportsUrlParameters = useRecoilValue(supportsUrlParametersState);
+    const currentVenueName = useRecoilValue(currentVenueNameState);
+    const initialVenueName = useRecoilValue(initialVenueNameState);
     const setNotificationMessage = useSetRecoilState(notificationMessageState);
 
     // API availability checks only. Framed embeds are gated separately because
@@ -419,7 +423,8 @@ function Wayfinding({ onStartDirections, onBack, directionsToLocation, direction
                 base,
                 apiKey,
                 originId: originLocation.id,
-                destinationId: destinationLocation.id
+                destinationId: destinationLocation.id,
+                venue: currentVenueName !== initialVenueName ? currentVenueName : undefined
             });
 
             const originName = originLocation.properties?.name ?? '';

--- a/packages/map-template/src/components/Wayfinding/shareRouteHelpers.js
+++ b/packages/map-template/src/components/Wayfinding/shareRouteHelpers.js
@@ -5,7 +5,7 @@ export const shareRouteResults = {
     FAILED: 'failed'
 };
 
-export function buildRouteShareUrl({ base, apiKey, originId, destinationId }) {
+export function buildRouteShareUrl({ base, apiKey, originId, destinationId, venue }) {
     new URL(base);
 
     const hashIndex = base.indexOf('#');
@@ -14,7 +14,7 @@ export function buildRouteShareUrl({ base, apiKey, originId, destinationId }) {
     const queryIndex = baseBeforeHash.indexOf('?');
     const baseWithoutQuery = queryIndex === -1 ? baseBeforeHash : baseBeforeHash.slice(0, queryIndex);
     const query = queryIndex === -1 ? '' : baseBeforeHash.slice(queryIndex + 1);
-    const routeParamNames = new Set(['directionsFrom', 'directionsTo', 'apiKey']);
+    const routeParamNames = new Set(['directionsFrom', 'directionsTo', 'apiKey', 'venue']);
     const preservedParams = query
         ? query.split('&').filter((param) => {
             const key = param.split('=', 1)[0];
@@ -30,6 +30,10 @@ export function buildRouteShareUrl({ base, apiKey, originId, destinationId }) {
 
     if (apiKey) {
         routeParams.set('apiKey', apiKey);
+    }
+
+    if (venue) {
+        routeParams.set('venue', venue);
     }
 
     const routeQuery = routeParams.toString();

--- a/packages/map-template/src/components/Wayfinding/shareRouteHelpers.test.js
+++ b/packages/map-template/src/components/Wayfinding/shareRouteHelpers.test.js
@@ -71,6 +71,55 @@ describe('buildRouteShareUrl', () => {
         expect(url).toBe('https://example.com/map?x=1&&y=2&&directionsFrom=origin&directionsTo=destination');
     });
 
+    it('includes venue when provided', () => {
+        const url = buildRouteShareUrl({
+            base: 'https://example.com/map',
+            apiKey: 'api-key',
+            originId: 'origin',
+            destinationId: 'destination',
+            venue: 'BUILDINGB'
+        });
+
+        expect(url).toBe('https://example.com/map?directionsFrom=origin&directionsTo=destination&apiKey=api-key&venue=BUILDINGB');
+    });
+
+    it('omits venue when not provided', () => {
+        const url = buildRouteShareUrl({
+            base: 'https://example.com/map',
+            apiKey: 'api-key',
+            originId: 'origin',
+            destinationId: 'destination'
+        });
+
+        expect(new URL(url).searchParams.has('venue')).toBe(false);
+    });
+
+    it('replaces stale venue in base URL when a new venue is provided', () => {
+        const url = buildRouteShareUrl({
+            base: 'https://example.com/map?venue=OLDVENUE&floor=1',
+            apiKey: 'api-key',
+            originId: 'origin',
+            destinationId: 'destination',
+            venue: 'NEWVENUE'
+        });
+        const searchParams = new URL(url).searchParams;
+
+        expect(searchParams.get('venue')).toBe('NEWVENUE');
+        expect(searchParams.getAll('venue')).toHaveLength(1);
+        expect(searchParams.get('floor')).toBe('1');
+    });
+
+    it('drops stale venue from base URL when venue is not provided', () => {
+        const url = buildRouteShareUrl({
+            base: 'https://example.com/map?venue=OLDVENUE',
+            apiKey: 'api-key',
+            originId: 'origin',
+            destinationId: 'destination'
+        });
+
+        expect(new URL(url).searchParams.has('venue')).toBe(false);
+    });
+
     it('replaces stale directionsFrom/directionsTo/apiKey from base and removes stale apiKey when apiKey is undefined', () => {
         const url = buildRouteShareUrl({
             base: 'https://example.com/map?directionsFrom=stale-origin&directionsTo=stale-destination&apiKey=stale-key&floor=1',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Floors now consistently render after a floor selector is reattached to the page while a building is already active, preventing missing floor displays.
  * Shared route links now include the correct venue parameter when sharing directions to a venue other than the default, ensuring recipients land in the intended venue.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MapsPeople/web-ui/pull/696?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->