### PR TITLE
feat: highlight directionsFrom POI on initial load

### DIFF
--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.98.7] - 2026-05-28
+
+### Added
+
+- When `directionsFrom=<locationId>` is set in the URL (and `directionsTo` is not), the map now centres on the origin POI and highlights it with the standard `selectLocation()` red pin. The pin persists while a route is displayed and is cleared when the user changes the FROM field.
+
 ## [1.98.6] - 2026-05-28
 
 ### Fixed

--- a/packages/map-template/src/atoms/wayfindingOriginHighlightLocationState.js
+++ b/packages/map-template/src/atoms/wayfindingOriginHighlightLocationState.js
@@ -1,0 +1,8 @@
+import { atom } from 'recoil';
+
+const wayfindingOriginHighlightLocationState = atom({
+    key: 'wayfindingOriginHighlightLocation',
+    default: null
+});
+
+export default wayfindingOriginHighlightLocationState;

--- a/packages/map-template/src/components/Directions/Directions.jsx
+++ b/packages/map-template/src/components/Directions/Directions.jsx
@@ -17,6 +17,7 @@ import getDesktopPaddingLeft from '../../helpers/GetDesktopPaddingLeft';
 import getMobilePaddingBottom from '../../helpers/GetMobilePaddingBottom';
 import getDesktopPaddingBottom from '../../helpers/GetDesktopPaddingBottom';
 import kioskLocationState from '../../atoms/kioskLocationState';
+import wayfindingOriginHighlightLocationState from '../../atoms/wayfindingOriginHighlightLocationState';
 import qrCodeLinkState from '../../atoms/qrCodeLinkState';
 import Accessibility from '../Accessibility/Accessibility';
 import isDestinationStepState from '../../atoms/isDestinationStepState';
@@ -76,6 +77,8 @@ function Directions({ isOpen, onBack, onSetSize, onRouteFinished }) {
     const [substepsOpen, setSubstepsOpen] = useRecoilState(substepsToggledState);
 
     const kioskLocation = useRecoilValue(kioskLocationState);
+    
+    const wayfindingOriginHighlightLocation = useRecoilValue(wayfindingOriginHighlightLocationState);
 
     const isDesktop = useIsDesktop();
 
@@ -140,6 +143,9 @@ function Directions({ isOpen, onBack, onSetSize, onRouteFinished }) {
                     // Clear selection pin to avoid dual pins - route pins will handle navigation
                     if (mapsIndoorsInstance) {
                         mapsIndoorsInstance.deselectLocation();
+                        if (wayfindingOriginHighlightLocation) {
+                            mapsIndoorsInstance.selectLocation(wayfindingOriginHighlightLocation);
+                        }
                     }
                 });
 

--- a/packages/map-template/src/components/Directions/Directions.jsx
+++ b/packages/map-template/src/components/Directions/Directions.jsx
@@ -170,7 +170,7 @@ function Directions({ isOpen, onBack, onSetSize, onRouteFinished }) {
             }
             setMinZoom(appConfig?.appSettings?.minZoom ?? ZoomLevelValues.minZoom);
         };
