### PR TITLE
feat: upgrade to web sdk 4.59.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27951,7 +27951,7 @@
     },
     "packages/map-template": {
       "name": "@mapsindoors/map-template",
-      "version": "1.99.16",
+      "version": "1.99.17",
       "dependencies": {
         "@mapsindoors/components": "*",
         "@mapsindoors/css": "^3.0.0",
@@ -27980,7 +27980,7 @@
         "identity-obj-proxy": "^3.0.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
-        "mapbox-gl": "^3.22.0",
+        "mapbox-gl": "^3.28.1",
         "prop-types": "^15.8.1",
         "qrcode": "^1.5.3",
         "react": "^18.2.0",
@@ -28408,13 +28408,6 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
-    "packages/map-template/node_modules/earcut": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
-      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
-      "dev": true,
-      "license": "ISC"
-    },
     "packages/map-template/node_modules/esbuild": {
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
@@ -28476,55 +28469,17 @@
       }
     },
     "packages/map-template/node_modules/mapbox-gl": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.22.0.tgz",
-      "integrity": "sha512-ZIpF+oAMcQoDlvABmiRkHoydyBR9zI6CyDeVRa2/iyua0/B2+rPuIzoCV/CgN14P5F0HVk53GIZw220WSqJPyA==",
+      "version": "3.28.1",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.28.1.tgz",
+      "integrity": "sha512-f8bCHFzZ51bKig7rnD7e08aoFLOV3MNFZduspZ4lgOgiaNVp9sw4NSWcgo3IWTyekYKKXjiICD2BP2o4DiYfxw==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.txt",
       "workspaces": [
         "src/style-spec",
-        "packages/pmtiles-provider",
-        "test/build/vite",
-        "test/build/webpack",
+        "plugins/mapbox-gl-pmtiles-provider",
+        "test/bundlers/*",
         "test/build/typings"
-      ],
-      "dependencies": {
-        "@mapbox/mapbox-gl-supported": "^3.0.0",
-        "@mapbox/point-geometry": "^1.1.0",
-        "@mapbox/tiny-sdf": "^2.0.6",
-        "@mapbox/unitbezier": "^0.0.1",
-        "@mapbox/vector-tile": "^2.0.4",
-        "@types/geojson": "^7946.0.16",
-        "@types/geojson-vt": "^3.2.5",
-        "@types/pbf": "^3.0.5",
-        "@types/supercluster": "^7.1.3",
-        "cheap-ruler": "^4.0.0",
-        "csscolorparser": "~1.0.3",
-        "earcut": "^3.0.1",
-        "geojson-vt": "^4.0.2",
-        "gl-matrix": "^3.4.4",
-        "grid-index": "^1.1.0",
-        "kdbush": "^4.0.2",
-        "martinez-polygon-clipping": "^0.8.1",
-        "murmurhash-js": "^1.0.0",
-        "pbf": "^4.0.1",
-        "potpack": "^2.0.0",
-        "quickselect": "^3.0.0",
-        "supercluster": "^8.0.1",
-        "tinyqueue": "^3.0.0"
-      }
-    },
-    "packages/map-template/node_modules/martinez-polygon-clipping": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/martinez-polygon-clipping/-/martinez-polygon-clipping-0.8.1.tgz",
-      "integrity": "sha512-9PLLMzMPI6ihHox4Ns6LpVBLpRc7sbhULybZ/wyaY8sY3ECNe2+hxm1hA2/9bEEpRrdpjoeduBuZLg2aq1cSIQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "robust-predicates": "^2.0.4",
-        "splaytree": "^0.1.4",
-        "tinyqueue": "3.0.0"
-      }
+      ]
     },
     "packages/map-template/node_modules/picomatch": {
       "version": "4.0.4",
@@ -28538,13 +28493,6 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
-    },
-    "packages/map-template/node_modules/quickselect": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
-      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
-      "dev": true,
-      "license": "ISC"
     },
     "packages/map-template/node_modules/react-refresh": {
       "version": "0.18.0",
@@ -28600,20 +28548,6 @@
         "@rollup/rollup-win32-x64-msvc": "4.59.0",
         "fsevents": "~2.3.2"
       }
