### PR TITLE
fix: duplicate map style loading

### DIFF
--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - User chat bubble fallback background uses `#005655` so white text keeps sufficient contrast
 - `prefers-reduced-motion` rule in `MapTemplate.scss` disables CSS animations and transitions (included in published bundles), scoped to `.mapsindoors-map` and its descendants so embedding host pages keep their own motion behaviour
 - Fixed-width panels use `max-width: 100%` for reflow; scroll containers use `scroll-padding-top` so sticky headers do not obscure focused content
+- A custom `mapboxMapStyle` is now applied at map initialization instead of being swapped in with `setStyle` afterwards, avoiding a brief flash of the default MapsIndoors style
 - Sidebar modal width accounts for its horizontal inset (`max-width: calc(100% - 2 * var(--spacing-medium))`), so it no longer overflows the right edge when map-template is embedded in a container narrower than 584px
 
 ## [1.99.14] - 2026-07-30
@@ -31,10 +32,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Major panels now expose semantic `h2` headings for screen reader navigation (Search results, Directions, Wayfinding, Location Details, Usage Consent)
 - Screen-reader-only heading styles now use `clip-path` instead of deprecated `clip`, shared via an `sr-only` SCSS mixin
 - Accessibility toggle text is associated via a `<label>`; Wayfinding departure/destination inputs are grouped in a `<fieldset>` with a screen-reader-only legend
-
-### Fixed
-
-- A custom `mapboxMapStyle` is now applied at map initialization instead of being swapped in with `setStyle` afterwards, avoiding a brief flash of the default MapsIndoors style
 
 ## [1.99.12] - 2026-07-15
 

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Major panels now expose semantic `h2` headings for screen reader navigation (Search results, Directions, Wayfinding, Location Details, Usage Consent)
 - Screen-reader-only heading styles now use `clip-path` instead of deprecated `clip`, shared via an `sr-only` SCSS mixin
 
+### Fixed
+
+- A custom `mapboxMapStyle` is now applied at map initialization instead of being swapped in with `setStyle` afterwards, avoiding a brief flash of the default MapsIndoors style
+
 ## [1.99.12] - 2026-07-15
 
 ### Fixed

--- a/packages/map-template/src/components/MIMap/MapboxMap/MapboxMap.jsx
+++ b/packages/map-template/src/components/MIMap/MapboxMap/MapboxMap.jsx
@@ -87,7 +87,8 @@ function MapboxMap({ accessToken, onInitialized, center, zoom, bounds, bearing, 
             bounds: bounds ? [bounds.west, bounds.south, bounds.east, bounds.north] : undefined,
             bearing: bearing ?? 0,
             pitch: pitch ?? 0,
-            useMapsIndoorsMapboxStyle: mapOptions?.mapboxMapStyle ? false : true,
+            useMapsIndoorsMapboxStyle: !mapOptions?.mapboxMapStyle,
+            ...(mapOptions?.mapboxMapStyle && { style: mapOptions.mapboxMapStyle }),
             localIdeographFontFamily: 'sans-serif',
             ...mapOptions
         };
@@ -106,15 +107,10 @@ function MapboxMap({ accessToken, onInitialized, center, zoom, bounds, bearing, 
         if (!isNullOrUndefined(mapOptions?.showMapMarkers)) {
             mapViewOptions.showMapMarkers = mapOptions.showMapMarkers;
         }
-        
+
         const mapView = new window.mapsindoors.mapView.MapboxV3View(mapViewOptions);
 
         setMapViewInstance(mapView);
-
-        // If mapboxMapStyle is not null or undefined and useMapsIndoorsMapboxStyle is false, set it as mapboxMapStyle in the mapView.
-        if (!isNullOrUndefined(mapOptions?.mapboxMapStyle) && !mapViewOptions.useMapsIndoorsMapboxStyle) {
-            mapView?.getMap()?.setStyle(mapOptions.mapboxMapStyle);
-        }
 
         onInitialized(mapView);
     }, []);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented a brief flash of the default MapsIndoors style when a custom Mapbox map style is configured.
  - Custom map styles are now applied immediately during map initialization for a smoother visual experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->