-    }, [isOpen, directions, mapsIndoorsInstance, travelMode, shuttleBusOn, appConfig]);
+    }, [isOpen, directions, mapsIndoorsInstance, travelMode, shuttleBusOn, appConfig, wayfindingOriginHighlightLocation]);
 
 
     /**

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -640,7 +640,7 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
                 mapsIndoorsInstance.deselectLocation();
             }
         }
-    }, [currentLocation, wayfindingOriginHighlightLocation, mapsIndoorsInstance, isMapReady, mapType]);
+    }, [currentLocation, wayfindingOriginHighlightLocation, kioskOriginLocationId, mapsIndoorsInstance, isMapReady, mapType]);
 
     /**
      * React on changes to the app config.

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -57,6 +57,7 @@ import showExternalIDsState from '../../atoms/showExternalIDsState.js'
 import showRoadNamesState from '../../atoms/showRoadNamesState.js';
 import searchExternalLocationsState from '../../atoms/searchExternalLocationsState.js';
 import wayfindingLocationState from '../../atoms/wayfindingLocation.js';
+import wayfindingOriginHighlightLocationState from '../../atoms/wayfindingOriginHighlightLocationState.js';
 import isNullOrUndefined from '../../helpers/isNullOrUndefined.js';
 import centerState from '../../atoms/centerState.js';
 import PropTypes from 'prop-types';
@@ -188,6 +189,7 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
     const [viewModeSwitchVisible, setViewModeSwitchVisible] = useState();
     const mapClickActionRef = useRef();
     const setWayfindingLocation = useSetRecoilState(wayfindingLocationState);
+    const [wayfindingOriginHighlightLocation, setWayfindingOriginHighlightLocation] = useRecoilState(wayfindingOriginHighlightLocationState);
     const [qrCodeLink, setQrCodeLink] = useRecoilState(qrCodeLinkState);
 
     const [showVenueSelector, setShowVenueSelector] = useState(true);
@@ -236,6 +238,19 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
     const mapType = useRecoilValue(mapTypeState);
     const isKiosk = useIsKioskContext();
     const disableRightClick = isKiosk && (appConfig?.appSettings?.disableRightClick === true || appConfig?.appSettings?.disableRightClick === 'true');
+
+    /**
+     * When ?directionsFrom resolves to a real Location AND there is no ?directionsTo
+     * AND the value isn't the USER_POSITION magic string, expose it as the wayfinding
+     * origin to highlight on initial load (zoom + selectLocation pin).
+     */
+    useEffect(() => {
+        const eligible = directionsFromLocation
+            && directionsFromLocation !== 'USER_POSITION_PENDING'
+            && !directionsTo
+            && directionsFrom !== 'USER_POSITION';
+        setWayfindingOriginHighlightLocation(eligible ? directionsFromLocation : null);
+    }, [directionsFromLocation, directionsTo, directionsFrom]);
 
     /**
      * Ensure that MapsIndoors Web SDK is available.
@@ -605,15 +620,19 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
     useEffect(() => {
         if (!isMapReady) return;
 
-        if (currentLocation && currentLocation.id !== kioskOriginLocationId) {
+        const locationToSelect = currentLocation && currentLocation.id !== kioskOriginLocationId
+            ? currentLocation
+            : wayfindingOriginHighlightLocation;
+
+        if (locationToSelect) {
             if (mapsIndoorsInstance?.selectLocation) {
                 mapsIndoorsInstance.highlight?.([]);
 
                 const map = mapsIndoorsInstance.getMap();
                 if (mapType === mapTypes.Mapbox) {
-                    map.once('idle', () => mapsIndoorsInstance.selectLocation(currentLocation));
+                    map.once('idle', () => mapsIndoorsInstance.selectLocation(locationToSelect));
                 } else {
-                    mapsIndoorsInstance.selectLocation(currentLocation);
+                    mapsIndoorsInstance.selectLocation(locationToSelect);
                 }
             }
         } else {
@@ -621,7 +640,7 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
                 mapsIndoorsInstance.deselectLocation();
             }
         }
-    }, [currentLocation, mapsIndoorsInstance, isMapReady, mapType]);
+    }, [currentLocation, wayfindingOriginHighlightLocation, mapsIndoorsInstance, isMapReady, mapType]);
 
     /**
      * React on changes to the app config.

--- a/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
+++ b/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
@@ -36,6 +36,7 @@ import ShuttleBus from '../ShuttleBus/ShuttleBus';
 import searchExternalLocationsState from '../../atoms/searchExternalLocationsState';
 import PropTypes from 'prop-types';
 import wayfindingLocationState from '../../atoms/wayfindingLocation';
+import wayfindingOriginHighlightLocationState from '../../atoms/wayfindingOriginHighlightLocationState';
 import appConfigState from '../../atoms/appConfigState';
 import mapsIndoorsInstanceState from '../../atoms/mapsIndoorsInstanceState';
 import ShareIcon from '../../assets/share.svg?react';
@@ -110,6 +111,7 @@ function Wayfinding({ onStartDirections, onBack, directionsToLocation, direction
     const selectedMapType = useRecoilValue(mapTypeState);
     const primaryColor = useRecoilValue(primaryColorState);
     const [wayfindingLocation, setWayfindingLocation] = useRecoilState(wayfindingLocationState);
+    const [wayfindingOriginHighlightLocation, setWayfindingOriginHighlightLocation] = useRecoilState(wayfindingOriginHighlightLocationState);
 
     const [activeSearchField, setActiveSearchField] = useState();
     const [isSharing, setIsSharing] = useState(false);
@@ -484,6 +486,30 @@ function Wayfinding({ onStartDirections, onBack, directionsToLocation, direction
         triggerRouteSearch();
         setWayfindingLocation(null); // will re-trigger another run with early exit but necessary in order to be able to re-click already clicked locations on the map
     }, [wayfindingLocation]);
+
+    /**
+     * The wayfinding-origin highlight tracks the QR-code POI from ?directionsFrom.
+     * Clear it once the user picks (or clears) a different origin — the FROM field
+     * is no longer pointing at the highlighted POI.
+     *
+     * The ref guards against the initial undefined state of `originLocation`: on
+     * mount, `originLocation` is undefined while `wayfindingOriginHighlightLocation`
+     * is already set by the URL. The auto-fill effect below populates `originLocation`
+     * a tick later. Without the ref the clear would fire on the first render and wipe
+     * the highlight before the pin renders.
+     */
+    const originMatchedHighlightRef = useRef(false);
+    useEffect(() => {
+        if (!wayfindingOriginHighlightLocation) {
+            originMatchedHighlightRef.current = false;
+            return;
+        }
+        if (originLocation?.id === wayfindingOriginHighlightLocation.id) {
+            originMatchedHighlightRef.current = true;
+        } else if (originMatchedHighlightRef.current) {
+            setWayfindingOriginHighlightLocation(null);
+        }
+    }, [originLocation, wayfindingOriginHighlightLocation]);
 
     useEffect(() => {
         let originLocationWasSet = false;

--- a/packages/map-template/src/hooks/useMapBoundsDeterminer.js
+++ b/packages/map-template/src/hooks/useMapBoundsDeterminer.js
@@ -14,6 +14,7 @@ import currentVenueNameState from '../atoms/currentVenueNameState';
 import venuesInSolutionState from '../atoms/venuesInSolutionState';
 import venueWasSelectedState from '../atoms/venueWasSelectedState';
 import isMapReadyState from '../atoms/isMapReadyState.js';
+import wayfindingOriginHighlightLocationState from '../atoms/wayfindingOriginHighlightLocationState';
 
 // Hooks
 import getMobilePaddingBottom from '../helpers/GetMobilePaddingBottom';
@@ -53,6 +54,7 @@ const useMapBoundsDeterminer = () => {
     const venuesInSolution = useRecoilValue(venuesInSolutionState);
     const currentPitch = useRecoilValue(currentPitchSelector);
     const venueWasSelected = useRecoilValue(venueWasSelectedState);
+    const wayfindingOriginHighlightLocation = useRecoilValue(wayfindingOriginHighlightLocationState);
     const [kioskLocationDisplayRuleWasChanged, setKioskLocationDisplayRuleWasChanged] = useState(false);
     const [currentVenueName, setCurrentVenueName] = useRecoilState(currentVenueNameState);
     const isMapReady = useRecoilState(isMapReadyState);
@@ -76,7 +78,7 @@ const useMapBoundsDeterminer = () => {
      */
     useEffect(() => {
         determineMapBounds();
-    }, [mapsIndoorsInstance, currentVenueName, locationId, kioskOriginLocationId, pitch, bearing, startZoomLevel, categories, center]);
+    }, [mapsIndoorsInstance, currentVenueName, locationId, kioskOriginLocationId, pitch, bearing, startZoomLevel, categories, center, wayfindingOriginHighlightLocation]);
 
     /**
      * Based on the combination of the states for venueName, locationId & kioskOriginLocationId,
@@ -182,6 +184,24 @@ const useMapBoundsDeterminer = () => {
                                 });
                             }
                         }
+                    });
+                }
+            } else if (wayfindingOriginHighlightLocation) {
+                const location = wayfindingOriginHighlightLocation;
+                if (location.properties.floor !== undefined) {
+                    mapsIndoorsInstance.setFloor(location.properties.floor);
+                }
+                if (isDesktop) {
+                    getDesktopPaddingLeft().then(desktopPaddingLeft => {
+                        if (determineMapBoundsKeyRef.current !== key) return;
+                        setMapPositionKnown(location.geometry);
+                        goTo(location.geometry, mapsIndoorsInstance, 0, desktopPaddingLeft, getZoomLevel(startZoomLevel), currentPitch, bearing);
+                    });
+                } else {
+                    getMobilePaddingBottom().then(mobilePaddingBottom => {
+                        if (determineMapBoundsKeyRef.current !== key) return;
+                        setMapPositionKnown(location.geometry);
+                        goTo(location.geometry, mapsIndoorsInstance, mobilePaddingBottom, 0, getZoomLevel(startZoomLevel), currentPitch, bearing);
                     });
                 }
             } else if (!locationId && originalMapCenter && mapsIndoorsInstance) {


### PR DESCRIPTION
Closes MS-3845.
Adds zoom + red pin highlight when ?directionsFrom=<id> is set (no directionsTo). Pin persists during route render via re-select after DirectionsRenderer. Cleared when user changes FROM. No effect for USER_POSITION or when directionsTo is also set.
Test plan: hit ?directionsFrom=<locationId> on map-template dev server; verify zoom, pin, persistence through route, clearing on FROM change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * When a starting location is provided via URL (and no destination), the map centers and zooms to the origin POI and highlights it with the standard red pin.
  * The origin pin remains visible while a route is displayed.
  * The origin highlight is cleared when the FROM field changes or is removed.
  * Map positioning and padding adjusted for desktop and mobile when focusing the origin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->