### PR TITLE
fix(a11y): add semantic h2 headings to major panels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27951,7 +27951,7 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.99.10",
+      "version": "1.99.12",
       "dependencies": {
         "@mapsindoors/components": "*",
         "@mapsindoors/css": "^3.0.0",

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Major panels now expose semantic `h2` headings for screen reader navigation (Search results, Directions, Wayfinding, Location Details, Usage Consent)
+- Screen-reader-only heading styles now use `clip-path` instead of deprecated `clip`, shared via an `sr-only` SCSS mixin
 
 ## [1.99.12] - 2026-07-15
 

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Major panels now expose semantic `h2` headings for screen reader navigation (Search results, Directions, Wayfinding, Location Details, Usage Consent)
+
 ## [1.99.12] - 2026-07-15
 
 ### Fixed

--- a/packages/map-template/src/components/ChatWindow/UsageConsentOverlay/UsageConsentOverlay.jsx
+++ b/packages/map-template/src/components/ChatWindow/UsageConsentOverlay/UsageConsentOverlay.jsx
@@ -13,9 +13,9 @@ function UsageConsentOverlay({ onAccept, onDecline }) {
     return (
         <div className="usage-consent-overlay">
             <div className="usage-consent-overlay__card">
-                <h3 className="usage-consent-overlay__title">
+                <h2 className="usage-consent-overlay__title">
                     {t('Usage consent title')}
-                </h3>
+                </h2>
                 <p className="usage-consent-overlay__message">
                     {t('Usage consent message')}
                 </p>

--- a/packages/map-template/src/components/Directions/Directions.jsx
+++ b/packages/map-template/src/components/Directions/Directions.jsx
@@ -360,6 +360,7 @@ function Directions({ isOpen, onBack, onSetSize, onRouteFinished }) {
 
     return (
         <div className="directions" style={{ display: !isKioskContext ? 'grid' : 'block' }}>
+            <h2 className="directions__sr-heading">{t('Directions')}</h2>
             <div className="directions__header">
                 <div className="directions__minutes">{totalTime && <mi-time translations={JSON.stringify({ days: t('d'), hours: t('h'), minutes: t('min') })} seconds={totalTime} />}</div>
                 <RouteInstructionsStepHeader

--- a/packages/map-template/src/components/Directions/Directions.scss
+++ b/packages/map-template/src/components/Directions/Directions.scss
@@ -12,15 +12,7 @@
     }
 
     &__sr-heading {
-        position: absolute;
-        width: 1px;
-        height: 1px;
-        padding: 0;
-        margin: -1px;
-        overflow: hidden;
-        clip: rect(0, 0, 0, 0);
-        white-space: nowrap;
-        border: 0;
+        @include variables.sr-only;
     }
 
     &__cancel,

--- a/packages/map-template/src/components/Directions/Directions.scss
+++ b/packages/map-template/src/components/Directions/Directions.scss
@@ -11,6 +11,18 @@
         padding: var(--spacing-medium) 0;
     }
 
+    &__sr-heading {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+    }
+
     &__cancel,
     &__finish {
         background-color: var(--tailwind-colors-gray-100);

--- a/packages/map-template/src/components/LocationDetails/LocationDetails.jsx
+++ b/packages/map-template/src/components/LocationDetails/LocationDetails.jsx
@@ -343,9 +343,9 @@ function LocationDetails({ onBack, onStartWayfinding, onSetSize, onStartDirectio
                         {locationDisplayRule && <img alt="" src={locationDisplayRule.icon.src ? locationDisplayRule.icon.src : locationDisplayRule.icon} />}
                     </div>
                     <div className="location-info__content">
-                        <div className="location-info__name">
+                        <h2 className="location-info__name">
                             {location.properties.name}
-                        </div>
+                        </h2>
                         <mi-location-info level={t('Level')} ref={locationInfoElement} show-external-id={showExternalIDs} show-floor={showFloor} />
                     </div>
                     <div className="location-info__actions">

--- a/packages/map-template/src/components/LocationDetails/LocationDetails.scss
+++ b/packages/map-template/src/components/LocationDetails/LocationDetails.scss
@@ -183,6 +183,9 @@
         text-overflow: ellipsis;
         white-space: nowrap;
         max-width: 100%;
+        font-size: var(--font-size-small);
+        font-weight: var(--font-weight-large);
+        margin: 0;
     }
 
     &__content {

--- a/packages/map-template/src/components/Search/Search.jsx
+++ b/packages/map-template/src/components/Search/Search.jsx
@@ -826,6 +826,7 @@ function Search({ onSetSize, isOpen, isSheetExpanded, onOpenChat }) {
             {/* When search results are found (category is selected or search term is used) */}
             {searchResults.length > 0 && (
                 <div className={`search__results prevent-scroll${isKioskContext ? ' search__results--kiosk' : ''}`}>
+                    <h2 className="search__sr-heading">{t('Search results')}</h2>
 
                     {/* Subcategories should only show if a top level category is selected and if that top level category has any childKeys */}
                     {selectedCategory && (

--- a/packages/map-template/src/components/Search/Search.scss
+++ b/packages/map-template/src/components/Search/Search.scss
@@ -107,4 +107,16 @@
             display: none;
         }
     }
+
+    &__sr-heading {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+    }
 }

--- a/packages/map-template/src/components/Search/Search.scss
+++ b/packages/map-template/src/components/Search/Search.scss
@@ -109,14 +109,6 @@
     }
 
     &__sr-heading {
-        position: absolute;
-        width: 1px;
-        height: 1px;
-        padding: 0;
-        margin: -1px;
-        overflow: hidden;
-        clip: rect(0, 0, 0, 0);
-        white-space: nowrap;
-        border: 0;
+        @include variables.sr-only;
     }
 }

--- a/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
+++ b/packages/map-template/src/components/Wayfinding/Wayfinding.jsx
@@ -573,7 +573,7 @@ function Wayfinding({ onStartDirections, onBack, directionsToLocation, direction
     return (
         <div className="wayfinding" ref={wayfindingRef}>
             <div className="wayfinding__directions">
-                <div className="wayfinding__title">{t('Directions')}</div>
+                <h2 className="wayfinding__title">{t('Directions')}</h2>
                 <button className="wayfinding__close"
                     onClick={() => closeWayfinding()}
                     aria-label={t('Close')}>

--- a/packages/map-template/src/components/Wayfinding/Wayfinding.scss
+++ b/packages/map-template/src/components/Wayfinding/Wayfinding.scss
@@ -20,7 +20,8 @@
         text-align: center;
         font-weight: var(--font-weight-large);
         color: var(--color-gray-70);
-        padding-bottom: var(--spacing-medium)
+        padding-bottom: var(--spacing-medium);
+        margin: 0;
     }
 
     &__close {

--- a/packages/map-template/src/i18n/da.js
+++ b/packages/map-template/src/i18n/da.js
@@ -10,6 +10,7 @@ const da = {
     'Show legend': 'Vis forklaring',
     'Legend': 'Forklaring',
     'Nothing was found': 'Intet fundet',
+    'Search results': 'Søgeresultater',
     'd': 'd',
     'h': 't',
     'min': 'min',

--- a/packages/map-template/src/i18n/de.js
+++ b/packages/map-template/src/i18n/de.js
@@ -10,6 +10,7 @@ const de = {
     'Show legend': 'Legende anzeigen',
     'Legend': 'Legende',
     'Nothing was found': 'Keine Suchtreffer',
+    'Search results': 'Suchergebnisse',
     'd': 'd',
     'h': 'h',
     'min': 'min',

--- a/packages/map-template/src/i18n/en.js
+++ b/packages/map-template/src/i18n/en.js
@@ -10,6 +10,7 @@ const en = {
     'Show legend': 'Show legend',
     'Legend': 'Legend',
     'Nothing was found': 'Nothing was found',
+    'Search results': 'Search results',
     'd': 'd',
     'h': 'h',
     'min': 'min',

--- a/packages/map-template/src/i18n/es.js
+++ b/packages/map-template/src/i18n/es.js
@@ -10,6 +10,7 @@ const es = {
     'Show legend': 'Mostrar leyenda',
     'Legend': 'Leyenda',
     'Nothing was found': 'No se encontró nada',
+    'Search results': 'Resultados de búsqueda',
     'd': 'd',
     'h': 'h',
     'min': 'mín',

--- a/packages/map-template/src/i18n/fr.js
+++ b/packages/map-template/src/i18n/fr.js
@@ -10,6 +10,7 @@ const fr = {
     'Show legend': 'Afficher la légende',
     'Legend': 'Légende',
     'Nothing was found': 'Rien n\'a été trouvé',
+    'Search results': 'Résultats de recherche',
     'd': 'd',
     'h': 'h',
     'min': 'min',

--- a/packages/map-template/src/i18n/it.js
+++ b/packages/map-template/src/i18n/it.js
@@ -10,6 +10,7 @@ const it = {
     'Show legend': 'Mostra legenda',
     'Legend': 'Legenda',
     'Nothing was found': 'Non è stato trovato nulla',
+    'Search results': 'Risultati della ricerca',
     'd': 'g',
     'h': 'o',
     'min': 'min',

--- a/packages/map-template/src/i18n/nl.js
+++ b/packages/map-template/src/i18n/nl.js
@@ -10,6 +10,7 @@ const nl = {
     'Show legend': 'Legende weergeven',
     'Legend': 'Legende',
     'Nothing was found': 'Er is niets gevonden',
+    'Search results': 'Zoekresultaten',
     'd': 'd',
     'h': 'u',
     'min': 'min',

--- a/packages/map-template/src/i18n/zh-Hans.js
+++ b/packages/map-template/src/i18n/zh-Hans.js
@@ -10,6 +10,7 @@ const zhHans = {
     'Show legend': '显示图例',
     'Legend': '图例',
     'Nothing was found': '未找到任何结果',
+    'Search results': '搜索结果',
     'd': '天',
     'h': '小时',
     'min': '分钟',

--- a/packages/map-template/src/i18n/zh-Hant.js
+++ b/packages/map-template/src/i18n/zh-Hant.js
@@ -10,6 +10,7 @@ const zhHant = {
       'Show legend': '顯示圖例',
       'Legend': '圖例',
       'Nothing was found': '找不到任何結果',
+      'Search results': '搜尋結果',
       'd': '天',
       'h': '小時',
       'min': '分鐘',

--- a/packages/map-template/src/variables.scss
+++ b/packages/map-template/src/variables.scss
@@ -1,1 +1,13 @@
-	$desktop-breakpoint: 992px;
+$desktop-breakpoint: 992px;
+
+@mixin sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+}


### PR DESCRIPTION
## Summary
- Adds semantic `h2` headings to Search results, Directions, Wayfinding, Location Details, and Usage Consent so screen readers can navigate panel structure
- Visually hides Search/Directions headings where a visible title already exists; styles Location Details / Wayfinding headings to match existing look
- Adds `Search results` i18n keys across all 9 languages
- Skips LegendDialog (already has an `h2` from the aria-labels work)

Extracted from `feat/improve-accesibility-v2` as the next slice after `feat/extract-aria-labels`.

## Test plan
- [ ] Open Search results → confirm visually unchanged; VoiceOver/NVDA rotor shows an `h2` for search results
- [ ] Open Wayfinding → title still looks the same, announced as a heading
- [ ] Open Location Details → location name still looks the same, announced as a heading
- [ ] Start Directions → visually unchanged; heading announced as “Directions”
- [ ] Open chat Usage Consent → title level is `h2` (was `h3`)
- [ ] Switch language and confirm Search results heading translates



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility Improvements**
  * Improved screen reader navigation by adding/adjusting semantic `h2` headings in search results, directions, wayfinding, location details, and usage consent panels.
  * Updated screen-reader-only heading styling to use modern `clip-path` via a shared `sr-only` mixin.
* **Localization**
  * Added the translated “Search results” label across supported languages.
* **Documentation**
  * Updated the unreleased changelog to reflect the accessibility and screen-reader-only styling improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->