### PR TITLE
fix: follow mode unreachable

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.36.1] - 2026-06-04
+
+### Fixed
+
+- **mi-my-position**: Fixed FOLLOW mode being unreachable with a fast-streaming custom position provider. Incoming positions no longer reset the `CENTERED` state back to `KNOWN`, so a user can click `CENTERED` → `FOLLOW`.
+
 ## [13.35.0] - 2026-06-03
 
 ### Added

--- a/packages/components/src/components/my-position/my-position.tsx
+++ b/packages/components/src/components/my-position/my-position.tsx
@@ -207,8 +207,17 @@ export class MyPositionComponent {
             } else if (this.positionState === PositionStateTypes.POSITION_UNKNOWN || this.positionState === PositionStateTypes.POSITION_REQUESTING) {
                 // Auto-enter FOLLOW mode only on first position (from UNKNOWN or REQUESTING)
                 this.setPositionState(PositionStateTypes.POSITION_FOLLOW);
-            } else if (this.positionState !== PositionStateTypes.POSITION_UNTRACKED && this.positionState !== PositionStateTypes.POSITION_FOLLOW) {
-                // For other states, transition to KNOWN
+            /**
+             * For other states, transition to KNOWN.
+             * CENTERED is preserved so that with a fast-streaming customPositionProvider
+             * the user can still click CENTERED -> FOLLOW; the legitimate CENTERED -> KNOWN
+             * transition is handled by resetPositionState on user_interaction.
+             */
+            } else if (
+                this.positionState !== PositionStateTypes.POSITION_UNTRACKED
+                && this.positionState !== PositionStateTypes.POSITION_FOLLOW
+                && this.positionState !== PositionStateTypes.POSITION_CENTERED
+            ) {
                 this.setPositionState(PositionStateTypes.POSITION_KNOWN);
             }
 


### PR DESCRIPTION
## What
Fixes `mi-my-position` so FOLLOW mode is reachable when a fast-streaming
custom position provider is in use (e.g. an external positioning system
feeding the map-template `devicePosition` prop every few seconds).

## Why
The position button steps through KNOWN → CENTERED → FOLLOW on successive
clicks. With positions streaming in ~every 3s, each incoming position reset
the button from CENTERED back to KNOWN before the user could click again — so
the CENTERED → FOLLOW step never happened and FOLLOW could never be reached.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where FOLLOW mode became unreachable when using fast-streaming custom position providers. The component now properly preserves centered positioning state, allowing seamless transitions between centered and follow modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->