### PR TITLE
fix: directionsFrom now selects the origin's venue/building before it's floor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27921,7 +27921,7 @@
     },
     "packages/components": {
       "name": "@mapsindoors/components",
-      "version": "13.36.2",
+      "version": "13.36.3",
       "license": "MIT",
       "dependencies": {
         "@googlemaps/js-api-loader": "^1.16.8",

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.99.6] - 2026-06-18
+
+### Fixed
+
+- `directionsFrom` now selects the origin Location's venue and building before setting its floor, so the map and the floor selector reliably land on the origin's floor.
+
 ## [1.99.5] - 2026-06-16
 
 ### Fixed

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -302,7 +302,10 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
             mapsIndoorsInstance.addListener('building_changed', onChange);
             mapsIndoorsInstance.addListener('floor_changed', onChange);
             apply();
-        })();
+        })().catch(error => {
+            detach();
+            console.warn('directionsFrom: failed to sync origin venue/building/floor', error);
+        });
 
         return () => { cancelled = true; detach(); };
     }, [mapsIndoorsInstance, wayfindingOriginHighlightLocation]);

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -255,6 +255,59 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
     }, [directionsFromLocation, directionsTo, directionsFrom]);
 
     /**
+     * directionsFrom origin: drive the SDK to the origin's Venue → Building → Floor.
+     */
+    useEffect(() => {
+        const loc = wayfindingOriginHighlightLocation;
+        if (!mapsIndoorsInstance || !loc) return;
+        const targetFloor = loc.properties.floor;
+        let cancelled = false;
+        let detach = () => {};
+
+        (async () => {
+            const services = window.mapsindoors.services;
+            const venues = await services.VenuesService.getVenues();
+            if (cancelled) return;
+            const venue = venues.find(v =>
+                v.id === loc.properties.venueId
+                || v.name === loc.properties.venueId
+                || v.venueInfo?.name === loc.properties.venue);
+            if (!venue) return;
+            setCurrentVenueName(venue.name);
+            const buildings = await services.VenuesService.getBuildings(venue.id);
+            if (cancelled) return;
+            const building = buildings.find(b =>
+                b.id === loc.properties.buildingId || b.buildingInfo?.name === loc.properties.building);
+
+            const settled = () =>
+                mapsIndoorsInstance.getVenue()?.id === venue.id
+                && (!building || mapsIndoorsInstance.getBuilding()?.id === building.id)
+                && (targetFloor === undefined || mapsIndoorsInstance.getFloor() === targetFloor);
+
+            const apply = () => {
+                if (mapsIndoorsInstance.getVenue()?.id !== venue.id) mapsIndoorsInstance.setVenue(venue);
+                if (building && mapsIndoorsInstance.getBuilding()?.id !== building.id) mapsIndoorsInstance.setBuilding(building);
+                if (targetFloor !== undefined && mapsIndoorsInstance.getFloor() !== targetFloor) mapsIndoorsInstance.setFloor(targetFloor);
+            };
+
+            const onChange = () => {
+                if (cancelled || settled()) return detach();
+                apply();
+            };
+
+            detach = () => {
+                mapsIndoorsInstance.removeListener('building_changed', onChange);
+                mapsIndoorsInstance.removeListener('floor_changed', onChange);
+            };
+            mapsIndoorsInstance.addListener('building_changed', onChange);
+            mapsIndoorsInstance.addListener('floor_changed', onChange);
+            apply();
+        })();
+
+        return () => { cancelled = true; detach(); };
+    }, [mapsIndoorsInstance, wayfindingOriginHighlightLocation]);
+
+    /**
      * Ensure that MapsIndoors Web SDK is available.
      *
      * @returns {Promise}

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -54,6 +54,7 @@ import categoryState from '../../atoms/categoryState.js';
 import hideNonMatchesState from '../../atoms/hideNonMatchesState.js';
 import appConfigState from '../../atoms/appConfigState.js';
 import { useCurrentVenue } from '../../hooks/useCurrentVenue.js';
+import { useSyncToLocationContext } from '../../hooks/useSyncToLocationContext.js';
 import showExternalIDsState from '../../atoms/showExternalIDsState.js'
 import showRoadNamesState from '../../atoms/showRoadNamesState.js';
 import searchExternalLocationsState from '../../atoms/searchExternalLocationsState.js';
@@ -255,60 +256,10 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
     }, [directionsFromLocation, directionsTo, directionsFrom]);
 
     /**
-     * directionsFrom origin: drive the SDK to the origin's Venue → Building → Floor.
+     * Centre the SDK's Venue/Building/Floor on the directionsFrom origin so the map AND the floor
+     * selector land on it — the origin may live in a non-default Venue/Building. 
      */