-    },
-    "packages/map-template/node_modules/splaytree": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/splaytree/-/splaytree-0.1.4.tgz",
-      "integrity": "sha512-D50hKrjZgBzqD3FT2Ek53f2dcDLAQT8SSGrzj3vidNH5ISRgceeGVJ2dQIthKOuayqFXfFjXheHNo4bbt9LhRQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "packages/map-template/node_modules/tinyqueue": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
-      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
-      "dev": true,
-      "license": "ISC"
     },
     "packages/map-template/node_modules/vite": {
       "version": "7.3.2",
@@ -31191,7 +31125,7 @@
         "identity-obj-proxy": "^3.0.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
-        "mapbox-gl": "^3.22.0",
+        "mapbox-gl": "^3.28.1",
         "motion": "^12.38.0",
         "prop-types": "^15.8.1",
         "qrcode": "^1.5.3",
@@ -31391,12 +31325,6 @@
             "react-refresh": "^0.18.0"
           }
         },
-        "earcut": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
-          "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
-          "dev": true
-        },
         "esbuild": {
           "version": "0.27.3",
           "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
@@ -31439,57 +31367,15 @@
           "requires": {}
         },
         "mapbox-gl": {
-          "version": "3.22.0",
-          "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.22.0.tgz",
-          "integrity": "sha512-ZIpF+oAMcQoDlvABmiRkHoydyBR9zI6CyDeVRa2/iyua0/B2+rPuIzoCV/CgN14P5F0HVk53GIZw220WSqJPyA==",
-          "dev": true,
-          "requires": {
-            "@mapbox/mapbox-gl-supported": "^3.0.0",
-            "@mapbox/point-geometry": "^1.1.0",
-            "@mapbox/tiny-sdf": "^2.0.6",
-            "@mapbox/unitbezier": "^0.0.1",
-            "@mapbox/vector-tile": "^2.0.4",
-            "@types/geojson": "^7946.0.16",
-            "@types/geojson-vt": "^3.2.5",
-            "@types/pbf": "^3.0.5",
-            "@types/supercluster": "^7.1.3",
-            "cheap-ruler": "^4.0.0",
-            "csscolorparser": "~1.0.3",
-            "earcut": "^3.0.1",
-            "geojson-vt": "^4.0.2",
-            "gl-matrix": "^3.4.4",
-            "grid-index": "^1.1.0",
-            "kdbush": "^4.0.2",
-            "martinez-polygon-clipping": "^0.8.1",
-            "murmurhash-js": "^1.0.0",
-            "pbf": "^4.0.1",
-            "potpack": "^2.0.0",
-            "quickselect": "^3.0.0",
-            "supercluster": "^8.0.1",
-            "tinyqueue": "^3.0.0"
-          }
-        },
-        "martinez-polygon-clipping": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/martinez-polygon-clipping/-/martinez-polygon-clipping-0.8.1.tgz",
-          "integrity": "sha512-9PLLMzMPI6ihHox4Ns6LpVBLpRc7sbhULybZ/wyaY8sY3ECNe2+hxm1hA2/9bEEpRrdpjoeduBuZLg2aq1cSIQ==",
-          "dev": true,
-          "requires": {
-            "robust-predicates": "^2.0.4",
-            "splaytree": "^0.1.4",
-            "tinyqueue": "3.0.0"
-          }
+          "version": "3.28.1",
+          "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.28.1.tgz",
+          "integrity": "sha512-f8bCHFzZ51bKig7rnD7e08aoFLOV3MNFZduspZ4lgOgiaNVp9sw4NSWcgo3IWTyekYKKXjiICD2BP2o4DiYfxw==",
+          "dev": true
         },
         "picomatch": {
           "version": "4.0.4",
           "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
           "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-          "dev": true
-        },
-        "quickselect": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
-          "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
           "dev": true
         },
         "react-refresh": {
@@ -31532,18 +31418,6 @@
             "@types/estree": "1.0.8",
             "fsevents": "~2.3.2"
           }
-        },
-        "splaytree": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/splaytree/-/splaytree-0.1.4.tgz",
-          "integrity": "sha512-D50hKrjZgBzqD3FT2Ek53f2dcDLAQT8SSGrzj3vidNH5ISRgceeGVJ2dQIthKOuayqFXfFjXheHNo4bbt9LhRQ==",
-          "dev": true
-        },
-        "tinyqueue": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
-          "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
-          "dev": true
         },
         "vite": {
           "version": "7.3.2",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.36.6] - 2026-08-11
+
+### Changed
+
+- **map-mapbox**: Updated Mapbox GL JS CDN version from v3.22.0 to v3.28.1.
+
 ## [13.36.5] - 2026-08-03
 
 ### Added

