### PR TITLE
chore: update MapsIndoors SDK to version 4.59.0

### DIFF
--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.99.14] - 2026-07-30
+
+### Fixed
+
+- Updated to Web SDK v4.59.0
 
 ### Changed
 

--- a/packages/map-template/index.html
+++ b/packages/map-template/index.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#005655" />
   <title>MapsIndoors Web</title>
-  <script defer src="https://app.mapsindoors.com/mapsindoors/js/sdk/4.58.6/mapsindoors-4.58.6.js.gz"
-    integrity="sha384-ahXe5UYswPGj6d85fO/46UVy0IHL6UL9i8jvQoYBKMwCyuk54Iq7ugHM1wglwdlh"
+  <script defer src="https://app.mapsindoors.com/mapsindoors/js/sdk/4.59.0/mapsindoors-4.59.0.js.gz"
+    integrity="sha384-Bzao9/GbXnR102RPMe3Acr8ij7Qkl6wz0Dr4H/5y7eQOZjnDwweXkPwqydIviRwB"
     crossorigin="anonymous"></script>
 </head>
 

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -276,8 +276,8 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
             const miSdkApiTag = document.createElement('script');
             miSdkApiTag.setAttribute('type', 'text/javascript');
             // Remember to update the root index.html with the same version / integrity
-            miSdkApiTag.setAttribute('src', 'https://app.mapsindoors.com/mapsindoors/js/sdk/4.58.6/mapsindoors-4.58.6.js.gz');
-            miSdkApiTag.setAttribute('integrity', 'sha384-ahXe5UYswPGj6d85fO/46UVy0IHL6UL9i8jvQoYBKMwCyuk54Iq7ugHM1wglwdlh');
+            miSdkApiTag.setAttribute('src', 'https://app.mapsindoors.com/mapsindoors/js/sdk/4.59.0/mapsindoors-4.59.0.js.gz');
+            miSdkApiTag.setAttribute('integrity', 'sha384-Bzao9/GbXnR102RPMe3Acr8ij7Qkl6wz0Dr4H/5y7eQOZjnDwweXkPwqydIviRwB');
             miSdkApiTag.setAttribute('crossorigin', 'anonymous');
             document.body.appendChild(miSdkApiTag);
             miSdkApiTag.onload = () => {


### PR DESCRIPTION
Release Directions Renderer, with SDK update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the map template to Web SDK version 4.59.0.
* **Documentation**
  * Added release notes documenting the SDK update in version 1.99.14.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->