-    useEffect(() => {
-        const loc = wayfindingOriginHighlightLocation;
-        if (!mapsIndoorsInstance || !loc) return;
-        const targetFloor = loc.properties.floor;
-        let cancelled = false;
-        let detach = () => {};
-
-        (async () => {
-            const services = window.mapsindoors.services;
-            const venues = await services.VenuesService.getVenues();
-            if (cancelled) return;
-            const venue = venues.find(v =>
-                v.id === loc.properties.venueId
-                || v.name === loc.properties.venueId
-                || v.venueInfo?.name === loc.properties.venue);
-            if (!venue) return;
-            setCurrentVenueName(venue.name);
-            const buildings = await services.VenuesService.getBuildings(venue.id);
-            if (cancelled) return;
-            const building = buildings.find(b =>
-                b.id === loc.properties.buildingId || b.buildingInfo?.name === loc.properties.building);
-
-            const settled = () =>
-                mapsIndoorsInstance.getVenue()?.id === venue.id
-                && (!building || mapsIndoorsInstance.getBuilding()?.id === building.id)
-                && (targetFloor === undefined || mapsIndoorsInstance.getFloor() === targetFloor);
-
-            const apply = () => {
-                if (mapsIndoorsInstance.getVenue()?.id !== venue.id) mapsIndoorsInstance.setVenue(venue);
-                if (building && mapsIndoorsInstance.getBuilding()?.id !== building.id) mapsIndoorsInstance.setBuilding(building);
-                if (targetFloor !== undefined && mapsIndoorsInstance.getFloor() !== targetFloor) mapsIndoorsInstance.setFloor(targetFloor);
-            };
-
-            const onChange = () => {
-                if (cancelled || settled()) return detach();
-                apply();
-            };
-
-            detach = () => {
-                mapsIndoorsInstance.removeListener('building_changed', onChange);
-                mapsIndoorsInstance.removeListener('floor_changed', onChange);
-            };
-            mapsIndoorsInstance.addListener('building_changed', onChange);
-            mapsIndoorsInstance.addListener('floor_changed', onChange);
-            apply();
-        })().catch(error => {
-            detach();
-            console.warn('directionsFrom: failed to sync origin venue/building/floor', error);
-        });
-
-        return () => { cancelled = true; detach(); };
-    }, [mapsIndoorsInstance, wayfindingOriginHighlightLocation]);
+    useSyncToLocationContext(wayfindingOriginHighlightLocation, setCurrentVenueName);
 
     /**
      * Ensure that MapsIndoors Web SDK is available.

--- a/packages/map-template/src/hooks/useMapBoundsDeterminer.js
+++ b/packages/map-template/src/hooks/useMapBoundsDeterminer.js
@@ -189,9 +189,6 @@ const useMapBoundsDeterminer = () => {
                 }
             } else if (wayfindingOriginHighlightLocation) {
                 const location = wayfindingOriginHighlightLocation;
-                if (location.properties.floor !== undefined) {
-                    mapsIndoorsInstance.setFloor(location.properties.floor);
-                }
                 if (isDesktop) {
                     getDesktopPaddingLeft().then(desktopPaddingLeft => {
                         if (determineMapBoundsKeyRef.current !== key) return;

--- a/packages/map-template/src/hooks/useSyncToLocationContext.js
+++ b/packages/map-template/src/hooks/useSyncToLocationContext.js
@@ -1,0 +1,78 @@
+import { useEffect } from 'react';
+import { useRecoilValue } from 'recoil';
+import mapsIndoorsInstanceState from '../atoms/mapsIndoorsInstanceState';
+
+/**
+ * Drives the SDK to a target Location's Venue → Building → Floor and keeps them in sync.
+ *
+ * @param {object|null} targetLocation - MapsIndoors Location to centre the Venue/Building/Floor on, or null to disable.
+ * @param {function} setCurrentVenueName - Venue setter from `useCurrentVenue`, used to keep the
+ *   app's Venue state (venue selector, categories, search scope) in sync with the SDK.
+ */
+export const useSyncToLocationContext = (targetLocation, setCurrentVenueName) => {
+    const mapsIndoorsInstance = useRecoilValue(mapsIndoorsInstanceState);
+
+    useEffect(() => {
+        if (!mapsIndoorsInstance || !targetLocation) return;
+
+        const targetFloor = targetLocation.properties.floor;
+        let isCancelled = false;
+        let detachListeners = () => {};
+
+        (async () => {
+            const { VenuesService } = window.mapsindoors.services;
+
+            const venues = await VenuesService.getVenues();
+            if (isCancelled) return;
+            const targetVenue = venues.find(venue =>
+                venue.id === targetLocation.properties.venueId
+                || venue.name === targetLocation.properties.venueId
+                || venue.venueInfo?.name === targetLocation.properties.venue);
+            if (!targetVenue) return;
+
+            /**  
+             * Keep the app's Venue state in sync (selector, categories, search scope). The direct 
+             * setVenue below still runs because the SDK's own building_changed handler can otherwise
+             * override the recoil-driven venue.
+            */
+            setCurrentVenueName(targetVenue.name);
+
+            const buildings = await VenuesService.getBuildings(targetVenue.id);
+            if (isCancelled) return;
+            const targetBuilding = buildings.find(building =>
+                building.id === targetLocation.properties.buildingId
+                || building.buildingInfo?.name === targetLocation.properties.building);
+
+            const isContextActive = () =>
+                mapsIndoorsInstance.getVenue()?.id === targetVenue.id
+                && (!targetBuilding || mapsIndoorsInstance.getBuilding()?.id === targetBuilding.id)
+                && (targetFloor === undefined || mapsIndoorsInstance.getFloor() === targetFloor);
+
+            const applyContext = () => {
+                if (mapsIndoorsInstance.getVenue()?.id !== targetVenue.id) mapsIndoorsInstance.setVenue(targetVenue);
+                if (targetBuilding && mapsIndoorsInstance.getBuilding()?.id !== targetBuilding.id) mapsIndoorsInstance.setBuilding(targetBuilding);
+                if (targetFloor !== undefined && mapsIndoorsInstance.getFloor() !== targetFloor) mapsIndoorsInstance.setFloor(targetFloor);
+            };
+
+            const reassertUntilSettled = () => {
+                if (isCancelled || isContextActive()) return detachListeners();
+                applyContext();
+            };
+
+            detachListeners = () => {
+                mapsIndoorsInstance.removeListener('building_changed', reassertUntilSettled);
+                mapsIndoorsInstance.removeListener('floor_changed', reassertUntilSettled);
+            };
+            mapsIndoorsInstance.addListener('building_changed', reassertUntilSettled);
+            mapsIndoorsInstance.addListener('floor_changed', reassertUntilSettled);
+            applyContext();
+        })().catch(error => {
+            detachListeners();
+            console.warn('Failed to sync map to location venue/building/floor', error);
+        });
+
+        return () => { isCancelled = true; detachListeners(); };
+    }, [mapsIndoorsInstance, targetLocation, setCurrentVenueName]);
+};
+
+export default useSyncToLocationContext;


### PR DESCRIPTION
Selects the `directionsFrom` origin's venue and building before setting its floor, so the map and the floor selector reliably land on the origin's floor.
  Fixes origins that live in a non-default venue/building, where the selector previously showed the wrong building's floors (e.g. the default venue's ground
  floor).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the directions-from origin location did not reliably sync to the correct floor, venue, and building on the map. The map and floor selector now consistently land on the origin's intended floor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->