--- a/packages/components/src/components/map-mapbox/map-mapbox.tsx
+++ b/packages/components/src/components/map-mapbox/map-mapbox.tsx
@@ -444,7 +444,7 @@ export class MapMapbox implements ComponentInterface {
                 const mapboxApiTag = document.createElement('script');
                 mapboxApiTag.setAttribute('type', 'text/javascript');
                 // When upgrading the version please remember to update url to the MapBox css in the render function.
-                mapboxApiTag.setAttribute('src', 'https://api.mapbox.com/mapbox-gl-js/v3.22.0/mapbox-gl.js');
+                mapboxApiTag.setAttribute('src', 'https://api.mapbox.com/mapbox-gl-js/v3.28.1/mapbox-gl.js');
                 document.body.appendChild(mapboxApiTag);
                 mapboxApiTag.onload = (): void => resolve();
             });
@@ -643,7 +643,7 @@ export class MapMapbox implements ComponentInterface {
     render(): JSX.Element {
         return (
             <Host>
-                <link href='https://api.mapbox.com/mapbox-gl-js/v3.22.0/mapbox-gl.css' rel='stylesheet' />
+                <link href='https://api.mapbox.com/mapbox-gl-js/v3.28.1/mapbox-gl.css' rel='stylesheet' />
                 <div ref={(el) => this.mapElement = el as HTMLDivElement}></div>
             </Host>
         );

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.99.16] - 2026-08-10
+
+### Fixed
+
+- Updated to Web SDK v4.59.1
+
 ## [1.99.15] - 2026-08-06
 
 ### Changed

--- a/packages/map-template/CHANGELOG.md
+++ b/packages/map-template/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Updated to Web SDK v4.59.1
+- Updated Mapbox GL JS to v3.28.1
 
 ## [1.99.15] - 2026-08-06
 

--- a/packages/map-template/index.html
+++ b/packages/map-template/index.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#005655" />
   <title>MapsIndoors Web</title>
-  <script defer src="https://app.mapsindoors.com/mapsindoors/js/sdk/4.59.0/mapsindoors-4.59.0.js.gz"
-    integrity="sha384-Bzao9/GbXnR102RPMe3Acr8ij7Qkl6wz0Dr4H/5y7eQOZjnDwweXkPwqydIviRwB"
+  <script defer src="https://app.mapsindoors.com/mapsindoors/js/sdk/4.59.1/mapsindoors-4.59.1.js.gz"
+    integrity="sha384-mW4B/nPOrd3xdgWKQL2JDcH5OiqAfTlcao/in1DzFWKB0+5hwMq3+VHmq60gJnDs"
     crossorigin="anonymous"></script>
 </head>
 

--- a/packages/map-template/package.json
+++ b/packages/map-template/package.json
@@ -26,7 +26,7 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
-    "mapbox-gl": "^3.22.0",
+    "mapbox-gl": "^3.28.1",
     "prop-types": "^15.8.1",
     "qrcode": "^1.5.3",
     "react": "^18.2.0",

--- a/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
+++ b/packages/map-template/src/components/MapTemplate/MapTemplate.jsx
@@ -276,8 +276,8 @@ function MapTemplate({ apiKey, gmApiKey, mapboxAccessToken, venue, locationId, p
             const miSdkApiTag = document.createElement('script');
             miSdkApiTag.setAttribute('type', 'text/javascript');
             // Remember to update the root index.html with the same version / integrity
-            miSdkApiTag.setAttribute('src', 'https://app.mapsindoors.com/mapsindoors/js/sdk/4.59.0/mapsindoors-4.59.0.js.gz');
-            miSdkApiTag.setAttribute('integrity', 'sha384-Bzao9/GbXnR102RPMe3Acr8ij7Qkl6wz0Dr4H/5y7eQOZjnDwweXkPwqydIviRwB');
+            miSdkApiTag.setAttribute('src', 'https://app.mapsindoors.com/mapsindoors/js/sdk/4.59.1/mapsindoors-4.59.1.js.gz');
+            miSdkApiTag.setAttribute('integrity', 'sha384-mW4B/nPOrd3xdgWKQL2JDcH5OiqAfTlcao/in1DzFWKB0+5hwMq3+VHmq60gJnDs');
             miSdkApiTag.setAttribute('crossorigin', 'anonymous');
             document.body.appendChild(miSdkApiTag);
             miSdkApiTag.onload = () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Updated the embedded MapsIndoors Web SDK to version 4.59.1 with refreshed security integrity verification.
  - Upgraded Mapbox GL JS to version 3.28.1 for the map experience.
  - Updated the map template tooling to use the latest Mapbox GL JS version.

- **Documentation**
  - Added release notes for version 1.99.16, dated August 10, 2026.
  - Documented the Mapbox GL JS upgrade in the components release notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->