### PR TITLE
fix: filter even listener leak

### DIFF
--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Filter/highlight in `MapWrapper` no longer re-applies on every map `idle` event. The persistent `idle` listener called the SDK's `highlight()`/`filter()` on each idle, which rewrites a GeoJSON source (`setData`) and forces a render that settles into another `idle` — a self-sustaining loop that pinned CPU/GPU at ~100% even on an idle map. It now applies once (immediately, plus a one-shot `idle` to cover the initial `fitBounds`/`goTo` transition), which still preserves the highlight-timing fix (highlights applied mid-transition were previously wiped on first load).
+- Filter/highlight in `MapWrapper` no longer re-applies on every map `idle` event.
 
 ## [1.99.11] - 2026-07-15
 

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Filter/highlight in `MapWrapper` no longer re-applies on every map `idle` event. The persistent `idle` listener called the SDK's `highlight()`/`filter()` on each idle, which rewrites a GeoJSON source (`setData`) and forces a render that settles into another `idle` — a self-sustaining loop that pinned CPU/GPU at ~100% even on an idle map. It now applies once (immediately, plus a one-shot `idle` to cover the initial `fitBounds`/`goTo` transition), which still preserves the highlight-timing fix (highlights applied mid-transition were previously wiped on first load).
+
 ## [1.99.10] - 2026-07-08
 
 ### Added

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.99.12] - 2026-07-15
 
 ### Fixed
 

--- a/packages/map-template/src/components/MapWrapper/MapWrapper.jsx
+++ b/packages/map-template/src/components/MapWrapper/MapWrapper.jsx
@@ -211,12 +211,16 @@ function MapWrapper({ onLocationClick, onMapPositionKnown, useMapProviderModule,
 
         const map = mapsIndoorsInstance.getMap();
         let removeIdleListener;
+        applyFilterOrHighlight();
         if (map) {
-            if (mapType === mapTypes.Mapbox && typeof map.on === 'function') {
-                map.on('idle', applyFilterOrHighlight);
+            if (mapType === mapTypes.Mapbox && typeof map.once === 'function') {
+                map.once('idle', applyFilterOrHighlight);
                 removeIdleListener = () => map.off?.('idle', applyFilterOrHighlight);
             } else if (mapType === mapTypes.Google && typeof map.addListener === 'function') {
-                const idleListener = map.addListener('idle', applyFilterOrHighlight);
+                const idleListener = map.addListener('idle', () => {
+                    idleListener.remove();
+                    applyFilterOrHighlight();
+                });
                 removeIdleListener = () => idleListener.remove();
             }
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where filter/highlight could repeatedly re-apply on map `idle`, leading to sustained CPU/GPU usage and frequent highlight wiping.
  * Updated map filter/highlight synchronization to apply immediately once the map instance is ready, matching the current floor right after navigation.
  * Changed map idle handling to run once for the initial positioning transition, preventing unnecessary render loops and unintended reset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->